### PR TITLE
chore: prepare v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## 0.2.1 - 2026-07-13
+
+- Replace session-label regex trimming with a linear sanitizer to prevent adversarial input from causing excessive processing.
+- Keep unexpected internal HTTP failure details in server logs while returning a generic error response to clients.
+- Add regression coverage for long hostile session labels and internal error-detail disclosure.
+- Document and verify native Hermes plugin installation directly from the repository subdirectory.
+
 ## 0.2.0 - 2026-07-12
 
 - Reposition the project as the realtime custom-client bridge for Hermes Agent, with a marketing-first README, honest Voice Mode comparison, provider compatibility roadmap, support guide, and release runbook.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hermes-live-voice",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes-live-voice",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@google/genai": "^2.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-live-voice",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Realtime voice bridge for Hermes Agent with Gemini Live, OpenAI Realtime, barge-in, tools, memory, and approvals.",
   "type": "module",
   "main": "./dist/index.js",

--- a/plugins/hermes-live/plugin.yaml
+++ b/plugins/hermes-live/plugin.yaml
@@ -1,5 +1,5 @@
 name: hermes-live
-version: 0.2.0
+version: 0.2.1
 description: "Connect Hermes Agent to an interruptible Gemini Live or OpenAI Realtime voice session through the self-hosted Hermes Live Voice gateway."
 author: Biel Carpi and Hermes Live contributors
 kind: standalone


### PR DESCRIPTION
## Summary
- bump package and Hermes plugin metadata to v0.2.1
- record the CodeQL security fixes and native plugin install documentation in the changelog
- prepare the immutable patch release that contains the post-v0.2.0 hardening

## Verification
- npm ci
- npm run verify (123 tests across 14 files)
- npm audit --audit-level=moderate (0 vulnerabilities)
- npm pack --dry-run (141 files)
- docker build -t hermes-live-voice:0.2.1 .
- runtime image healthy as non-root; health and authenticated/unauthenticated capabilities checks passed