### PR TITLE
fix: harden live session cancellation diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-## 0.2.0 - 2026-07-11
+## 0.2.0 - 2026-07-12
 
 - Reposition the project as the realtime custom-client bridge for Hermes Agent, with a marketing-first README, honest Voice Mode comparison, provider compatibility roadmap, support guide, and release runbook.
 - Default OpenAI Realtime sessions to the currently documented `gpt-realtime-2.1` model.
@@ -20,6 +20,8 @@
 - Remove unsupported OpenAI Realtime reasoning effort value `none` and tighten clone-first setup docs.
 - Add `hermes-live provider-smoke` and `npm run check:live-provider` for optional real Gemini Live/OpenAI Realtime session handshakes.
 - Upgrade the Gemini SDK to v2, Vitest to v4, and tsx to the latest v4 release while keeping Node type-checking aligned with the package's minimum supported Node 20 runtime.
+- Treat client-close aborts of active Hermes event streams as expected cancellation instead of logging or emitting a false run failure.
+- Normalize structured realtime-provider startup errors into safe, actionable diagnostics instead of displaying `[object Object]`.
 
 ## 0.1.0
 

--- a/src/adapters/inbound/http/server.ts
+++ b/src/adapters/inbound/http/server.ts
@@ -14,6 +14,7 @@ import type { Logger } from "../../../logger.js";
 import { buildReadinessReport } from "../../../readiness.js";
 import { serveStatic } from "./static.js";
 import { WebSocketClientConnection } from "./websocket-client-connection.js";
+import { errorToMessage } from "../../../domain/error-message.js";
 
 export interface StartServerOptions {
   config: AppConfig;
@@ -48,8 +49,9 @@ export async function startServer({ config, logger, hermes: providedHermes, live
         requireRealtimeProviderConfig: !providedLiveModel,
       });
     } catch (error) {
-      logger.error("http handler failed", { error: String(error) });
-      json(req, res, 500, { status: "error", error: String(error) });
+      const message = errorToMessage(error);
+      logger.error("http handler failed", { error: message });
+      json(req, res, 500, { status: "error", error: message });
     }
   });
 

--- a/src/adapters/outbound/realtime/openai-realtime.adapter.ts
+++ b/src/adapters/outbound/realtime/openai-realtime.adapter.ts
@@ -7,6 +7,7 @@ import {
   type LiveToolCall,
 } from "../../../application/live-gateway/ports/realtime-model.port.js";
 import type { RealtimeResponseTruncation } from "../../../domain/protocol/client-protocol.js";
+import { errorToMessage } from "../../../domain/error-message.js";
 import { OPENAI_HERMES_LIVE_TOOLS } from "../../../application/live-gateway/tool-definitions.js";
 import type {
   LiveModelAdapter,
@@ -46,7 +47,7 @@ export class OpenAIRealtimeAdapter implements LiveModelAdapter {
       const onInitialError = (error: unknown) => {
         cleanup();
         closeWebSocket(ws, 1011, "OpenAI Realtime session start failed");
-        reject(error);
+        reject(error instanceof Error ? error : new Error(errorToMessage(error)));
       };
       const onInitialClose = (code: number, reason: Buffer) => {
         cleanup();

--- a/src/application/live-gateway/live-gateway-session.ts
+++ b/src/application/live-gateway/live-gateway-session.ts
@@ -1,4 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
+import { errorToMessage } from "../../domain/error-message.js";
 import { isPcmMimeType } from "../../domain/audio/pcm.js";
 import { makeSessionKey, type AppConfig } from "../../config.js";
 import type { Logger } from "../../logger.js";
@@ -404,6 +405,13 @@ export class LiveGatewaySession {
 
       return { ok: true, run_id: runId, output: finalOutput || transcript.join(""), usage };
     } catch (error) {
+      if (this.abort.signal.aborted) {
+        return {
+          ok: false,
+          ...(runId ? { run_id: runId } : {}),
+          status: "cancelled",
+        };
+      }
       if (!runId) {
         throw error;
       }
@@ -531,10 +539,6 @@ function validateText(value: string, maxChars: number, label: string): void {
   if (value.length > maxChars) {
     throw new Error(`${label} exceeds HERMES_LIVE_MAX_TEXT_CHARS.`);
   }
-}
-
-function errorToMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
 }
 
 function requestIdFromUnknown(value: unknown): string | undefined {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,7 @@ import { ApprovalChoiceSchema } from "./protocol.js";
 import { buildReadinessReport } from "./readiness.js";
 import { startServer } from "./adapters/inbound/http/server.js";
 import { runLiveProviderSmoke } from "./live-provider-smoke.js";
+import { errorToMessage } from "./domain/error-message.js";
 
 const logger = createLogger((process.env.HERMES_LIVE_LOG_LEVEL as any) ?? "info");
 
@@ -105,10 +106,6 @@ function redact(value: string | undefined): string | undefined {
 function positiveInt(value: string | undefined, fallback: number): number {
   const parsed = Number(value);
   return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
-}
-
-function errorToMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
 }
 
 function printHelp(): void {

--- a/src/domain/error-message.ts
+++ b/src/domain/error-message.ts
@@ -1,0 +1,33 @@
+const ERROR_FIELDS = ["message", "code", "type", "param"] as const;
+
+export function errorToMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  if (!error || typeof error !== "object") {
+    return String(error);
+  }
+
+  const record = error as Record<string, unknown>;
+  if (record.error && record.error !== error) {
+    const nested = errorToMessage(record.error);
+    if (nested !== "Unknown structured error.") {
+      return nested;
+    }
+  }
+
+  const details = ERROR_FIELDS.flatMap((field) => {
+    const value = record[field];
+    if (typeof value === "string" && value.trim()) {
+      return [`${field}=${value.trim().slice(0, 500)}`];
+    }
+    if (typeof value === "number" || typeof value === "boolean") {
+      return [`${field}=${String(value)}`];
+    }
+    return [];
+  });
+  return details.length > 0 ? details.join(", ") : "Unknown structured error.";
+}

--- a/src/live-provider-smoke.ts
+++ b/src/live-provider-smoke.ts
@@ -3,6 +3,7 @@ import type { AppConfig } from "./config.js";
 import { assertRealtimeProviderConfig } from "./config.js";
 import { createLiveModelAdapter } from "./adapters/outbound/realtime/factory.js";
 import type { LiveModelEvent } from "./application/live-gateway/ports/realtime-model.port.js";
+import { errorToMessage } from "./domain/error-message.js";
 
 export interface LiveProviderSmokeReport {
   ok: true;
@@ -118,16 +119,6 @@ async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: s
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function errorToMessage(error: unknown): string {
-  if (error instanceof Error) {
-    return error.message;
-  }
-  if (error && typeof error === "object" && "message" in error && typeof (error as { message?: unknown }).message === "string") {
-    return (error as { message: string }).message;
-  }
-  return String(error);
 }
 
 function summarizeLiveEvent(event: LiveModelEvent): Record<string, unknown> {

--- a/src/readiness.ts
+++ b/src/readiness.ts
@@ -6,6 +6,7 @@ import {
 } from "./config.js";
 import type { HermesRunsPort } from "./application/live-gateway/ports/hermes-runs.port.js";
 import { HermesClient } from "./adapters/outbound/hermes/hermes-runs.client.js";
+import { errorToMessage } from "./domain/error-message.js";
 
 export interface ReadinessSection extends Record<string, unknown> {
   ok: boolean;
@@ -118,8 +119,4 @@ function realtimeCheckSummary(config: AppConfig): Record<string, unknown> {
     };
   }
   return base;
-}
-
-function errorToMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
 }

--- a/test/live-provider-smoke.test.ts
+++ b/test/live-provider-smoke.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { errorToMessage } from "../src/domain/error-message.js";
+
+describe("provider error formatting", () => {
+  it("formats nested structured provider errors without falling back to object coercion", () => {
+    expect(
+      errorToMessage({
+        type: "error",
+        error: {
+          type: "invalid_request_error",
+          code: "model_not_found",
+          message: "The requested realtime model is unavailable.",
+        },
+      }),
+    ).toBe(
+      "message=The requested realtime model is unavailable., code=model_not_found, type=invalid_request_error",
+    );
+  });
+
+  it("returns a safe diagnostic for unknown objects", () => {
+    expect(errorToMessage({ unexpected: { secret: "not rendered" } })).toBe(
+      "Unknown structured error.",
+    );
+  });
+});

--- a/test/live-websocket.test.ts
+++ b/test/live-websocket.test.ts
@@ -723,6 +723,52 @@ describe("live gateway WebSocket", () => {
     });
   });
 
+  it("treats a client-close event-stream abort as cancellation instead of a run failure", async () => {
+    const streamAborted = deferred<void>();
+    const logger = fakeLogger();
+    const hermes = fakeHermes({
+      streamEvents: async function* (_runId: string, options?: { signal?: AbortSignal }) {
+        await new Promise<void>((_resolve, reject) => {
+          const signal = options?.signal;
+          if (signal?.aborted) {
+            streamAborted.resolve();
+            reject(new DOMException("This operation was aborted", "AbortError"));
+            return;
+          }
+          signal?.addEventListener(
+            "abort",
+            () => {
+              streamAborted.resolve();
+              reject(new DOMException("This operation was aborted", "AbortError"));
+            },
+            { once: true },
+          );
+        });
+        yield { event: "run.completed", output: "unreachable" };
+      },
+    });
+    const server = await startServer({
+      config: testConfig(),
+      hermes,
+      liveModel: new MockLiveAdapter(),
+      logger,
+    });
+    openServers.push(server);
+    const socket = new WebSocket(toWebSocketUrl(server.url), { headers: { origin: server.url } });
+    openSockets.push(socket);
+
+    await waitForOpen(socket);
+    send(socket, { type: "session.start" });
+    await waitForMessage(socket, "session.ready");
+    send(socket, { type: "text.input", text: "Run until the socket closes" });
+    await waitForMessage(socket, "run.started");
+    socket.close(1000, "test close");
+
+    await streamAborted.promise;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(logger.warn).not.toHaveBeenCalledWith("Hermes run bridge failed", expect.anything());
+  });
+
   it("rejects unauthorized WebSocket upgrades when auth is configured", async () => {
     const server = await startServer({
       config: testConfig({ server: { authToken: "secret-token" } }),

--- a/test/openai-realtime.test.ts
+++ b/test/openai-realtime.test.ts
@@ -143,7 +143,7 @@ describe("OpenAI Realtime adapter helpers", () => {
           systemInstruction: "test",
           callbacks: { onEvent: () => undefined },
         }),
-      ).rejects.toEqual({ message: "invalid session" });
+      ).rejects.toThrow("message=invalid session");
       await expect(withTimeout(closed, 2_000, "Timed out waiting for failed OpenAI socket to close.")).resolves.toEqual({
         code: 1011,
         reason: "OpenAI Realtime session start failed",


### PR DESCRIPTION
## Summary

- treat client-close aborts as expected Hermes run cancellation
- normalize structured provider startup errors into actionable, bounded diagnostics
- update the v0.2.0 changelog date and release notes

## Verification

- `npm run verify` — 14 test files, 122 tests, full CLI/gateway/plugin/package smoke
- `npm audit --audit-level=low` — 0 vulnerabilities
- Docker image build and healthy container
- official Hermes Agent v0.18.2 Docker API: health, capabilities, authenticated run, SSE completion, stop, and persisted cancellation
- Gemini Live `gemini-3.1-flash-live-preview`: real handshake and full Gemini Live → hermes-live → Hermes Docker run
- OpenAI Realtime `gpt-realtime-2.1`: endpoint reached; Onira credential currently returns `insufficient_quota`, now reported correctly
