### PR TITLE
fix: resolve CodeQL security alerts

### DIFF
--- a/src/adapters/inbound/http/server.ts
+++ b/src/adapters/inbound/http/server.ts
@@ -51,7 +51,7 @@ export async function startServer({ config, logger, hermes: providedHermes, live
     } catch (error) {
       const message = errorToMessage(error);
       logger.error("http handler failed", { error: message });
-      json(req, res, 500, { status: "error", error: message });
+      json(req, res, 500, { status: "error", error: "Internal server error." });
     }
   });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -212,12 +212,41 @@ export function realtimeProviderConfigured(config: Pick<AppConfig, "realtime" | 
 }
 
 export function sanitizeSessionComponent(value: string): string {
-  return value
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9._:-]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .slice(0, 80);
+  const sanitized: string[] = [];
+  let replacingUnsafeRun = false;
+
+  for (const character of value.trim().toLowerCase()) {
+    if (isSafeSessionCharacter(character)) {
+      sanitized.push(character);
+      replacingUnsafeRun = false;
+    } else if (!replacingUnsafeRun) {
+      sanitized.push("-");
+      replacingUnsafeRun = true;
+    }
+  }
+
+  let start = 0;
+  let end = sanitized.length;
+  while (start < end && sanitized[start] === "-") {
+    start += 1;
+  }
+  while (end > start && sanitized[end - 1] === "-") {
+    end -= 1;
+  }
+
+  return sanitized.slice(start, Math.min(end, start + 80)).join("");
+}
+
+function isSafeSessionCharacter(character: string): boolean {
+  const code = character.charCodeAt(0);
+  return (
+    (code >= 97 && code <= 122) ||
+    (code >= 48 && code <= 57) ||
+    character === "." ||
+    character === "_" ||
+    character === ":" ||
+    character === "-"
+  );
 }
 
 export function makeSessionKey(prefix: string, profileId: string, userLabel: string): string {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -85,6 +85,9 @@ describe("config", () => {
 
   it("redacts unsafe session pieces into stable session keys", () => {
     expect(sanitizeSessionComponent(" Alice Example!!! ")).toBe("alice-example");
+    expect(sanitizeSessionComponent("---Alice---Example---")).toBe("alice---example");
+    expect(sanitizeSessionComponent("Alice!!!Example")).toBe("alice-example");
+    expect(sanitizeSessionComponent(`${"-".repeat(100_000)}Alice`)).toBe("alice");
     expect(makeSessionKey("agent:main:hermes-live", "Default Profile", "Alice Example")).toBe(
       "agent:main:hermes-live:profile:default-profile:user:alice-example",
     );

--- a/test/server-http.test.ts
+++ b/test/server-http.test.ts
@@ -154,6 +154,30 @@ describe("HTTP server", () => {
     });
   });
 
+  it("logs internal HTTP failures without exposing their details to clients", async () => {
+    const hermes = fakeHermes();
+    vi.mocked(hermes.assertRunsSupported).mockResolvedValueOnce({
+      model: "hermes-agent",
+      features: { nonSerializableInternalValue: 1n },
+    });
+    const logger = fakeLogger();
+    const server = await startServer({
+      config: testConfig(),
+      hermes,
+      liveModel: new MockLiveAdapter(),
+      logger,
+    });
+    openServers.push(server);
+
+    const response = await fetch(`${server.url}/ready`);
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({ status: "error", error: "Internal server error." });
+    expect(logger.error).toHaveBeenCalledWith("http handler failed", {
+      error: expect.stringContaining("BigInt"),
+    });
+  });
+
   it("honors CORS allowlist for configured origins", async () => {
     const server = await startServer({
       config: testConfig({ server: { allowOrigin: "https://app.example.com" } }),


### PR DESCRIPTION
## Summary
- replace the session-component trimming regex with a linear sanitizer
- keep internal HTTP error details in server logs while returning a generic 500 response
- add regressions for long adversarial session labels and response-detail exposure

## Verification
- npm run verify (123 tests across 14 files)
- npm audit --audit-level=low (0 vulnerabilities)