### PR TITLE
docs: add native Hermes plugin install

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,14 @@ npm run build
 
 ### 2. Install the Hermes plugin
 
+Current Hermes releases can install and enable the plugin directly from this repository:
+
+```sh
+hermes plugins install bielcarpi/hermes-live-voice/plugins/hermes-live --enable
+```
+
+If you already cloned and built the gateway, the package installer provides the same plugin locally:
+
 ```sh
 node dist/cli.js plugin install
 hermes plugins enable hermes-live

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -95,7 +95,13 @@ The realtime provider does not receive Hermes tools directly. It receives gatewa
 
 ## Install In Hermes
 
-Hermes discovers user plugins from `~/.hermes/plugins/<plugin-name>/`. Copy or symlink this directory there, then enable it:
+Current Hermes releases can clone the plugin subdirectory, install it under `~/.hermes/plugins/hermes-live/`, and enable it in one command:
+
+```sh
+hermes plugins install bielcarpi/hermes-live-voice/plugins/hermes-live --enable
+```
+
+For a local clone or npm package, copy or symlink the packaged plugin directory instead:
 
 ```sh
 node dist/cli.js plugin install


### PR DESCRIPTION
## Summary

- document the native Hermes `plugins install owner/repo/subdir --enable` path
- keep the package/local-clone installer as an alternative

## Verification

- `npm run check:docs`
- installed directly into official Hermes Agent v0.18.2 Docker
- plugin appeared as enabled v0.2.0 and registered `hermes_live_status` in `/v1/toolsets`
