### PR TITLE
fix: harden live voice sessions for v0.3.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,10 +20,16 @@ HERMES_LIVE_TRUST_CLIENT_IDENTITY=false
 # summary avoids forwarding raw Hermes event payloads; raw is for trusted developer clients only.
 HERMES_LIVE_RUN_EVENT_DETAIL=summary
 HERMES_LIVE_MAX_SESSIONS=8
+# Per-frame decoded audio limit. Hard compatibility ceiling: 5900000 bytes.
 HERMES_LIVE_MAX_AUDIO_BYTES=2000000
+# Client text limit. Hard configuration ceiling: 1000000 characters.
 HERMES_LIVE_MAX_TEXT_CHARS=20000
 HERMES_LIVE_PROVIDER_READY_TIMEOUT_MS=15000
+# Bounds the one-shot `hermes-live client` WebSocket and session.ready handshake.
+HERMES_LIVE_CLIENT_READY_TIMEOUT_MS=10000
 HERMES_LIVE_DEMO_ENABLED=true
+
+# Clients negotiate Hermes Live protocol v2 even though the WebSocket endpoint remains /v1/live.
 
 # Realtime provider: "gemini", "openai", or "mock".
 HERMES_LIVE_PROVIDER=gemini

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,24 @@
 
 ## 0.3.0 - 2026-07-13
 
-- Add a first-class **Live Voice** tab to the official Hermes Dashboard with responsive desktop/mobile layouts, browser microphone and playback, text fallback, transcript, capability status, task activity, separate response interruption and Hermes run cancellation, and approval controls.
+- Add a first-class **Live Voice** integration for Hermes Dashboard with responsive desktop/mobile layouts, browser microphone and playback, text fallback, transcript, capability status, task activity, separate response interruption and Hermes run cancellation, and approval controls.
 - Add an authenticated same-origin Dashboard HTTP/WebSocket proxy that delegates to Hermes' own Dashboard authentication and origin checks while keeping the upstream gateway URL and bearer out of browser code.
 - Publish a dependency-free `hermes-live-voice/browser` client and microphone worklet with strict protocol/lifecycle validation, bounded input and playback queues, request IDs, state subscriptions, and host-provided authenticated WebSocket URLs.
 - Normalize client close frames to browser-legal codes and bounded UTF-8 reasons, recover from missing close events, suppress late audio after interruption until the next response begins, and replace stale connected notices when a gateway connection drops.
-- Negotiate protocol v1 explicitly and expose provider-neutral response lifecycle, model/provider metadata, audio capabilities, turn-detection mode, structured approvals, and UI-safe run state.
+- Move the negotiated wire contract to protocol v2, a breaking client handshake that removes raw provider envelopes, adds `run.stopping`, and requires exact approval identity and choice correlation while retaining `/v1/live` as the endpoint path.
 - Enable Gemini Live input/output audio transcription, preserve speaker/final metadata, avoid duplicate transcript events, and emit a normalized response-start lifecycle before assistant output.
-- Preserve concurrent approvals in FIFO order across the browser client, Dashboard, demo, persistent terminal, and one-shot CLI; only the queue head is actionable and only resolved entries are removed.
-- Limit permanent approvals to choices backed by displayable permission patterns and require a second confirmation in every interactive client.
-- Remove approval submission from realtime-provider tools and enforce human approval choices against a sanitized server-side FIFO queue, with fail-closed denial and no bulk resolution.
-- Harden the default unauthenticated loopback WebSocket policy against DNS rebinding while retaining headerless terminal/native clients and exact configured browser origins.
+- Preserve concurrent approvals in a capacity-bounded FIFO across the browser client, Dashboard, demo, persistent terminal, and one-shot CLI; only the queue head is actionable and only the exact confirmed entry is removed.
+- Assign gateway-owned approval IDs, correlate them to bounded upstream identities, cache exact responses idempotently, and reject request-ID reuse, duplicate upstream identities, mismatched run/approval IDs, widened choices, and bulk resolution.
+- Project approval details without silently rewriting them: opaque or incomplete requests are deny-only, `once` requires informed display context, and session/permanent choices require exact inspectable permission patterns plus a second interactive confirmation.
+- Remove approval submission from realtime-provider tools and contain indeterminate approval or run mutations by stopping owned work and closing the session instead of risking a retry against the wrong action.
+- Emit `run.stopping` when Hermes accepts a stop request and reserve `run.stopped` for confirmed `run.cancelled`; completion and failure retain their own terminal messages.
+- Harden the default unauthenticated loopback WebSocket policy against Host-header and DNS-rebinding attacks while retaining headerless terminal/native clients and exact configured browser origins.
+- Bound client/provider queues, WebSocket backpressure, PCM16 conversion, transcripts, audio, usage, tool arguments/results, Hermes JSON/SSE bodies, and terminal output; close on violated provider contracts instead of allowing unbounded memory growth.
+- Correlate Hermes run IDs across start responses, status, SSE events, approvals, and terminal events; treat ambiguous starts, early event-stream EOF, late starts, failed stops, and unconfirmed disconnect cleanup as fatal containment conditions.
+- Bound provider input, tool-result, response-cancel, and close operations so a stalled realtime provider cannot make session shutdown wait forever.
 - Add `hermes-live terminal` and its `chat` alias for persistent remote/headless text control with transcripts, task progress, approvals, `/interrupt`, `/stop`, and safe exit behavior.
 - Package the Dashboard frontend/backend assets and browser client in plugin, npm tarball, and Docker runtime outputs, with generated-asset parity and smoke checks.
-- Promote the official Dashboard to the recommended UI, document secure community UI integration, clarify Hermes Voice Mode and OpenAI-compatible UI boundaries, and add a real Dashboard screenshot.
+- Make the Hermes Dashboard integration the recommended UI, add the persistent terminal as a first-class headless surface, document the secure browser SDK/relay path for community UIs, clarify Hermes Voice Mode and generic OpenAI-compatible UI boundaries, and add a real Dashboard screenshot.
 - Align the Docker Compose OpenAI Realtime default with `gpt-realtime-2.1`.
 - Make tagged release jobs fail when the Git tag does not match `package.json` or point at the exact protected `main` commit.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 </p>
 
 <p align="center">
-  <img src="assets/dashboard-live-voice.jpg" alt="Hermes Live Voice running inside the official Hermes Dashboard" width="100%">
+  <img src="assets/dashboard-live-voice.jpg" alt="Hermes Live Voice running inside Hermes Dashboard" width="100%">
 </p>
 
 <p align="center">
@@ -40,7 +40,7 @@
 
 Hermes Live Voice is a Hermes plugin, a self-hosted voice gateway, and a small client protocol. It turns an existing Hermes Agent into the action-taking brain behind an interruptible speech-to-speech conversation.
 
-Ask it to inspect a repository, use memory, research something current, run a command, or request an approval. The realtime model keeps the conversation fluid while Hermes performs the actual work.
+Ask it to inspect a repository, use memory, research something current, run a command, or request an approval. The realtime model handles the speech loop; Hermes performs the tool-using work, while clients keep progress, stop controls, and approvals visible.
 
 ```txt
 You speak
@@ -53,6 +53,8 @@ Hermes Agent — memory, tools, skills, MCP, approvals
    ↓
 The result returns to the live conversation
 ```
+
+In v0.3, delegation to Hermes is synchronous from the realtime provider's perspective: conversation is fluid before and after the delegated run, but the speech model waits for that run's terminal result. The Dashboard and other clients still receive live task events, approvals, and stop controls during the wait. Continuous provider-side conversation while Hermes works is a roadmap item, not a current claim.
 
 The realtime provider receives three narrow gateway tools—not unrestricted access to the Hermes toolbelt. Provider credentials, Hermes credentials, Hermes session keys, and approval decisions remain outside the provider.
 
@@ -97,7 +99,7 @@ This project does not replace Hermes Voice Mode. It serves the integration layer
 
 | Surface | Best for | Audio |
 | --- | --- | --- |
-| **Official Hermes Dashboard — recommended** | Daily use with transcript, task progress, interruption, stop, and approvals | Browser microphone and playback |
+| **Hermes Dashboard + Live Voice plugin — recommended** | Daily use with transcript, task progress, interruption, stop, and approvals | Browser microphone and playback |
 | **Bundled browser demo** | Local development and gateway troubleshooting | Browser microphone and playback |
 | **`hermes-live-voice/browser`** | Community web UIs and custom React, Vue, Svelte, vanilla, or Electron clients | Host-integrated microphone and playback |
 | **`hermes-live terminal`** | SSH, headless systems, automation, and remote text control | Text only |
@@ -118,7 +120,7 @@ Generic chat UI compatibility is not the same as Hermes Live compatibility. A co
 Until the first npm publication, install from GitHub:
 
 ```sh
-git clone https://github.com/bielcarpi/hermes-live-voice.git
+git clone --branch v0.3.0 --depth 1 https://github.com/bielcarpi/hermes-live-voice.git
 cd hermes-live-voice
 npm ci
 npm run build
@@ -152,7 +154,7 @@ HERMES_LIVE_PROVIDER=mock \
 npm run dev
 ```
 
-Start or restart the official Dashboard after enabling the plugin:
+Start or restart Hermes Dashboard after enabling the plugin:
 
 ```sh
 hermes dashboard
@@ -324,7 +326,7 @@ Start a session:
 ```json
 {
   "type": "session.start",
-  "protocolVersion": 1,
+  "protocolVersion": 2,
   "profileId": "default",
   "userLabel": "alice"
 }
@@ -341,7 +343,7 @@ Send text for a smoke test:
 
 Or stream base64 PCM16 audio frames and end the turn with `audio.end`. The server emits provider audio/transcripts, Hermes run events, approvals, completion, and typed errors.
 
-The package also exposes the dependency-free browser client used by both the official Dashboard tab and the bundled demo:
+The package also exposes the dependency-free browser client used by both the Hermes Dashboard integration and the bundled demo:
 
 ```js
 import { HermesLiveAudio, HermesLiveClient } from "hermes-live-voice/browser";
@@ -355,13 +357,15 @@ const audio = new HermesLiveAudio(client, {
 
 client.on("approval.request", showApproval);
 client.on("run.completed", ({ output }) => showResult(output));
+client.on("audio.output", (message) => void audio.play(message).catch(showError));
+client.on("input.speech_started", () => audio.interrupt("provider detected user speech"));
 await client.connect();
 await audio.startMicrophone();
 ```
 
 The gateway serves the canonical worklet at `/mic-worklet.js`; package consumers can also resolve the `hermes-live-voice/browser/mic-worklet.js` export into their own static assets. The client validates lifecycle messages, returns request IDs, bounds microphone and playback buffering, and exposes `subscribe()`/`getSnapshot()` for React or other state-driven UIs.
 
-`webSocketUrlProvider` lets a host return a same-origin authenticated proxy URL or a host-issued short-lived ticket. The Hermes Live gateway does not mint per-user tickets itself. Do not embed an installation-wide `HERMES_LIVE_AUTH_TOKEN` in a public web app; the official Dashboard keeps it server-side through its authenticated plugin proxy.
+`webSocketUrlProvider` lets a host return a same-origin authenticated proxy URL or a host-issued short-lived ticket. The Hermes Live gateway does not mint per-user tickets itself. Do not embed an installation-wide `HERMES_LIVE_AUTH_TOKEN` in a public web app; the Dashboard integration keeps it server-side through its authenticated plugin proxy.
 
 See [UI integration](docs/ui-integration.md) and the [client protocol](docs/client-protocol.md) before building a client.
 

--- a/apps/web-demo/app.js
+++ b/apps/web-demo/app.js
@@ -21,7 +21,7 @@ gatewayInput.value = `${location.protocol === "https:" ? "wss" : "ws"}://${locat
 
 connectButton.addEventListener("click", () => {
   if (client?.connected || client?.state === "starting") {
-    client.disconnect();
+    void client.disconnect().catch(showError);
     return;
   }
   if (client?.state === "connecting") return;
@@ -142,10 +142,12 @@ function handleMessage(message) {
     audio.clearPlayback();
     if (message.type === "session.error" && !message.recoverable) setInteractive(false);
     addLog("error", JSON.stringify(message, null, 2));
+  } else if (message.type === "run.stopping") {
+    addLog("run", `stop requested for ${message.runId}: ${message.status}`);
   } else if (message.type === "run.stopped") {
     audio.clearPlayback();
     addLog("run", `stopped ${message.runId}: ${message.status}`);
-  } else if (message.type !== "realtime.message") {
+  } else {
     addLog(message.type, JSON.stringify(message, null, 2));
   }
 }
@@ -199,28 +201,36 @@ function addApprovalRequest(message) {
   const body = document.createElement("pre");
   const approval = message.approval ?? {};
   const patternKeys = approvalPatternKeys(approval);
+  const informed =
+    (typeof approval.command === "string" && approval.command.length > 0) ||
+    (typeof approval.description === "string" && approval.description.length > 0);
   body.textContent = [
     approval.description,
     approval.command ? `Command: ${approval.command}` : undefined,
     approval.approvalId ? `Approval: ${approval.approvalId}` : undefined,
-    patternKeys.length ? `Permission pattern: ${patternKeys.join(", ")}` : "No inspectable permission pattern; permanent approval is unavailable.",
+    patternKeys.length
+      ? `Permission pattern: ${patternKeys.join(", ")}`
+      : informed
+        ? "No inspectable permission pattern; session and permanent approval are unavailable."
+        : "Request details are unavailable; denial is the only safe option.",
   ].filter(Boolean).join("\n") || "Hermes requested an approval without additional context.";
   const actions = document.createElement("div");
   actions.className = "approval-actions";
   const queueStatus = document.createElement("span");
   queueStatus.className = "approval-queue-status";
 
-  const informed = typeof approval.command === "string" || typeof approval.description === "string";
-  const suppliedChoices = Array.isArray(approval.choices) && approval.choices.length > 0
+  const allowedChoices = ["once", "session", "always", "deny"];
+  const suppliedChoices = Array.isArray(approval.choices) &&
+      approval.choices.length > 0 &&
+      approval.choices.every((choice) => typeof choice === "string" && allowedChoices.includes(choice))
     ? approval.choices
-    : informed
-      ? ["once", "session", "always", "deny"]
-      : ["once", "deny"];
+    : ["deny"];
   const choices = [...new Set(suppliedChoices)]
-    .filter((choice) => ["once", "session", "always", "deny"].includes(choice))
-    .filter((choice) => informed || choice === "once" || choice === "deny")
+    .filter((choice) => allowedChoices.includes(choice))
+    .filter((choice) => informed || choice === "deny")
+    .filter((choice) => !["session", "always"].includes(choice) || patternKeys.length > 0)
     .filter((choice) => choice !== "always" || (approval.allowPermanent === true && patternKeys.length > 0));
-  if (choices.length === 0) choices.push("once", "deny");
+  if (!choices.includes("deny")) choices.push("deny");
   const queued = {
     message,
     actions,
@@ -241,9 +251,16 @@ function addApprovalRequest(message) {
         queueStatus.textContent = "Permanent approval changes future policy. Click confirm always again to continue.";
         return;
       }
-      client.respondToApproval(choice, message.runId);
-      queued.submitted = true;
-      refreshApprovalQueue();
+      try {
+        client.respondToApproval(choice, message.runId, { approvalId: approval.approvalId });
+        queued.submitted = true;
+        refreshApprovalQueue();
+      } catch (error) {
+        queued.permanentArmed = false;
+        if (choice === "always") button.textContent = "always";
+        refreshApprovalQueue();
+        showError(error);
+      }
     });
     queued.buttons.push(button);
     actions.append(button);
@@ -282,21 +299,15 @@ function inspectablePattern(value) {
 }
 
 function resolveApprovalQueue(message) {
-  let remaining = Number.isInteger(message.resolved) && message.resolved >= 0 ? message.resolved : 1;
-  for (let index = 0; index < approvalQueue.length && remaining > 0;) {
+  const index = approvalQueue.findIndex((queued) =>
+    queued.message.runId === message.runId &&
+    queued.message.approval?.approvalId === message.approvalId);
+  if (index >= 0) {
     const queued = approvalQueue[index];
-    if (queued.message.runId !== message.runId) {
-      index += 1;
-      continue;
-    }
     queued.submitted = true;
     queued.queueStatus.textContent = `Resolved: ${message.choice}`;
     for (const button of queued.buttons) button.disabled = true;
     approvalQueue.splice(index, 1);
-    remaining -= 1;
-  }
-  if (message.resolved === 0 && approvalQueue[0]?.message.runId === message.runId) {
-    approvalQueue[0].submitted = false;
   }
   refreshApprovalQueue();
 }

--- a/clients/browser/hermes-live-client.d.ts
+++ b/clients/browser/hermes-live-client.d.ts
@@ -8,12 +8,12 @@ export type HermesLiveClientState =
   | "failed";
 
 export type HermesApprovalChoice = "once" | "session" | "always" | "deny";
-export const HERMES_LIVE_PROTOCOL_VERSION: 1;
+export const HERMES_LIVE_PROTOCOL_VERSION: 2;
 export type HermesRunEvent = Record<string, unknown> & { event?: string; approval_id?: string };
 
 export interface HermesLiveSessionReady {
   type: "session.ready";
-  protocolVersion: 1;
+  protocolVersion: 2;
   sessionId: string;
   model: string;
   hermes: { model?: string; capabilities?: Record<string, unknown> };
@@ -40,12 +40,11 @@ export type HermesLiveServerMessage =
   | { type: "session.error"; code: string; message: string; requestId?: string; recoverable?: boolean }
   | { type: "audio.output"; data: string; mimeType: string; itemId?: string; contentIndex?: number }
   | { type: "transcript.delta"; speaker: "user" | "assistant" | "system"; text: string; final?: boolean }
-  | { type: "input.speech_started"; provider: string; itemId?: string; audioStartMs?: number }
+  | { type: "input.speech_started"; provider: "openai"; itemId?: string; audioStartMs?: number }
   | { type: "response.started"; responseId?: string }
   | { type: "response.completed"; responseId?: string }
   | { type: "response.cancelled"; responseId?: string }
   | { type: "response.failed"; responseId?: string; error: string }
-  | { type: "realtime.message"; message: unknown }
   | { type: "run.started"; runId: string; sessionId: string }
   | { type: "run.event"; runId: string; event: HermesRunEvent }
   | {
@@ -53,7 +52,7 @@ export type HermesLiveServerMessage =
       runId: string;
       event: HermesRunEvent;
       approval: {
-        approvalId?: string;
+        approvalId: string;
         command?: string;
         description?: string;
         patternKey?: string;
@@ -62,9 +61,17 @@ export type HermesLiveServerMessage =
         allowPermanent: boolean;
       };
     }
-  | { type: "approval.responded"; runId: string; choice: HermesApprovalChoice; resolved?: number }
+  | {
+      type: "approval.responded";
+      requestId: string;
+      runId: string;
+      approvalId: string;
+      choice: HermesApprovalChoice;
+      resolved: 1;
+    }
   | { type: "run.completed"; runId: string; output: string; usage?: Record<string, unknown> }
   | { type: "run.failed"; runId: string; error: string }
+  | { type: "run.stopping"; runId: string; status: string }
   | { type: "run.stopped"; runId: string; status: string }
   | { type: "log"; level: "debug" | "info" | "warn" | "error"; message: string; data?: unknown }
   | (Record<string, unknown> & { type: string });
@@ -76,6 +83,7 @@ export interface HermesLiveClientOptions {
   profileId?: string;
   userLabel?: string;
   connectTimeoutMs?: number;
+  disconnectTimeoutMs?: number;
   maxBufferedAmountBytes?: number;
   maxInboundMessageBytes?: number;
   webSocketFactory?: (url: URL) => WebSocket;
@@ -121,9 +129,9 @@ export interface HermesLiveClientEventMap {
   "approval.responded": Extract<HermesLiveServerMessage, { type: "approval.responded" }>;
   "run.completed": Extract<HermesLiveServerMessage, { type: "run.completed" }>;
   "run.failed": Extract<HermesLiveServerMessage, { type: "run.failed" }>;
+  "run.stopping": Extract<HermesLiveServerMessage, { type: "run.stopping" }>;
   "run.stopped": Extract<HermesLiveServerMessage, { type: "run.stopped" }>;
   log: Extract<HermesLiveServerMessage, { type: "log" }>;
-  "realtime.message": Extract<HermesLiveServerMessage, { type: "realtime.message" }>;
   "listener.error": { type: keyof HermesLiveClientEventMap; error: Error };
 }
 
@@ -146,8 +154,8 @@ export class HermesLiveClient {
   stopRun(reason?: string, runId?: string, options?: { id?: string }): string;
   respondToApproval(
     choice: HermesApprovalChoice,
-    runId?: string,
-    options?: { id?: string; resolveAll?: boolean },
+    runId: string | undefined,
+    options: { approvalId: string; id?: string },
   ): string;
   sendMessage(message: Record<string, unknown> & { type: string; id?: string }): string;
 }

--- a/clients/browser/hermes-live-client.js
+++ b/clients/browser/hermes-live-client.js
@@ -1,11 +1,12 @@
 const DEFAULT_CONNECT_TIMEOUT_MS = 15_000;
+const DEFAULT_DISCONNECT_TIMEOUT_MS = 12_000;
 const DEFAULT_MAX_BUFFERED_AMOUNT_BYTES = 1_000_000;
 const DEFAULT_MAX_INBOUND_MESSAGE_BYTES = 8_000_000;
-const DEFAULT_MAX_QUEUED_AUDIO_MS = 30_000;
+const DEFAULT_MAX_QUEUED_AUDIO_MS = 5_000;
 const DEFAULT_SAMPLE_RATE = 24_000;
 const MAX_PENDING_APPROVALS = 128;
 const OPEN = 1;
-export const HERMES_LIVE_PROTOCOL_VERSION = 1;
+export const HERMES_LIVE_PROTOCOL_VERSION = 2;
 
 const KNOWN_SERVER_MESSAGE_TYPES = new Set([
   "session.ready",
@@ -17,13 +18,13 @@ const KNOWN_SERVER_MESSAGE_TYPES = new Set([
   "response.completed",
   "response.cancelled",
   "response.failed",
-  "realtime.message",
   "run.started",
   "run.event",
   "approval.request",
   "approval.responded",
   "run.completed",
   "run.failed",
+  "run.stopping",
   "run.stopped",
   "log",
 ]);
@@ -78,6 +79,7 @@ export class HermesLiveClient {
     this.profileId = optionalString(options.profileId);
     this.userLabel = optionalString(options.userLabel);
     this.connectTimeoutMs = positiveInteger(options.connectTimeoutMs, DEFAULT_CONNECT_TIMEOUT_MS);
+    this.disconnectTimeoutMs = positiveInteger(options.disconnectTimeoutMs, DEFAULT_DISCONNECT_TIMEOUT_MS);
     this.maxBufferedAmountBytes = positiveInteger(
       options.maxBufferedAmountBytes,
       DEFAULT_MAX_BUFFERED_AMOUNT_BYTES,
@@ -136,7 +138,19 @@ export class HermesLiveClient {
   }
 
   async openConnection(generation, signal) {
-    const socketUrl = await this.resolveSocketUrl();
+    const startedAt = Date.now();
+    let socketUrl;
+    try {
+      socketUrl = await settleConnectionPrerequisite(
+        this.resolveSocketUrl(),
+        this.connectTimeoutMs,
+        signal,
+      );
+    } catch (error) {
+      const normalized = toError(error);
+      if (normalized.name !== "AbortError") this.emitError(normalized, "url_resolution_failed");
+      throw normalized;
+    }
     if (generation !== this.generation) throw abortError();
     if (signal?.aborted) throw abortError();
 
@@ -154,6 +168,7 @@ export class HermesLiveClient {
     return await new Promise((resolve, reject) => {
       let settled = false;
       let ready = false;
+      let fatalServerErrorReceived = false;
       const finish = (error, session) => {
         if (settled) return;
         settled = true;
@@ -167,11 +182,12 @@ export class HermesLiveClient {
         this.emitError(normalized, code);
         finish(normalized);
       };
+      const remainingTimeoutMs = Math.max(1, this.connectTimeoutMs - (Date.now() - startedAt));
       const timeout = setTimeout(() => {
         const error = new Error(`Hermes Live session did not become ready within ${this.connectTimeoutMs}ms.`);
         failStartup(error, "connect_timeout");
         closeSocket(socket, 4000, "session ready timeout");
-      }, this.connectTimeoutMs);
+      }, remainingTimeoutMs);
       const onAbort = () => {
         const error = abortError();
         finish(error);
@@ -212,6 +228,7 @@ export class HermesLiveClient {
               finish(error);
               closeSocket(socket, 1008, "session startup rejected");
             } else if (message.type === "session.error" && message.recoverable === false) {
+              fatalServerErrorReceived = true;
               this.setState("failed");
               closeSocket(socket, 1011, "nonrecoverable session error");
             }
@@ -253,7 +270,7 @@ export class HermesLiveClient {
         this.emitter.emit("close", closeEvent);
         if (!ready) {
           finish(new Error(`Hermes Live connection closed before session readiness (${closeEvent.code}).`));
-        } else if (!closeEvent.clean && closeEvent.code !== 1000) {
+        } else if (!closeEvent.clean && closeEvent.code !== 1000 && !fatalServerErrorReceived) {
           this.emitError(new Error("Hermes Live connection was lost."), "connection_lost", closeEvent);
         }
       });
@@ -286,22 +303,36 @@ export class HermesLiveClient {
       return;
     }
     this.setState("closing");
+    this.updateSnapshot({ lastError: undefined });
+    let requestedProtocolClose = false;
     if (socket.readyState === OPEN) {
       try {
         this.sendRaw({ type: "session.close", id: this.createRequestId() });
+        requestedProtocolClose = true;
       } catch {
-        // The close below is authoritative.
+        // Fall back to a local WebSocket close below.
       }
     }
     let closeObserved = false;
+    let closeTimedOut = false;
+    let observedClose;
     await new Promise((resolve) => {
-      const timeout = setTimeout(resolve, 1_000);
-      socket.addEventListener("close", () => {
+      const timeout = setTimeout(() => {
+        closeTimedOut = true;
+        closeSocket(socket, 4000, "gateway close confirmation timeout");
+        resolve();
+      }, requestedProtocolClose ? this.disconnectTimeoutMs : 1_000);
+      socket.addEventListener("close", (event) => {
         closeObserved = true;
+        observedClose = {
+          code: Number(event.code ?? 1006),
+          reason: String(event.reason ?? ""),
+          clean: Boolean(event.wasClean),
+        };
         clearTimeout(timeout);
         resolve();
       }, { once: true });
-      closeSocket(socket, 1000, reason);
+      if (!requestedProtocolClose) closeSocket(socket, 1000, reason);
     });
     if (!closeObserved && this.isCurrentSocket(socket, this.generation)) {
       ++this.generation;
@@ -320,6 +351,16 @@ export class HermesLiveClient {
         reason: "disconnect timed out",
         clean: false,
       });
+    }
+    if (closeTimedOut) {
+      throw new Error("The gateway did not confirm session shutdown; verify any active Hermes task before reconnecting.");
+    }
+    await this.messageChain.catch(() => undefined);
+    if (observedClose && (observedClose.code !== 1000 || !observedClose.clean)) {
+      throw new Error(
+        this.snapshot.lastError?.error?.message ||
+        "The gateway closed abnormally and did not confirm complete session shutdown. Verify any active Hermes task.",
+      );
     }
   }
 
@@ -371,6 +412,9 @@ export class HermesLiveClient {
 
   respondToApproval(choice, runId = this.activeRunId, options = {}) {
     if (!runId) throw new Error("An approval response requires an active Hermes run ID.");
+    if (typeof options.approvalId !== "string" || !options.approvalId) {
+      throw new Error("An approval response requires the exact pending approval ID.");
+    }
     if (!["once", "session", "always", "deny"].includes(choice)) {
       throw new TypeError(`Unsupported Hermes approval choice: ${choice}`);
     }
@@ -379,8 +423,8 @@ export class HermesLiveClient {
       type: "approval.respond",
       id,
       runId,
+      approvalId: options.approvalId,
       choice,
-      ...(options.resolveAll === undefined ? {} : { resolveAll: Boolean(options.resolveAll) }),
     });
     return id;
   }
@@ -419,7 +463,7 @@ export class HermesLiveClient {
     } else {
       throw new TypeError("Hermes Live returned an unsupported WebSocket message type.");
     }
-    if (text.length > this.maxInboundMessageBytes) {
+    if (encodedMessageSize(text) > this.maxInboundMessageBytes) {
       throw new Error("Hermes Live server message exceeded the configured client limit.");
     }
     return validateServerMessage(JSON.parse(text));
@@ -458,13 +502,12 @@ export class HermesLiveClient {
         }
         break;
       case "approval.responded": {
-        let remaining = message.resolved === undefined ? 1 : message.resolved;
         this.updateSnapshot({
-          pendingApprovals: this.snapshot.pendingApprovals.filter((entry) => {
-            if (entry.runId !== message.runId || remaining <= 0) return true;
-            remaining -= 1;
-            return false;
-          }),
+          pendingApprovals: this.snapshot.pendingApprovals.filter(
+            (entry) =>
+              entry.runId !== message.runId ||
+              entry.approval.approvalId !== message.approvalId,
+          ),
         });
         break;
       }
@@ -486,6 +529,9 @@ export class HermesLiveClient {
         });
         break;
       }
+      case "run.stopping":
+        this.updateSnapshot({ run: { state: "stopping", runId: message.runId } });
+        break;
       case "session.error":
         if (message.requestId && message.requestId === this.pendingStopRequestId) {
           this.pendingStopRequestId = "";
@@ -949,11 +995,11 @@ export function validateServerMessage(value) {
       requireString(message, "mimeType");
       break;
     case "transcript.delta":
-      requireString(message, "speaker");
+      requireEnum(message, "speaker", ["user", "assistant", "system"]);
       requireString(message, "text", true);
       break;
     case "input.speech_started":
-      requireString(message, "provider");
+      requireEnum(message, "provider", ["openai"]);
       break;
     case "response.started":
     case "response.completed":
@@ -974,12 +1020,15 @@ export function validateServerMessage(value) {
       requireString(message, "runId");
       requireObject(message, "event");
       requireObject(message, "approval");
+      message.approval = normalizeApprovalDetails(message.approval);
       break;
     case "approval.responded":
+      requireString(message, "requestId");
       requireString(message, "runId");
-      requireString(message, "choice");
-      if (message.resolved !== undefined && (!Number.isInteger(message.resolved) || message.resolved < 0)) {
-        throw new TypeError("Hermes Live approval.responded message requires a non-negative integer resolved count.");
+      requireString(message, "approvalId");
+      requireEnum(message, "choice", ["once", "session", "always", "deny"]);
+      if (message.resolved !== 1) {
+        throw new TypeError("Hermes Live approval.responded message must confirm exactly one resolved approval.");
       }
       break;
     case "run.completed":
@@ -990,12 +1039,16 @@ export function validateServerMessage(value) {
       requireString(message, "runId");
       requireString(message, "error");
       break;
+    case "run.stopping":
+      requireString(message, "runId");
+      requireString(message, "status");
+      break;
     case "run.stopped":
       requireString(message, "runId");
       requireString(message, "status");
       break;
     case "log":
-      requireString(message, "level");
+      requireEnum(message, "level", ["debug", "info", "warn", "error"]);
       requireString(message, "message", true);
       break;
   }
@@ -1008,10 +1061,107 @@ function requireString(value, key, allowEmpty = false) {
   }
 }
 
+function requireEnum(value, key, allowed) {
+  requireString(value, key);
+  if (!allowed.includes(value[key])) {
+    throw new TypeError(`Hermes Live ${value.type} message contains an unsupported ${key}.`);
+  }
+}
+
 function requireObject(value, key) {
   if (!value[key] || typeof value[key] !== "object" || Array.isArray(value[key])) {
     throw new TypeError(`Hermes Live ${value.type} message requires ${key}.`);
   }
+}
+
+function normalizeApprovalDetails(value) {
+  const rawApprovalId = typeof value.approvalId === "string" ? value.approvalId : "";
+  const approvalId = safeInspectableText(rawApprovalId, 256);
+  if (!approvalId || approvalId !== rawApprovalId) {
+    throw new TypeError("Hermes Live approval.request requires a safe gateway approvalId.");
+  }
+  const commandProjection = exactApprovalDisplayText(value.command, 4_000);
+  const descriptionProjection = exactApprovalDisplayText(value.description, 2_000);
+  const command = commandProjection.value;
+  const description = descriptionProjection.value;
+  const displayComplete = commandProjection.exact && descriptionProjection.exact && Boolean(command || description);
+  const patterns = exactApprovalPatterns(value);
+  const inspectablePatterns = displayComplete && patterns.exact ? patterns.values : [];
+  const hasInspectablePermanentPattern = displayComplete && patterns.exact && inspectablePatterns.length > 0;
+  const allowedChoices = ["once", "session", "always", "deny"];
+  const suppliedChoices = Array.isArray(value.choices) &&
+      value.choices.length > 0 &&
+      value.choices.every((choice) => typeof choice === "string" && allowedChoices.includes(choice))
+    ? value.choices
+    : ["deny"];
+  const allowPermanent = hasInspectablePermanentPattern && value.allowPermanent === true;
+  const choices = [...new Set(suppliedChoices)]
+    .filter((choice) => displayComplete || choice === "deny")
+    .filter((choice) => !["session", "always"].includes(choice) || hasInspectablePermanentPattern)
+    .filter((choice) => choice !== "always" || allowPermanent);
+  if (!choices.includes("deny")) choices.push("deny");
+  return {
+    approvalId,
+    ...(command ? { command } : {}),
+    ...(description ? { description } : {}),
+    ...(inspectablePatterns[0] ? { patternKey: inspectablePatterns[0] } : {}),
+    ...(inspectablePatterns.length > 1 ? { patternKeys: inspectablePatterns.slice(1) } : {}),
+    choices,
+    allowPermanent: allowPermanent && choices.includes("always"),
+  };
+}
+
+function exactApprovalDisplayText(value, maximum) {
+  if (value === undefined || value === null || value === "") return { exact: true };
+  if (typeof value !== "string" || /[\r\n\t]/u.test(value)) return { exact: false };
+  const projected = safeDisplayText(value, maximum);
+  return projected && projected === value && /[\p{L}\p{N}\p{P}\p{S}]/u.test(projected)
+    ? { value: projected, exact: true }
+    : { exact: false };
+}
+
+function exactApprovalPatterns(value) {
+  const rawValues = [];
+  if (value.patternKey !== undefined && value.patternKey !== null && value.patternKey !== "") {
+    rawValues.push(value.patternKey);
+  }
+  if (value.patternKeys !== undefined && value.patternKeys !== null) {
+    if (!Array.isArray(value.patternKeys) || value.patternKeys.length > 32) {
+      return { values: [], exact: false };
+    }
+    rawValues.push(...value.patternKeys);
+  }
+  if (rawValues.length > 32) return { values: [], exact: false };
+
+  const values = [];
+  for (const raw of rawValues) {
+    const projected = safeInspectableText(raw, 256);
+    if (typeof raw !== "string" || !projected || projected !== raw) {
+      return { values: [], exact: false };
+    }
+    if (!values.includes(projected)) values.push(projected);
+  }
+  return { values, exact: true };
+}
+
+function safeDisplayText(value, maximum) {
+  if (typeof value !== "string") return "";
+  const withoutTerminalSequences = value
+    .replace(/\u001b\][^\u0007]*(?:\u0007|\u001b\\|$)/g, "")
+    .replace(/(?:\u001b\[|\u009b)[0-?]*[ -/]*[@-~]/g, "")
+    .replace(/\u001b[@-_]/g, "")
+    .replace(/\r\n?/g, "\n");
+  return Array.from(withoutTerminalSequences.normalize("NFC"))
+    .filter((character) =>
+      character === "\n" || character === "\t" || !/[\p{Cc}\p{Cf}\p{Cs}\p{Co}\p{Cn}]/u.test(character))
+    .slice(0, maximum)
+    .join("")
+    .trim();
+}
+
+function safeInspectableText(value, maximum) {
+  const normalized = safeDisplayText(value, maximum).replace(/\s+/gu, " ").trim();
+  return /[\p{L}\p{N}\p{P}\p{S}]/u.test(normalized) ? normalized : "";
 }
 
 function requireNumber(value, key) {
@@ -1021,13 +1171,17 @@ function requireNumber(value, key) {
 }
 
 function validateRealtimeCapabilities(value) {
-  requireString({ type: "session.ready realtime", ...value }, "provider");
+  requireEnum({ type: "session.ready realtime", ...value }, "provider", ["gemini", "openai", "mock"]);
   requireString({ type: "session.ready realtime", ...value }, "model");
   requireObject({ type: "session.ready realtime", ...value }, "audio");
   const audio = value.audio;
   requireObject({ type: "session.ready realtime audio", ...audio }, "input");
   requireObject({ type: "session.ready realtime audio", ...audio }, "output");
-  requireString({ type: "session.ready realtime audio", ...audio }, "turnDetection");
+  requireEnum(
+    { type: "session.ready realtime audio", ...audio },
+    "turnDetection",
+    ["disabled", "semantic_vad", "server_vad", "provider", "none"],
+  );
   if (typeof audio.input.enabled !== "boolean" || typeof audio.output.enabled !== "boolean") {
     throw new TypeError("Hermes Live session.ready realtime audio capabilities require enabled flags.");
   }
@@ -1047,7 +1201,7 @@ function createSnapshot(connection) {
 }
 
 function approvalRequestId(message) {
-  const approvalId = message?.approval?.approvalId ?? message?.event?.approval_id;
+  const approvalId = message?.approval?.approvalId;
   return typeof approvalId === "string" && approvalId ? `${message.runId}:${approvalId}` : "";
 }
 
@@ -1057,7 +1211,7 @@ function defaultRequestId() {
 }
 
 function encodedMessageSize(data) {
-  if (typeof data === "string") return data.length;
+  if (typeof data === "string") return new TextEncoder().encode(data).byteLength;
   if (typeof data?.size === "number") return data.size;
   if (typeof data?.byteLength === "number") return data.byteLength;
   return 0;
@@ -1144,6 +1298,34 @@ function normalizeCloseReason(value) {
 function positiveInteger(value, fallback) {
   const parsed = Number(value);
   return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function settleConnectionPrerequisite(promise, timeoutMs, signal) {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const finish = (error, value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      signal?.removeEventListener("abort", onAbort);
+      if (error) reject(error);
+      else resolve(value);
+    };
+    const onAbort = () => finish(abortError());
+    const timeout = setTimeout(
+      () => finish(new Error(`Hermes Live gateway URL or token did not resolve within ${timeoutMs}ms.`)),
+      timeoutMs,
+    );
+    if (signal?.aborted) {
+      onAbort();
+      return;
+    }
+    signal?.addEventListener("abort", onAbort, { once: true });
+    Promise.resolve(promise).then(
+      (value) => finish(undefined, value),
+      (error) => finish(toError(error)),
+    );
+  });
 }
 
 function optionalString(value) {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,14 +20,14 @@ Custom browser/mobile/desktop client
 
 ### Client
 
-Voice clients capture microphone audio, encode frames as base64 PCM16, and send JSON messages to `/v1/live`. The gateway returns provider audio, transcript deltas, Hermes run events, approval requests, errors, and logs. The shared browser client provides the connection lifecycle, protocol validation, request IDs, bounded buffering, microphone worklet, and audio playback helpers used by the official Dashboard and bundled demo.
+Voice clients capture microphone audio, encode frames as base64 PCM16, and send JSON messages to `/v1/live`. The gateway returns provider audio, transcript deltas, Hermes run events, approval requests, errors, and logs. The shared browser client provides the connection lifecycle, protocol validation, request IDs, bounded buffering, microphone worklet, and audio playback helpers used by the Hermes Dashboard integration and the bundled demo.
 
 The terminal client is deliberately different: it keeps the same persistent session and control contract but sends and renders text only. Local terminal microphone use remains the responsibility of official Hermes Voice Mode.
 
 Clients may be:
 
 - A Hermes-focused web or mobile client.
-- The official Hermes Dashboard tab.
+- A **Live Voice** integration for Hermes Dashboard.
 - A community web UI integration or the bundled web demo.
 - A native desktop app.
 - The text-control terminal client.
@@ -39,7 +39,7 @@ The plugin owns the Hermes-facing discovery surface:
 - Gateway metadata.
 - `hermes_live_status` tool registration.
 - `/hermes-live` slash command.
-- An official Dashboard **Live Voice** tab.
+- A Hermes Dashboard **Live Voice** tab supplied by this plugin.
 - Dashboard-packaged browser client, microphone worklet, and styles.
 - An authenticated same-origin HTTP/WebSocket proxy that keeps gateway credentials out of browser code.
 - Default local gateway URL.
@@ -62,7 +62,7 @@ The gateway owns:
 
 ### Dashboard Authentication Boundary
 
-The official Dashboard browser never receives `HERMES_LIVE_AUTH_TOKEN`. It authenticates to Hermes' own Dashboard, obtains a host-authorized same-origin WebSocket URL, and connects to the plugin backend. The backend revalidates Dashboard authentication and origin policy, then opens the upstream gateway socket with the installation credential server-side.
+The Dashboard browser never receives `HERMES_LIVE_AUTH_TOKEN`. It authenticates to Hermes' own Dashboard, obtains a host-authorized same-origin WebSocket URL, and connects to the plugin backend. The backend revalidates Dashboard authentication and origin policy, then opens the upstream gateway socket with the installation credential server-side.
 
 Custom/community web UIs should use the same shape: an authenticated same-origin WebSocket proxy or a backend-issued short-lived ticket. A static frontend that embeds the shared gateway bearer is suitable only for trusted local development.
 
@@ -131,7 +131,7 @@ It receives gateway tools:
 - `get_hermes_run_status`
 - `stop_hermes_run`
 
-The realtime provider cannot submit approvals. The gateway keeps the sanitized approval envelopes it has emitted in FIFO order and accepts a human `approval.respond` only when its choice is offered by the queue head. The sanitizer always preserves a fail-closed `deny` choice even if Hermes omits it. Permanent approval additionally requires the emitted envelope to contain an inspectable permission pattern. Bulk approval resolution is rejected in protocol v1.
+The realtime provider cannot submit approvals. The gateway assigns every sanitized envelope a gateway-owned id, keeps envelopes in FIFO order, and accepts a human `approval.respond` only when its request id has not been reused and its run id, approval id, and choice match the queue head. Opaque requests are deny-only; session and permanent policy choices require an inspectable visible pattern. Mutating responses are idempotently cached, and an ambiguous Hermes approval outcome stops the run and closes the session. Bulk approval resolution is rejected in protocol v2.
 
 This preserves the intended chain:
 
@@ -140,6 +140,10 @@ Realtime model = ears, mouth, turn-taking
 Hermes = brain, memory, actions
 Gateway = translator, session manager, safety boundary
 ```
+
+### Current delegation model
+
+In v0.3, `start_hermes_run` is synchronous from the realtime provider's perspective: its tool result returns after the Hermes SSE run reaches a terminal event. The Dashboard and connected clients still receive progress, approvals, and stop controls while that work runs, but the speech model cannot naturally hold a second provider-side conversation or call `get_hermes_run_status` during the outstanding tool call. Provider-authored transcript lines are therefore labeled **Live voice**, not Hermes. A future async run bridge will return the run id immediately and deliver bounded progress/completion notifications independently.
 
 ## Session Identity
 
@@ -172,5 +176,8 @@ The gateway should fail closed:
 - Hermes missing run features: refuse session startup.
 - Invalid client frames: return `session.error`.
 - Provider tool calls without response ids: fail before Hermes side effects.
-- Stream ends without terminal run event: return `run.failed`.
-- Active run on socket close: request Hermes stop.
+- Invalid or oversized provider output: close the provider/client session before forwarding it.
+- Slow client: terminate its WebSocket when bounded outbound buffering is exhausted.
+- Stream ends without a terminal run event: request stop, mark ownership indeterminate, and close the voice session until terminal state can be re-established.
+- Stop request accepted: emit `run.stopping`; retain run ownership until terminal SSE confirmation.
+- Active or still-starting run on socket close: close the realtime provider immediately, capture any late run id, and issue a separately bounded Hermes stop.

--- a/docs/client-protocol.md
+++ b/docs/client-protocol.md
@@ -94,11 +94,29 @@ When any section is not ready, the endpoint returns `503` with that section's `e
 
 ## Client Limits
 
-Client message metadata such as request IDs, profile IDs, user labels, run IDs, MIME types, cancellation reasons, and playback truncation fields is bounded by the protocol before dispatch. Text input and provider tool-call text use `HERMES_LIVE_MAX_TEXT_CHARS`; audio frames use `HERMES_LIVE_MAX_AUDIO_BYTES`.
+Client message metadata such as request IDs, profile IDs, user labels, run IDs, MIME types, cancellation reasons, and playback truncation fields is bounded by the protocol before dispatch. Text input and provider tool-call text use `HERMES_LIVE_MAX_TEXT_CHARS`; audio frames use `HERMES_LIVE_MAX_AUDIO_BYTES`. PCM16 input must declare one integer `rate=` between 8,000 and 192,000 Hz. Resampling validates its target and refuses any calculated output above the 16 MiB allocation ceiling before allocating memory.
+
+The reverse path is bounded too. Provider transcript deltas, provider audio frames, retained Hermes output, usage payloads, raw run events, pre-ready provider events, and per-client WebSocket buffering all have hard ceilings. A provider that violates its negotiated output contract or a client that stops draining data is disconnected rather than allowed to grow process memory without bound.
+
+| Boundary | Default or hard ceiling |
+| --- | --- |
+| Client text | `HERMES_LIVE_MAX_TEXT_CHARS` (20,000; configurable up to 1,000,000) |
+| Decoded client/provider audio frame | `HERMES_LIVE_MAX_AUDIO_BYTES` (2,000,000; configurable up to 5,900,000) |
+| Queued inbound client messages | 256 messages / 8 MiB |
+| Pre-ready provider events | 256 events / 8 MiB |
+| Provider transcript delta | 20,000 characters |
+| Retained Hermes output | 200,000 characters |
+| Public raw run-event payload | 256,000 bytes |
+| Public usage payload | 64,000 bytes |
+| Individual provider tool response | 256,000 bytes; 4 MiB aggregate replay cache |
+| Browser inbound message | 8,000,000 bytes by default |
+| Browser queued playback | five seconds by default |
+
+Limits are protocol safety boundaries, not recommended application payload sizes.
 
 ## Request IDs
 
-Every client message can include an optional `id` string. When that message causes a `session.error`, the gateway echoes it as `requestId` so browser, mobile, and terminal clients can correlate recoverable validation or session-state failures.
+Every client message can include an `id` string. It is required for the mutating `approval.respond` message and optional elsewhere. When a message causes a `session.error`, the gateway echoes it as `requestId` so browser, mobile, and terminal clients can correlate validation or session-state failures.
 
 ```json
 {
@@ -115,7 +133,7 @@ The first message must be `session.start`.
 ```json
 {
   "type": "session.start",
-  "protocolVersion": 1,
+  "protocolVersion": 2,
   "profileId": "default",
   "userLabel": "alice"
 }
@@ -128,7 +146,7 @@ The server replies:
 ```json
 {
   "type": "session.ready",
-  "protocolVersion": 1,
+  "protocolVersion": 2,
   "sessionId": "live_...",
   "model": "gpt-realtime-2.1",
   "hermes": {
@@ -153,7 +171,7 @@ The server replies:
 }
 ```
 
-The current protocol version is `1`. The gateway still accepts legacy clients that omit `protocolVersion`, but rejects an explicit unsupported version before opening a provider session. New clients should send the version and use the negotiated audio contract in `session.ready`; they must not assume every deployment uses PCM16.
+The current protocol version is `2`. Every client must send `protocolVersion: 2`; the gateway rejects missing or unsupported versions before opening a provider session. Protocol v2 is a breaking negotiation change: it makes approval correlation explicit, removes raw provider envelopes, and adds `run.stopping`. The `/v1/live` URL is retained as the endpoint path; it is not the protocol-version negotiation field. Clients must use the negotiated audio contract in `session.ready` rather than assume every deployment uses PCM16.
 
 ## Audio Input
 
@@ -188,7 +206,7 @@ Cancel the current realtime provider response before sending an interruption or 
 }
 ```
 
-This is a best-effort provider cancellation. OpenAI Realtime maps it to `response.cancel`. Gemini Live handles barge-in through live audio activity, so the current Gemini adapter accepts this message without sending a dedicated provider cancel event.
+This is a best-effort provider cancellation. OpenAI Realtime maps it to `response.cancel`, waits for the terminal response event before creating a queued follow-up response, and closes the provider session if cancellation is not acknowledged within a bounded deadline. Gemini Live handles barge-in through live audio activity, so the current Gemini adapter accepts this message without sending a dedicated provider cancel event.
 
 For OpenAI WebSocket playback, include truncation metadata when the user interrupts audio that has already started playing:
 
@@ -257,19 +275,6 @@ Provider-managed speech start:
 
 OpenAI VAD can emit this when the provider detects user speech. Voice clients should stop local assistant playback immediately and send `response.cancel`. If queued assistant audio has provider item metadata, include `truncate` so the gateway can remove unheard audio from the provider conversation.
 
-Raw realtime provider message:
-
-```json
-{
-  "type": "realtime.message",
-  "message": {
-    "type": "response.done"
-  }
-}
-```
-
-Clients usually do not need to show raw provider messages. They are useful for debugging and provider-specific telemetry.
-
 Provider-neutral response lifecycle:
 
 ```json
@@ -279,7 +284,7 @@ Provider-neutral response lifecycle:
 { "type": "response.failed", "responseId": "resp_...", "error": "Realtime response failed." }
 ```
 
-`responseId` is optional because not every provider exposes one. Clients should use these normalized events for UI state and completion instead of parsing `realtime.message` for provider-specific OpenAI or Gemini shapes.
+`responseId` is optional because not every provider exposes one. Raw provider payloads are intentionally not forwarded: audio and lifecycle data are emitted only through these normalized messages so audio bytes are not duplicated and provider internals do not leak into clients.
 
 Hermes run started:
 
@@ -305,7 +310,7 @@ Hermes run event (safe summary by default):
 }
 ```
 
-`HERMES_LIVE_RUN_EVENT_DETAIL=summary` forwards only allowlisted scalar metadata. `none` suppresses `run.event` messages. `raw` forwards upstream Hermes event payloads and should be used only with trusted developer clients because those events can contain tool arguments, output, paths, or error detail.
+`HERMES_LIVE_RUN_EVENT_DETAIL=summary` forwards only allowlisted scalar metadata. `none` suppresses `run.event` messages. `raw` forwards upstream Hermes event payloads up to a 256,000-byte event-payload ceiling and replaces larger events with a bounded summary carrying `truncated: true`. Raw mode should still be used only with trusted developer clients because events below that ceiling can contain tool arguments, output, paths, or error detail.
 
 Hermes completion:
 
@@ -361,16 +366,18 @@ When Hermes asks for approval, the gateway emits:
 }
 ```
 
-Hermes redacts credentials from approval commands before they enter its Runs API event stream. Hermes Live then bounds and projects only the fields needed for an informed decision. The gateway always adds `deny` when Hermes omits it so a human can fail closed. When the event lacks a command and description, other `choices` are restricted to `once`; clients must not invent persistent approval options for an opaque request.
+Hermes redacts credentials from approval commands before they enter its Runs API event stream. Hermes Live then projects only exact, bounded display values. If a supplied command, description, choice list, or permission pattern would need transformation, truncation, or control-character removal, the request is narrowed rather than silently repaired. A request with incomplete display context is deny-only. An informed request without an exact inspectable permission pattern can offer only `once` or `deny`. `session` and `always` require a visible exact `patternKey` or `patternKeys`, and clients must never invent wider choices.
 
-The gateway also retains these sanitized envelopes server-side in FIFO order. It accepts a response only for the active run's queue head and only when `choice` was offered in that envelope. `always` additionally requires `allowPermanent: true` and a non-empty `patternKey` or `patternKeys`. Protocol v1 rejects `resolveAll: true`; clients must answer each request explicitly.
+The gateway assigns every envelope an opaque gateway-owned `approvalId`, correlates it to Hermes' bounded upstream approval id, and retains envelopes server-side in FIFO order. It accepts a response only when the exact `runId` and `approvalId` match the active queue head and `choice` was offered in that envelope. `always` additionally requires `allowPermanent: true`. Protocol v2 rejects `resolveAll: true`; clients must answer each request explicitly. Approval request IDs are cached in a bounded idempotency window: an exact duplicate replays its prior acknowledgement without another Hermes mutation, while request-ID reuse with different data is rejected. Duplicate or mutated upstream approval identities fail closed. If Hermes' approval POST outcome cannot be confirmed, the gateway stops the run and closes the session rather than risk applying a retry to the next action.
 
 The client responds:
 
 ```json
 {
   "type": "approval.respond",
+  "id": "approval_response_123",
   "runId": "run_...",
+  "approvalId": "approval_...",
   "choice": "once"
 }
 ```
@@ -387,7 +394,9 @@ After the gateway submits the decision to Hermes, it emits:
 ```json
 {
   "type": "approval.responded",
+  "requestId": "approval_response_123",
   "runId": "run_...",
+  "approvalId": "approval_...",
   "choice": "once",
   "resolved": 1
 }
@@ -404,15 +413,17 @@ Stop the active run:
 }
 ```
 
-The server emits:
+The server first confirms that a stop was requested without claiming the run is terminal:
 
 ```json
 {
-  "type": "run.stopped",
+  "type": "run.stopping",
   "runId": "run_...",
   "status": "stopping"
 }
 ```
+
+Only Hermes `run.cancelled` emits `run.stopped`. Normal and failed terminal states emit `run.completed` and `run.failed`. Clients must keep the run in a stopping state until one of those terminal messages arrives.
 
 ## Logs
 
@@ -438,3 +449,5 @@ The gateway can emit operational logs to help clients explain non-terminal event
 ```
 
 Closing the WebSocket also closes the provider session and asks Hermes to stop any active run.
+
+For an orderly client shutdown, send `session.close` and wait for the server's WebSocket close instead of immediately starting a client close handshake. Code `1000` confirms gateway cleanup completed. `session_shutdown_unconfirmed` followed by code `1011`, or a client-side shutdown timeout, means cleanup could not be confirmed and the user must verify any active task directly in Hermes.

--- a/docs/live-provider-testing.md
+++ b/docs/live-provider-testing.md
@@ -152,7 +152,7 @@ Expected evidence:
 - OpenAI interruptions include `conversation.item.truncate` when the client has audio item metadata and playback duration, including `0` ms for queued/unheard audio.
 - With OpenAI VAD enabled, provider speech-start events reach the client as `input.speech_started`, and the client cancels provider output while stopping/truncating queued assistant playback.
 - Approval requests render decision buttons.
-- Stop sends `run.stop` and the gateway forwards Hermes cancellation.
+- Stop sends `run.stop`; an accepted request emits `run.stopping`, and the client remains in that state until Hermes confirms `run.stopped`, `run.completed`, or `run.failed`.
 
 ## Step 5: Test Negative Cases
 

--- a/docs/local-setup.md
+++ b/docs/local-setup.md
@@ -27,6 +27,8 @@ Hermes JSON requests time out after 30 seconds by default. Set `HERMES_LIVE_HERM
 
 Realtime provider sessions must report ready within 15 seconds by default. Set `HERMES_LIVE_PROVIDER_READY_TIMEOUT_MS` if your provider or network needs a longer startup bound.
 
+The one-shot `hermes-live client` command must complete both its WebSocket upgrade and protocol `session.ready` handshake within 10 seconds by default. Set `HERMES_LIVE_CLIENT_READY_TIMEOUT_MS` only when a slower trusted network requires it.
+
 Text inputs and provider tool-call messages are limited to 20,000 characters by default. Set `HERMES_LIVE_MAX_TEXT_CHARS` if you need a different bound.
 
 The gateway uses server-owned Hermes identity by default: `HERMES_LIVE_PROFILE_ID=default` and `HERMES_LIVE_USER_LABEL=voice`. Client-supplied `profileId` and `userLabel` values are ignored unless `HERMES_LIVE_TRUST_CLIENT_IDENTITY=true`. Only enable that option when every client is trusted to select its own Hermes memory scope.
@@ -38,7 +40,7 @@ The gateway accepts up to eight concurrent WebSocket sessions by default. Set `H
 ## 2. Install Gateway Dependencies
 
 ```sh
-npm install
+npm ci
 ```
 
 ## 3. Choose a Provider
@@ -82,7 +84,7 @@ Both commands report gateway, Hermes, and realtime provider readiness. A `503` r
 
 If you bind the gateway to `0.0.0.0`, set a strong `HERMES_LIVE_AUTH_TOKEN`; otherwise startup will fail unless you explicitly opt out with `HERMES_LIVE_ALLOW_UNAUTHENTICATED=true` for an isolated trusted network.
 
-## 5. Open The Official Dashboard
+## 5. Open Hermes Dashboard
 
 Install and enable the plugin, start the companion gateway, then start or restart Hermes Dashboard:
 

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -8,7 +8,7 @@ The plugin manifest version is kept identical to the npm package version and ver
 
 The plugin and gateway have different jobs:
 
-- The Hermes plugin gives Hermes installations a discoverable integration surface, status tool, slash command, and official Dashboard tab.
+- The Hermes plugin gives Hermes installations a discoverable integration surface, status tool, slash command, and Dashboard tab.
 - The gateway runtime owns WebSockets, audio frames, realtime provider sessions, client auth, and the browser demo.
 - Hermes remains responsible for memory, tools, skills, MCP, approvals, terminal/file access, and long-running work.
 
@@ -83,7 +83,7 @@ The `ready` argument includes the authenticated `/ready` probe when `HERMES_LIVE
 Run the gateway from a GitHub clone:
 
 ```sh
-npm install
+npm ci
 npm run build
 node dist/cli.js plugin install --symlink
 hermes plugins enable hermes-live

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,10 +8,10 @@ The roadmap favors a small, trustworthy bridge over a broad voice platform.
 
 - Keep Gemini Live and OpenAI Realtime adapters aligned with their documented GA event shapes.
 - Make installation, provider verification, and failure messages obvious.
-- Preserve the four-tool boundary between realtime providers and Hermes.
+- Preserve the three-tool boundary between realtime providers and Hermes.
 - Keep credentials and Hermes session keys server-side.
 - Improve deterministic coverage with captured provider fixtures.
-- Keep the official Dashboard, shared browser client, bundled demo, and terminal control surface aligned on protocol v1.
+- Keep the Dashboard integration, shared browser client, bundled demo, and terminal control surface aligned on protocol v2.
 - Collect installation, latency, interruption, and long-session evidence from real users.
 
 ## Next: excellent voice-agent experience

--- a/docs/security.md
+++ b/docs/security.md
@@ -29,7 +29,7 @@ When `HERMES_LIVE_HOST` is network-accessible, `hermes-live` refuses to start wi
 
 Use `Authorization: Bearer <token>` for HTTP endpoints and server-side clients. Query-token auth is accepted only for direct browser WebSocket clients that cannot set upgrade headers; treat the resulting URL as secret and prevent it from entering logs, analytics, referrers, screenshots, or support output.
 
-For production browser clients, use an authenticated same-origin WebSocket proxy or a backend-issued short-lived ticket. The official Hermes Dashboard plugin implements the proxy pattern: Hermes authenticates the browser, the plugin backend revalidates the Dashboard WebSocket request, and only that backend applies `HERMES_LIVE_AUTH_TOKEN` to the upstream gateway connection. The browser never receives the shared bearer or upstream gateway URL.
+For production browser clients, use an authenticated same-origin WebSocket proxy or a backend-issued short-lived ticket. The Hermes Dashboard integration implements the proxy pattern: Hermes authenticates the browser, the plugin backend revalidates the Dashboard WebSocket request, and only that backend applies `HERMES_LIVE_AUTH_TOKEN` to the upstream gateway connection. The browser never receives the shared bearer or upstream gateway URL.
 
 The shared browser client accepts `webSocketUrlProvider` so community UIs can request a fresh host-authorized URL at connection time. The Hermes Live gateway does not currently mint per-user tickets or turn its shared bearer into multi-tenant identity.
 
@@ -59,15 +59,21 @@ Use `wss://` for non-local clients. Terminate TLS at a trusted reverse proxy and
 
 ## Approvals
 
-Approval decisions should be rendered clearly in the client. The gateway only forwards choices; it does not decide whether a dangerous action should be approved.
+Approval decisions should be rendered clearly in the client. The gateway does not decide whether a dangerous action should be approved, but it deliberately narrows what a client is allowed to approve.
 
-Run-scoped actions are limited to the active Hermes run for the current voice session. Client messages and realtime provider tool calls cannot stop or inspect arbitrary Hermes run IDs through the gateway. The realtime provider has no approval-submission tool; human approval responses must match the gateway's sanitized FIFO queue, and non-displayable permission patterns cannot enable permanent approval.
+Run-scoped actions are limited to the active Hermes run for the current voice session. Client messages and realtime provider tool calls cannot stop or inspect arbitrary Hermes run IDs through the gateway. The realtime provider has no approval-submission tool.
+
+The gateway projects only exact, bounded approval display values. It never truncates or strips unsafe characters and then asks the user to approve the altered text. Opaque or incomplete requests are deny-only. `once` is available only when the user can see an exact command or description. `session` and `always` require an exact inspectable permission pattern, and interactive clients require a second confirmation before `always`.
+
+Every approval envelope receives a gateway-owned ID correlated to a bounded upstream Hermes approval identity. Responses must match the active run, exact queue-head approval ID, exact offered choice, and a previously unused client request ID. Exact retries are acknowledged from a bounded idempotency cache; reuse with changed data, duplicate upstream identities, widened choices, out-of-order responses, and bulk resolution fail closed.
+
+Mutating Hermes calls are treated as outcome-sensitive. If the gateway cannot determine whether an approval, run start, or stop took effect, it contains the owned run and closes the session rather than retrying against uncertain state. Graceful client disconnect waits for provider cleanup and active-run stop confirmation. If complete shutdown cannot be confirmed, the gateway emits `session_shutdown_unconfirmed`, closes with WebSocket code `1011`, and tells the operator to verify task state in Hermes.
 
 ## Abuse Handling
 
 The gateway sends a hashed session key as `OpenAI-Safety-Identifier` when using OpenAI Realtime. This is privacy-preserving and stable enough for provider-side abuse monitoring.
 
-Raw client WebSocket payload size is capped from `HERMES_LIVE_MAX_AUDIO_BYTES` and `HERMES_LIVE_MAX_TEXT_CHARS`, so oversized frames are closed before JSON parsing.
+Raw client WebSocket payload size is capped from `HERMES_LIVE_MAX_AUDIO_BYTES` and `HERMES_LIVE_MAX_TEXT_CHARS`, so oversized frames are closed before JSON parsing. Provider events, provider audio/transcripts, client/provider queues, gateway output buffering, Hermes JSON/SSE bodies, public run events, usage data, and CLI output have independent hard ceilings as well.
 
 Client metadata fields are also bounded before dispatch, including profile IDs, user labels, run IDs, reasons, MIME types, and playback truncation values.
 

--- a/docs/ui-integration.md
+++ b/docs/ui-integration.md
@@ -1,19 +1,19 @@
 # UI Integration
 
-Hermes Live Voice is a gateway and client protocol, not one fixed application. The official Hermes Dashboard is the recommended end-user surface; the shared browser client is the integration surface for community and custom UIs; the terminal client is the remote/headless control surface.
+Hermes Live Voice is a gateway and client protocol, not one fixed application. The Live Voice plugin makes Hermes Dashboard the recommended end-user surface; the shared browser client is the integration surface for community and custom UIs; the terminal client is the remote/headless control surface. This describes compatibility with Hermes Dashboard, not an endorsement by the Hermes maintainers.
 
 ## Surface Matrix
 
 | Surface | Current support | Intended use |
 | --- | --- | --- |
-| Official Hermes Dashboard | First-class | Browser voice, text fallback, transcript, task activity, interruption, run stop, and approvals. |
+| Hermes Dashboard + Live Voice plugin | First-class | Browser voice, text fallback, transcript, task activity, interruption, run stop, and approvals. |
 | Bundled browser demo | First-class development tool | Local gateway setup and protocol troubleshooting. |
 | `hermes-live-voice/browser` | First-class integration API | Custom/community browser, Electron, mobile-web, React, Vue, Svelte, or vanilla clients. |
 | `hermes-live terminal` | First-class text control | SSH, headless hosts, remote operations, transcripts, task events, approvals, interruption, and stop. |
 | Hermes Ctrl+B Voice Mode | Official Hermes feature | The shortest local terminal microphone path; not replaced by this project. |
 | Generic OpenAI-compatible chat UI | Hermes chat only | Does not implement Hermes Live realtime audio, lifecycle, task, or approval events by itself. |
 
-## Official Hermes Dashboard
+## Hermes Dashboard
 
 Install and enable the plugin, run the companion gateway, and restart the Dashboard:
 
@@ -79,7 +79,8 @@ client.subscribe(renderSnapshot);
 client.on("transcript.delta", renderTranscript);
 client.on("run.event", renderTaskEvent);
 client.on("approval.request", renderApproval);
-client.on("audio.output", (message) => audio.play(message));
+client.on("audio.output", (message) => void audio.play(message).catch(renderError));
+client.on("input.speech_started", () => audio.interrupt("provider detected user speech"));
 
 await client.connect();
 ```
@@ -89,7 +90,7 @@ The host endpoint should return either:
 1. a same-origin authenticated WebSocket proxy URL; or
 2. a short-lived, single-purpose WebSocket URL issued by the host backend.
 
-The gateway accepts a static bearer for trusted direct clients, but it does not mint per-user tickets. Do not ship `HERMES_LIVE_AUTH_TOKEN` in a public JavaScript bundle, local storage, or a long-lived browser URL. Copy the official Dashboard proxy pattern when building a production community integration.
+The gateway accepts a static bearer for trusted direct clients, but it does not mint per-user tickets. Do not ship `HERMES_LIVE_AUTH_TOKEN` in a public JavaScript bundle, local storage, or a long-lived browser URL. Copy the Hermes Dashboard integration's proxy pattern when building a production community integration.
 
 ### Required UI Event Mapping
 
@@ -102,14 +103,15 @@ A complete UI should handle at least:
 | `audio.output` | Queue PCM playback through `HermesLiveAudio`. |
 | `input.speech_started` | Stop local assistant playback and cancel/truncate provider output. |
 | `response.started/completed/cancelled/failed` | Represent provider speech lifecycle separately from Hermes work. |
-| `run.started/event/completed/failed/stopped` | Show task progress, allow stop, and render sanitized final output. |
+| `run.started/event/completed/failed/stopping/stopped` | Show task progress, keep stop controls pending through `stopping`, and render sanitized final output only at a terminal event. |
 | `approval.request/responded` | Render explicit choices and lock the decision while it is submitted. |
 | `session.error`, client `error`, and `close` | Show actionable connection state without leaking internal credentials or upstream error details. |
 
 Speech interruption and Hermes task cancellation are different actions:
 
-- `client.cancelResponse(...)` stops the current provider response and local playback.
-- `client.stopRun(...)` stops the active Hermes run while leaving the voice session connected.
+- `audio.interrupt(...)` clears queued local playback and sends correlated provider cancellation/truncation.
+- `client.cancelResponse(...)` sends only the protocol cancellation request; a custom audio player must clear its own queue.
+- `client.stopRun(...)` requests a stop for the active Hermes run while leaving the voice session connected. Keep the UI in `stopping` until `run.stopped`, `run.completed`, or `run.failed` confirms a terminal state.
 
 Do not map both actions to one ambiguous stop button.
 
@@ -122,9 +124,17 @@ Treat approvals as high-consequence controls:
 - show permanent approval only when `allowPermanent` is true and `patternKey` or `patternKeys` is present;
 - require a second confirmation before submitting `always`;
 - preserve the emitted FIFO order and make only the oldest pending approval actionable;
-- remove only the number of entries reported by `approval.responded.resolved`;
+- remove only the exact `runId` + `approvalId` acknowledged by `approval.responded` (protocol v2 always confirms `resolved: 1`);
 - disable duplicate decisions while a response is in flight;
 - keep the approval attached to the active run shown in the UI.
+
+Submit the exact gateway-owned identity; do not derive it from the upstream event:
+
+```js
+client.respondToApproval(choice, request.runId, {
+  approvalId: request.approval.approvalId,
+});
+```
 
 ### Audio And Browser Requirements
 
@@ -133,6 +143,7 @@ Treat approvals as high-consequence controls:
 - Start `AudioContext` and microphone capture from a user gesture.
 - Respect `session.ready.realtime.audio`; mock mode and some future providers may disable input or output.
 - Bound queued playback and clear it immediately on interruption or disconnect.
+- Await `client.disconnect()`. A clean resolution means the gateway confirmed session cleanup; rejection or `session_shutdown_unconfirmed` means the user must verify any active task in Hermes.
 - Test keyboard focus, screen-reader labels, reduced motion, narrow layouts, and permission denial.
 
 ## Community UI Compatibility
@@ -170,7 +181,7 @@ The terminal shows transcript, provider response state, Hermes task progress, ap
 Before calling a UI integration ready:
 
 1. Verify authenticated status and WebSocket connection without exposing a bearer in browser state or logs.
-2. Confirm protocol v1 and render the provider/model/audio capabilities from `session.ready`.
+2. Confirm protocol v2 and render the provider/model/audio capabilities from `session.ready`.
 3. Send text and complete a real Hermes run.
 4. Test microphone permission granted and denied.
 5. Verify provider audio playback and barge-in.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hermes-live-voice",
   "version": "0.3.0",
-  "description": "The realtime voice layer for Hermes Agent with an official Dashboard UI, browser client, interruptible speech, tools, memory, and approvals.",
+  "description": "Give Hermes Agent a voice with realtime conversation, a first-class Dashboard integration, browser and terminal clients, tools, memory, and approvals.",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/plugins/hermes-live/README.md
+++ b/plugins/hermes-live/README.md
@@ -7,14 +7,16 @@ It registers:
 - the `hermes_live_status` tool, which reports the configured companion gateway and can probe its health, capabilities, and readiness;
 - the `/hermes-live` command for a concise gateway status report;
 - the `/hermes-live ready` command for the authenticated readiness probe;
-- an official Hermes Dashboard **Live Voice** tab;
+- a Hermes Dashboard **Live Voice** integration;
 - an authenticated same-origin Dashboard proxy that keeps gateway credentials out of browser code.
 
-The plugin does not run the audio gateway inside Hermes. Start the Node.js companion runtime separately:
+The plugin does not run the audio gateway inside Hermes. From a built repository checkout, start the Node.js companion runtime separately:
 
 ```sh
-hermes-live serve
+node dist/cli.js serve
 ```
+
+After installing the npm package, the equivalent command is `hermes-live serve`.
 
 Set `HERMES_LIVE_URL` when the gateway is not at `http://127.0.0.1:8788`. Set `HERMES_LIVE_AUTH_TOKEN` in the Hermes process when the gateway requires authentication. The status tool reports whether a token is configured but never returns its value.
 

--- a/plugins/hermes-live/after-install.md
+++ b/plugins/hermes-live/after-install.md
@@ -32,13 +32,13 @@ hermes dashboard
 
 Open the Dashboard and choose **Live Voice**. The page reports gateway readiness before you connect. Microphone access works on `localhost` or another browser secure context.
 
-The Dashboard never receives the gateway credential. It opens an authenticated, same-origin WebSocket to the plugin backend; the backend connects to the companion gateway and applies the credential server-side.
+The Dashboard browser never receives the gateway credential or upstream gateway URL. It opens an authenticated, same-origin WebSocket to the plugin backend; the backend connects to the companion gateway and applies the credential server-side.
 
 ## 3. Know the controls
 
 - **Interrupt speech** cancels the current spoken response while leaving an active Hermes task running.
-- **Stop Hermes task** stops the active tool-using run while leaving the voice session connected.
-- **Disconnect** closes the live session. Disconnecting, refreshing, or navigating away also stops an active Hermes task.
+- **Stop Hermes task** requests cancellation of the active tool-using run while leaving the voice session connected. Keep watching until Hermes reports a terminal state.
+- **Disconnect** requests cleanup of the provider session and any active Hermes task, then waits for gateway confirmation. If confirmation fails or the page is closed before it arrives, verify the task directly in Hermes.
 - Permanent approval choices require a second confirmation and are shown only when Hermes provides an inspectable permission pattern.
 
 For a terminal-only conversation on the same machine, Hermes' built-in Voice Mode remains the shortest path. Hermes Live Voice is the realtime gateway and client surface for the Dashboard, browsers, mobile or desktop apps, and other custom clients.

--- a/plugins/hermes-live/dashboard/dist/hermes-live-client.js
+++ b/plugins/hermes-live/dashboard/dist/hermes-live-client.js
@@ -1,11 +1,12 @@
 const DEFAULT_CONNECT_TIMEOUT_MS = 15_000;
+const DEFAULT_DISCONNECT_TIMEOUT_MS = 12_000;
 const DEFAULT_MAX_BUFFERED_AMOUNT_BYTES = 1_000_000;
 const DEFAULT_MAX_INBOUND_MESSAGE_BYTES = 8_000_000;
-const DEFAULT_MAX_QUEUED_AUDIO_MS = 30_000;
+const DEFAULT_MAX_QUEUED_AUDIO_MS = 5_000;
 const DEFAULT_SAMPLE_RATE = 24_000;
 const MAX_PENDING_APPROVALS = 128;
 const OPEN = 1;
-export const HERMES_LIVE_PROTOCOL_VERSION = 1;
+export const HERMES_LIVE_PROTOCOL_VERSION = 2;
 
 const KNOWN_SERVER_MESSAGE_TYPES = new Set([
   "session.ready",
@@ -17,13 +18,13 @@ const KNOWN_SERVER_MESSAGE_TYPES = new Set([
   "response.completed",
   "response.cancelled",
   "response.failed",
-  "realtime.message",
   "run.started",
   "run.event",
   "approval.request",
   "approval.responded",
   "run.completed",
   "run.failed",
+  "run.stopping",
   "run.stopped",
   "log",
 ]);
@@ -78,6 +79,7 @@ export class HermesLiveClient {
     this.profileId = optionalString(options.profileId);
     this.userLabel = optionalString(options.userLabel);
     this.connectTimeoutMs = positiveInteger(options.connectTimeoutMs, DEFAULT_CONNECT_TIMEOUT_MS);
+    this.disconnectTimeoutMs = positiveInteger(options.disconnectTimeoutMs, DEFAULT_DISCONNECT_TIMEOUT_MS);
     this.maxBufferedAmountBytes = positiveInteger(
       options.maxBufferedAmountBytes,
       DEFAULT_MAX_BUFFERED_AMOUNT_BYTES,
@@ -136,7 +138,19 @@ export class HermesLiveClient {
   }
 
   async openConnection(generation, signal) {
-    const socketUrl = await this.resolveSocketUrl();
+    const startedAt = Date.now();
+    let socketUrl;
+    try {
+      socketUrl = await settleConnectionPrerequisite(
+        this.resolveSocketUrl(),
+        this.connectTimeoutMs,
+        signal,
+      );
+    } catch (error) {
+      const normalized = toError(error);
+      if (normalized.name !== "AbortError") this.emitError(normalized, "url_resolution_failed");
+      throw normalized;
+    }
     if (generation !== this.generation) throw abortError();
     if (signal?.aborted) throw abortError();
 
@@ -154,6 +168,7 @@ export class HermesLiveClient {
     return await new Promise((resolve, reject) => {
       let settled = false;
       let ready = false;
+      let fatalServerErrorReceived = false;
       const finish = (error, session) => {
         if (settled) return;
         settled = true;
@@ -167,11 +182,12 @@ export class HermesLiveClient {
         this.emitError(normalized, code);
         finish(normalized);
       };
+      const remainingTimeoutMs = Math.max(1, this.connectTimeoutMs - (Date.now() - startedAt));
       const timeout = setTimeout(() => {
         const error = new Error(`Hermes Live session did not become ready within ${this.connectTimeoutMs}ms.`);
         failStartup(error, "connect_timeout");
         closeSocket(socket, 4000, "session ready timeout");
-      }, this.connectTimeoutMs);
+      }, remainingTimeoutMs);
       const onAbort = () => {
         const error = abortError();
         finish(error);
@@ -212,6 +228,7 @@ export class HermesLiveClient {
               finish(error);
               closeSocket(socket, 1008, "session startup rejected");
             } else if (message.type === "session.error" && message.recoverable === false) {
+              fatalServerErrorReceived = true;
               this.setState("failed");
               closeSocket(socket, 1011, "nonrecoverable session error");
             }
@@ -253,7 +270,7 @@ export class HermesLiveClient {
         this.emitter.emit("close", closeEvent);
         if (!ready) {
           finish(new Error(`Hermes Live connection closed before session readiness (${closeEvent.code}).`));
-        } else if (!closeEvent.clean && closeEvent.code !== 1000) {
+        } else if (!closeEvent.clean && closeEvent.code !== 1000 && !fatalServerErrorReceived) {
           this.emitError(new Error("Hermes Live connection was lost."), "connection_lost", closeEvent);
         }
       });
@@ -286,22 +303,36 @@ export class HermesLiveClient {
       return;
     }
     this.setState("closing");
+    this.updateSnapshot({ lastError: undefined });
+    let requestedProtocolClose = false;
     if (socket.readyState === OPEN) {
       try {
         this.sendRaw({ type: "session.close", id: this.createRequestId() });
+        requestedProtocolClose = true;
       } catch {
-        // The close below is authoritative.
+        // Fall back to a local WebSocket close below.
       }
     }
     let closeObserved = false;
+    let closeTimedOut = false;
+    let observedClose;
     await new Promise((resolve) => {
-      const timeout = setTimeout(resolve, 1_000);
-      socket.addEventListener("close", () => {
+      const timeout = setTimeout(() => {
+        closeTimedOut = true;
+        closeSocket(socket, 4000, "gateway close confirmation timeout");
+        resolve();
+      }, requestedProtocolClose ? this.disconnectTimeoutMs : 1_000);
+      socket.addEventListener("close", (event) => {
         closeObserved = true;
+        observedClose = {
+          code: Number(event.code ?? 1006),
+          reason: String(event.reason ?? ""),
+          clean: Boolean(event.wasClean),
+        };
         clearTimeout(timeout);
         resolve();
       }, { once: true });
-      closeSocket(socket, 1000, reason);
+      if (!requestedProtocolClose) closeSocket(socket, 1000, reason);
     });
     if (!closeObserved && this.isCurrentSocket(socket, this.generation)) {
       ++this.generation;
@@ -320,6 +351,16 @@ export class HermesLiveClient {
         reason: "disconnect timed out",
         clean: false,
       });
+    }
+    if (closeTimedOut) {
+      throw new Error("The gateway did not confirm session shutdown; verify any active Hermes task before reconnecting.");
+    }
+    await this.messageChain.catch(() => undefined);
+    if (observedClose && (observedClose.code !== 1000 || !observedClose.clean)) {
+      throw new Error(
+        this.snapshot.lastError?.error?.message ||
+        "The gateway closed abnormally and did not confirm complete session shutdown. Verify any active Hermes task.",
+      );
     }
   }
 
@@ -371,6 +412,9 @@ export class HermesLiveClient {
 
   respondToApproval(choice, runId = this.activeRunId, options = {}) {
     if (!runId) throw new Error("An approval response requires an active Hermes run ID.");
+    if (typeof options.approvalId !== "string" || !options.approvalId) {
+      throw new Error("An approval response requires the exact pending approval ID.");
+    }
     if (!["once", "session", "always", "deny"].includes(choice)) {
       throw new TypeError(`Unsupported Hermes approval choice: ${choice}`);
     }
@@ -379,8 +423,8 @@ export class HermesLiveClient {
       type: "approval.respond",
       id,
       runId,
+      approvalId: options.approvalId,
       choice,
-      ...(options.resolveAll === undefined ? {} : { resolveAll: Boolean(options.resolveAll) }),
     });
     return id;
   }
@@ -419,7 +463,7 @@ export class HermesLiveClient {
     } else {
       throw new TypeError("Hermes Live returned an unsupported WebSocket message type.");
     }
-    if (text.length > this.maxInboundMessageBytes) {
+    if (encodedMessageSize(text) > this.maxInboundMessageBytes) {
       throw new Error("Hermes Live server message exceeded the configured client limit.");
     }
     return validateServerMessage(JSON.parse(text));
@@ -458,13 +502,12 @@ export class HermesLiveClient {
         }
         break;
       case "approval.responded": {
-        let remaining = message.resolved === undefined ? 1 : message.resolved;
         this.updateSnapshot({
-          pendingApprovals: this.snapshot.pendingApprovals.filter((entry) => {
-            if (entry.runId !== message.runId || remaining <= 0) return true;
-            remaining -= 1;
-            return false;
-          }),
+          pendingApprovals: this.snapshot.pendingApprovals.filter(
+            (entry) =>
+              entry.runId !== message.runId ||
+              entry.approval.approvalId !== message.approvalId,
+          ),
         });
         break;
       }
@@ -486,6 +529,9 @@ export class HermesLiveClient {
         });
         break;
       }
+      case "run.stopping":
+        this.updateSnapshot({ run: { state: "stopping", runId: message.runId } });
+        break;
       case "session.error":
         if (message.requestId && message.requestId === this.pendingStopRequestId) {
           this.pendingStopRequestId = "";
@@ -949,11 +995,11 @@ export function validateServerMessage(value) {
       requireString(message, "mimeType");
       break;
     case "transcript.delta":
-      requireString(message, "speaker");
+      requireEnum(message, "speaker", ["user", "assistant", "system"]);
       requireString(message, "text", true);
       break;
     case "input.speech_started":
-      requireString(message, "provider");
+      requireEnum(message, "provider", ["openai"]);
       break;
     case "response.started":
     case "response.completed":
@@ -974,12 +1020,15 @@ export function validateServerMessage(value) {
       requireString(message, "runId");
       requireObject(message, "event");
       requireObject(message, "approval");
+      message.approval = normalizeApprovalDetails(message.approval);
       break;
     case "approval.responded":
+      requireString(message, "requestId");
       requireString(message, "runId");
-      requireString(message, "choice");
-      if (message.resolved !== undefined && (!Number.isInteger(message.resolved) || message.resolved < 0)) {
-        throw new TypeError("Hermes Live approval.responded message requires a non-negative integer resolved count.");
+      requireString(message, "approvalId");
+      requireEnum(message, "choice", ["once", "session", "always", "deny"]);
+      if (message.resolved !== 1) {
+        throw new TypeError("Hermes Live approval.responded message must confirm exactly one resolved approval.");
       }
       break;
     case "run.completed":
@@ -990,12 +1039,16 @@ export function validateServerMessage(value) {
       requireString(message, "runId");
       requireString(message, "error");
       break;
+    case "run.stopping":
+      requireString(message, "runId");
+      requireString(message, "status");
+      break;
     case "run.stopped":
       requireString(message, "runId");
       requireString(message, "status");
       break;
     case "log":
-      requireString(message, "level");
+      requireEnum(message, "level", ["debug", "info", "warn", "error"]);
       requireString(message, "message", true);
       break;
   }
@@ -1008,10 +1061,107 @@ function requireString(value, key, allowEmpty = false) {
   }
 }
 
+function requireEnum(value, key, allowed) {
+  requireString(value, key);
+  if (!allowed.includes(value[key])) {
+    throw new TypeError(`Hermes Live ${value.type} message contains an unsupported ${key}.`);
+  }
+}
+
 function requireObject(value, key) {
   if (!value[key] || typeof value[key] !== "object" || Array.isArray(value[key])) {
     throw new TypeError(`Hermes Live ${value.type} message requires ${key}.`);
   }
+}
+
+function normalizeApprovalDetails(value) {
+  const rawApprovalId = typeof value.approvalId === "string" ? value.approvalId : "";
+  const approvalId = safeInspectableText(rawApprovalId, 256);
+  if (!approvalId || approvalId !== rawApprovalId) {
+    throw new TypeError("Hermes Live approval.request requires a safe gateway approvalId.");
+  }
+  const commandProjection = exactApprovalDisplayText(value.command, 4_000);
+  const descriptionProjection = exactApprovalDisplayText(value.description, 2_000);
+  const command = commandProjection.value;
+  const description = descriptionProjection.value;
+  const displayComplete = commandProjection.exact && descriptionProjection.exact && Boolean(command || description);
+  const patterns = exactApprovalPatterns(value);
+  const inspectablePatterns = displayComplete && patterns.exact ? patterns.values : [];
+  const hasInspectablePermanentPattern = displayComplete && patterns.exact && inspectablePatterns.length > 0;
+  const allowedChoices = ["once", "session", "always", "deny"];
+  const suppliedChoices = Array.isArray(value.choices) &&
+      value.choices.length > 0 &&
+      value.choices.every((choice) => typeof choice === "string" && allowedChoices.includes(choice))
+    ? value.choices
+    : ["deny"];
+  const allowPermanent = hasInspectablePermanentPattern && value.allowPermanent === true;
+  const choices = [...new Set(suppliedChoices)]
+    .filter((choice) => displayComplete || choice === "deny")
+    .filter((choice) => !["session", "always"].includes(choice) || hasInspectablePermanentPattern)
+    .filter((choice) => choice !== "always" || allowPermanent);
+  if (!choices.includes("deny")) choices.push("deny");
+  return {
+    approvalId,
+    ...(command ? { command } : {}),
+    ...(description ? { description } : {}),
+    ...(inspectablePatterns[0] ? { patternKey: inspectablePatterns[0] } : {}),
+    ...(inspectablePatterns.length > 1 ? { patternKeys: inspectablePatterns.slice(1) } : {}),
+    choices,
+    allowPermanent: allowPermanent && choices.includes("always"),
+  };
+}
+
+function exactApprovalDisplayText(value, maximum) {
+  if (value === undefined || value === null || value === "") return { exact: true };
+  if (typeof value !== "string" || /[\r\n\t]/u.test(value)) return { exact: false };
+  const projected = safeDisplayText(value, maximum);
+  return projected && projected === value && /[\p{L}\p{N}\p{P}\p{S}]/u.test(projected)
+    ? { value: projected, exact: true }
+    : { exact: false };
+}
+
+function exactApprovalPatterns(value) {
+  const rawValues = [];
+  if (value.patternKey !== undefined && value.patternKey !== null && value.patternKey !== "") {
+    rawValues.push(value.patternKey);
+  }
+  if (value.patternKeys !== undefined && value.patternKeys !== null) {
+    if (!Array.isArray(value.patternKeys) || value.patternKeys.length > 32) {
+      return { values: [], exact: false };
+    }
+    rawValues.push(...value.patternKeys);
+  }
+  if (rawValues.length > 32) return { values: [], exact: false };
+
+  const values = [];
+  for (const raw of rawValues) {
+    const projected = safeInspectableText(raw, 256);
+    if (typeof raw !== "string" || !projected || projected !== raw) {
+      return { values: [], exact: false };
+    }
+    if (!values.includes(projected)) values.push(projected);
+  }
+  return { values, exact: true };
+}
+
+function safeDisplayText(value, maximum) {
+  if (typeof value !== "string") return "";
+  const withoutTerminalSequences = value
+    .replace(/\u001b\][^\u0007]*(?:\u0007|\u001b\\|$)/g, "")
+    .replace(/(?:\u001b\[|\u009b)[0-?]*[ -/]*[@-~]/g, "")
+    .replace(/\u001b[@-_]/g, "")
+    .replace(/\r\n?/g, "\n");
+  return Array.from(withoutTerminalSequences.normalize("NFC"))
+    .filter((character) =>
+      character === "\n" || character === "\t" || !/[\p{Cc}\p{Cf}\p{Cs}\p{Co}\p{Cn}]/u.test(character))
+    .slice(0, maximum)
+    .join("")
+    .trim();
+}
+
+function safeInspectableText(value, maximum) {
+  const normalized = safeDisplayText(value, maximum).replace(/\s+/gu, " ").trim();
+  return /[\p{L}\p{N}\p{P}\p{S}]/u.test(normalized) ? normalized : "";
 }
 
 function requireNumber(value, key) {
@@ -1021,13 +1171,17 @@ function requireNumber(value, key) {
 }
 
 function validateRealtimeCapabilities(value) {
-  requireString({ type: "session.ready realtime", ...value }, "provider");
+  requireEnum({ type: "session.ready realtime", ...value }, "provider", ["gemini", "openai", "mock"]);
   requireString({ type: "session.ready realtime", ...value }, "model");
   requireObject({ type: "session.ready realtime", ...value }, "audio");
   const audio = value.audio;
   requireObject({ type: "session.ready realtime audio", ...audio }, "input");
   requireObject({ type: "session.ready realtime audio", ...audio }, "output");
-  requireString({ type: "session.ready realtime audio", ...audio }, "turnDetection");
+  requireEnum(
+    { type: "session.ready realtime audio", ...audio },
+    "turnDetection",
+    ["disabled", "semantic_vad", "server_vad", "provider", "none"],
+  );
   if (typeof audio.input.enabled !== "boolean" || typeof audio.output.enabled !== "boolean") {
     throw new TypeError("Hermes Live session.ready realtime audio capabilities require enabled flags.");
   }
@@ -1047,7 +1201,7 @@ function createSnapshot(connection) {
 }
 
 function approvalRequestId(message) {
-  const approvalId = message?.approval?.approvalId ?? message?.event?.approval_id;
+  const approvalId = message?.approval?.approvalId;
   return typeof approvalId === "string" && approvalId ? `${message.runId}:${approvalId}` : "";
 }
 
@@ -1057,7 +1211,7 @@ function defaultRequestId() {
 }
 
 function encodedMessageSize(data) {
-  if (typeof data === "string") return data.length;
+  if (typeof data === "string") return new TextEncoder().encode(data).byteLength;
   if (typeof data?.size === "number") return data.size;
   if (typeof data?.byteLength === "number") return data.byteLength;
   return 0;
@@ -1144,6 +1298,34 @@ function normalizeCloseReason(value) {
 function positiveInteger(value, fallback) {
   const parsed = Number(value);
   return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function settleConnectionPrerequisite(promise, timeoutMs, signal) {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const finish = (error, value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      signal?.removeEventListener("abort", onAbort);
+      if (error) reject(error);
+      else resolve(value);
+    };
+    const onAbort = () => finish(abortError());
+    const timeout = setTimeout(
+      () => finish(new Error(`Hermes Live gateway URL or token did not resolve within ${timeoutMs}ms.`)),
+      timeoutMs,
+    );
+    if (signal?.aborted) {
+      onAbort();
+      return;
+    }
+    signal?.addEventListener("abort", onAbort, { once: true });
+    Promise.resolve(promise).then(
+      (value) => finish(undefined, value),
+      (error) => finish(toError(error)),
+    );
+  });
 }
 
 function optionalString(value) {

--- a/plugins/hermes-live/dashboard/dist/index.js
+++ b/plugins/hermes-live/dashboard/dist/index.js
@@ -68,8 +68,7 @@
 
   function approvalKey(request, index) {
     const approval = request && request.approval ? request.approval : {};
-    const event = request && request.event ? request.event : {};
-    return String(approval.approvalId || event.approval_id || request.runId || "approval") + ":" + index;
+    return String(approval.approvalId || request.runId || "approval") + ":" + index;
   }
 
   function approvalPatternKeys(approval) {
@@ -383,12 +382,7 @@
               if (active) {
                 setConfirmPermanent("");
                 setBusyAction("");
-                if (message.resolved === 0) {
-                  setNotice({ tone: "warning", text: "Hermes did not resolve that approval; review it and try again." });
-                  addActivity("Approval still pending", approvalChoiceLabel(message.choice), "warning");
-                } else {
-                  addActivity("Approval answered", approvalChoiceLabel(message.choice), "success");
-                }
+                addActivity("Approval answered", approvalChoiceLabel(message.choice), "success");
               }
             }),
             client.on("run.completed", function (message) {
@@ -399,6 +393,9 @@
                 addActivity("Hermes task failed", message.error, "danger");
                 setNotice({ tone: "danger", text: clampText(message.error, 300) });
               }
+            }),
+            client.on("run.stopping", function (message) {
+              if (active) addActivity("Hermes task stopping", titleCase(message.status), "warning");
             }),
             client.on("run.stopped", function (message) {
               if (active) addActivity("Hermes task stopped", titleCase(message.status), "warning");
@@ -463,7 +460,7 @@
         audioRef.current = null;
         clientRef.current = null;
         if (audio) void audio.dispose();
-        if (client) void client.disconnect("dashboard page closed");
+        if (client) void client.disconnect("dashboard page closed").catch(function () { return undefined; });
       };
     }, [SDK, addActivity, addTranscript, finalizeAssistantTranscript]);
 
@@ -527,7 +524,9 @@
           .then(function () {
             setNotice({
               tone: "neutral",
-              text: activeRun ? "Disconnected. The active Hermes task was stopped." : "Live Voice disconnected.",
+              text: activeRun
+                ? "Disconnected. The gateway confirmed shutdown and accepted a stop request for the active Hermes task."
+                : "Live Voice disconnected.",
             });
           });
       });
@@ -575,6 +574,9 @@
       const client = clientRef.current;
       if (!text || !client) return;
       try {
+        const audio = audioRef.current;
+        if (audio) audio.interrupt("new Dashboard text input");
+        else client.cancelResponse("new Dashboard text input");
         client.sendText(text);
         addTranscript("user", text, true, "local");
         setTextInput("");
@@ -604,7 +606,7 @@
       if (!client) return;
       setBusyAction("approval:" + key);
       try {
-        client.respondToApproval(choice, request.runId);
+        client.respondToApproval(choice, request.runId, { approvalId: request.approval.approvalId });
         setConfirmPermanent("");
       } catch (error) {
         setBusyAction("");
@@ -665,11 +667,14 @@
       const suppliedChoices = Array.isArray(approval.choices) ? approval.choices : [];
       const choices = suppliedChoices
         .filter(function (choice) { return ["once", "session", "always", "deny"].includes(choice); })
-        .filter(function (choice) { return informed || choice === "once" || choice === "deny"; })
+        .filter(function (choice) { return informed || choice === "deny"; })
+        .filter(function (choice) {
+          return !["session", "always"].includes(choice) || patternKeys.length > 0;
+        })
         .filter(function (choice) {
           return choice !== "always" || (approval.allowPermanent === true && patternKeys.length > 0);
         });
-      if (!choices.length) choices.push("once", "deny");
+      if (!choices.includes("deny")) choices.push("deny");
       const key = approvalKey(request, index);
       const isBusy = busyAction === "approval:" + key;
       const permanentConfirmation = isActionable && confirmPermanent === key;
@@ -687,9 +692,13 @@
               "Permission pattern: ",
               h("code", null, patternKeys.join(", ")),
             )
-          : h("p", { className: "hlv-approval__opaque" },
-              "Hermes did not provide inspectable command details. Only a one-time approval is available.",
-            ),
+          : informed
+            ? h("p", { className: "hlv-approval__opaque" },
+                "No inspectable permission pattern was supplied. Only a one-time decision or denial is available.",
+              )
+            : h("p", { className: "hlv-approval__opaque" },
+                "Hermes did not provide enough inspectable action details. This request can only be denied.",
+              ),
         !isActionable
           ? h("p", { className: "hlv-approval__queued", role: "status" },
               "Answer the earlier approval first. Hermes resolves approval requests in FIFO order.",
@@ -755,7 +764,7 @@
         h("div", null,
           h("strong", null, "Hermes task is active"),
           h("span", null,
-            " Disconnecting, refreshing, or navigating away stops this task. Interrupt Speech only stops the current spoken response.",
+            " Disconnecting asks the gateway to stop this task; wait for shutdown confirmation. Refreshing or navigating away can only request cleanup. Interrupt Speech only stops the current spoken response.",
           ),
         ),
       ) : null,
@@ -763,7 +772,7 @@
       confirmDisconnect ? h("div", { className: "hlv-disconnect-confirm", role: "alert" },
         h("div", null,
           h("strong", null, "Disconnect and stop the active Hermes task?"),
-          h("p", null, "The voice session will close and run " + shortId(snapshot.run.runId) + " will be stopped."),
+          h("p", null, "The gateway will request a stop for run " + shortId(snapshot.run.runId) + " and confirm whether session shutdown completed."),
         ),
         h("div", { className: "hlv-button-row" },
           h(ControlButton, { variant: "danger", onClick: function () { disconnect(true); } }, "Disconnect & stop"),
@@ -977,8 +986,8 @@
             ? transcript.map(function (entry) {
                 return h("article", { key: entry.id, className: "hlv-message hlv-message--" + entry.speaker },
                   h("div", { className: "hlv-message__speaker" },
-                    h("span", { className: "hlv-message__avatar", "aria-hidden": "true" }, entry.speaker === "user" ? "Y" : entry.speaker === "assistant" ? "H" : "i"),
-                    h("strong", null, entry.speaker === "user" ? "You" : entry.speaker === "assistant" ? "Hermes" : "System"),
+                    h("span", { className: "hlv-message__avatar", "aria-hidden": "true" }, entry.speaker === "user" ? "Y" : entry.speaker === "assistant" ? "V" : "i"),
+                    h("strong", null, entry.speaker === "user" ? "You" : entry.speaker === "assistant" ? "Live voice" : "System"),
                     !entry.final ? h("span", { className: "hlv-message__streaming" }, "Live") : null,
                   ),
                   h("p", null, entry.text),
@@ -995,7 +1004,7 @@
 
       h("footer", { className: "hlv-footer" },
         h("p", null,
-          "Live Voice is a session surface, not a background job monitor. Leaving this page closes the voice session and stops its active Hermes task.",
+          "Live Voice is a session surface, not a background job monitor. Leaving this page closes the voice session and requests cleanup for its active Hermes task.",
         ),
       ),
     );

--- a/scripts/cli-client-smoke.mjs
+++ b/scripts/cli-client-smoke.mjs
@@ -1,21 +1,43 @@
 import { spawn } from "node:child_process";
 import { once } from "node:events";
+import { createServer } from "node:net";
 import { WebSocketServer } from "ws";
 
 const hermesPrompt = "hello from cli";
 const directPrompt = "hello direct from cli";
 const audioOnlyPrompt = "hello audio only from cli";
 const cleanClosePrompt = "hello clean close from cli";
+const invalidOutputPrompt = "hello invalid output from cli";
 const expectedHermesOutput = "cli ok";
 const expectedDirectOutput = "direct cli ok";
 const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+const stalledSockets = new Set();
+const stalledHandshakeServer = createServer((socket) => {
+  stalledSockets.add(socket);
+  socket.once("close", () => stalledSockets.delete(socket));
+});
 const receivedPrompts = new Set();
 
-server.on("connection", (socket) => {
+server.on("connection", (socket, request) => {
   socket.on("message", (raw) => {
     const message = JSON.parse(raw.toString("utf8"));
     if (message.type === "session.start") {
-      socket.send(JSON.stringify({ type: "session.ready", sessionId: "live_cli_smoke", model: "mock-live", hermes: {} }));
+      if (request.url === "/session-timeout") return;
+      if (request.url === "/oversized-message") {
+        socket.send(JSON.stringify({ type: "log", message: "x".repeat(2_700_100) }));
+        return;
+      }
+      if (request.url === "/invalid-ready") {
+        socket.send(JSON.stringify({ type: "session.ready", sessionId: "live_cli_smoke", model: "mock-live" }));
+        return;
+      }
+      socket.send(JSON.stringify({
+        type: "session.ready",
+        protocolVersion: 2,
+        sessionId: "live_cli_smoke",
+        model: "mock-live",
+        hermes: {},
+      }));
       return;
     }
     if (message.type === "text.input") {
@@ -23,15 +45,20 @@ server.on("connection", (socket) => {
       if (message.text === directPrompt) {
         socket.send(JSON.stringify({ type: "transcript.delta", speaker: "assistant", text: "direct " }));
         socket.send(JSON.stringify({ type: "transcript.delta", speaker: "assistant", text: "cli ok" }));
-        socket.send(JSON.stringify({ type: "realtime.message", message: { type: "response.done" } }));
+        socket.send(JSON.stringify({ type: "response.completed" }));
         return;
       }
       if (message.text === audioOnlyPrompt) {
-        socket.send(JSON.stringify({ type: "realtime.message", message: { type: "response.done" } }));
+        socket.send(JSON.stringify({ type: "response.completed" }));
         return;
       }
       if (message.text === cleanClosePrompt) {
         socket.close(1000, "clean close without terminal event");
+        return;
+      }
+      if (message.text === invalidOutputPrompt) {
+        socket.send(JSON.stringify({ type: "run.started", runId: "run_cli_smoke", sessionId: "live_cli_smoke" }));
+        socket.send(JSON.stringify({ type: "run.completed", runId: "run_cli_smoke", output: 42 }));
         return;
       }
       socket.send(JSON.stringify({ type: "run.started", runId: "run_cli_smoke", sessionId: "live_cli_smoke" }));
@@ -41,11 +68,18 @@ server.on("connection", (socket) => {
 });
 
 await once(server, "listening");
+stalledHandshakeServer.listen(0, "127.0.0.1");
+await once(stalledHandshakeServer, "listening");
 
 const address = server.address();
 const port = typeof address === "object" && address ? address.port : undefined;
 if (!port) {
   throw new Error("CLI smoke gateway did not bind a port.");
+}
+const stalledAddress = stalledHandshakeServer.address();
+const stalledPort = typeof stalledAddress === "object" && stalledAddress ? stalledAddress.port : undefined;
+if (!stalledPort) {
+  throw new Error("CLI smoke stalled-handshake server did not bind a port.");
 }
 
 try {
@@ -59,11 +93,43 @@ try {
     expectFailure: true,
     stderrIncludes: "Gateway WebSocket closed before completing the request: 1000 clean close without terminal event",
   });
+  await runClient(port, invalidOutputPrompt, "", {
+    expectFailure: true,
+    stderrIncludes: "Gateway run.completed output must be a bounded string",
+  });
+  await runClient(port, "invalid ready", "", {
+    path: "/invalid-ready",
+    expectFailure: true,
+    stderrIncludes: "Gateway session.ready protocolVersion must be an integer",
+  });
+  await runClient(port, "session timeout", "", {
+    path: "/session-timeout",
+    readyTimeoutMs: 50,
+    expectFailure: true,
+    stderrIncludes: "Gateway did not complete the WebSocket/session.ready handshake within 50ms",
+  });
+  await runClient(port, "oversized message", "", {
+    path: "/oversized-message",
+    expectFailure: true,
+    stderrIncludes: "Max payload size exceeded",
+  });
+  await runClient(stalledPort, "stalled handshake", "", {
+    readyTimeoutMs: 50,
+    expectFailure: true,
+    stderrIncludesAny: [
+      "Opening handshake has timed out",
+      "Gateway did not complete the WebSocket/session.ready handshake within 50ms",
+    ],
+  });
 } finally {
   await new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve(undefined))));
+  for (const socket of stalledSockets) socket.destroy();
+  await new Promise((resolve, reject) =>
+    stalledHandshakeServer.close((error) => (error ? reject(error) : resolve(undefined))),
+  );
 }
 
-for (const expectedPrompt of [hermesPrompt, directPrompt, audioOnlyPrompt, cleanClosePrompt]) {
+for (const expectedPrompt of [hermesPrompt, directPrompt, audioOnlyPrompt, cleanClosePrompt, invalidOutputPrompt]) {
   if (!receivedPrompts.has(expectedPrompt)) {
     throw new Error(`CLI smoke gateway did not receive prompt: ${expectedPrompt}`);
   }
@@ -74,9 +140,10 @@ async function runClient(port, prompt, expectedOutput, options = {}) {
     env: {
       ...process.env,
       HERMES_LIVE_PROVIDER: "mock",
+      ...(options.readyTimeoutMs ? { HERMES_LIVE_CLIENT_READY_TIMEOUT_MS: String(options.readyTimeoutMs) } : {}),
       HERMES_LIVE_URL: options.httpOrigin
         ? `http://127.0.0.1:${port}`
-        : `ws://127.0.0.1:${port}/v1/live`,
+        : `ws://127.0.0.1:${port}${options.path ?? "/v1/live"}`,
     },
     stdio: ["ignore", "pipe", "pipe"],
   });
@@ -103,6 +170,11 @@ async function runClient(port, prompt, expectedOutput, options = {}) {
     }
     if (options.stderrIncludes && !stderr.includes(options.stderrIncludes)) {
       throw new Error(`CLI smoke stderr mismatch. Expected it to include ${JSON.stringify(options.stderrIncludes)}, got:\n${stderr}`);
+    }
+    if (options.stderrIncludesAny && !options.stderrIncludesAny.some((expected) => stderr.includes(expected))) {
+      throw new Error(
+        `CLI smoke stderr mismatch. Expected it to include one of ${JSON.stringify(options.stderrIncludesAny)}, got:\n${stderr}`,
+      );
     }
     return;
   }

--- a/scripts/dashboard-plugin-smoke.py
+++ b/scripts/dashboard-plugin-smoke.py
@@ -179,7 +179,7 @@ def test_url_and_payload_guards(plugin: Any) -> None:
             continue
         raise AssertionError(f"unsafe gateway URL accepted: {value!r}")
 
-    assert plugin._is_bounded_json_message('{"type":"session.start","protocolVersion":1}')
+    assert plugin._is_bounded_json_message('{"type":"session.start","protocolVersion":2}')
     assert not plugin._is_bounded_json_message("[]")
     assert not plugin._is_bounded_json_message('{"type":"audio.input","data":NaN}')
     assert not plugin._is_bounded_json_message('{"notType":"session.start"}')
@@ -189,7 +189,7 @@ def test_url_and_payload_guards(plugin: Any) -> None:
 def test_capability_sanitizing(plugin: Any) -> None:
     protocol, provider, model, audio = plugin._capabilities_summary(
         {
-            "protocolVersion": 1,
+            "protocolVersion": 2,
             "realtime": {
                 "provider": "gemini",
                 "model": "gemini-live-2.5-flash",
@@ -209,7 +209,7 @@ def test_capability_sanitizing(plugin: Any) -> None:
             "secret": "must not escape",
         }
     )
-    assert protocol == 1
+    assert protocol == 2
     assert provider == "gemini"
     assert model == "gemini-live-2.5-flash"
     assert audio == {
@@ -257,7 +257,7 @@ async def test_status(plugin: Any) -> None:
             return plugin._Probe(
                 status=200,
                 body={
-                    "protocolVersion": 1,
+                    "protocolVersion": 2,
                     "realtime": {
                         "provider": "gemini",
                         "model": "gemini-live",
@@ -294,7 +294,7 @@ async def test_status(plugin: Any) -> None:
         "reachable": True,
         "ready": True,
         "gateway": {"mode": "server-proxied"},
-        "protocolVersion": 1,
+        "protocolVersion": 2,
         "provider": "gemini",
         "model": "gemini-live",
         "audio": {
@@ -313,7 +313,7 @@ async def test_status(plugin: Any) -> None:
 async def test_relay_and_route(plugin: Any) -> None:
     browser = _BrowserSocket(
         [
-            {"type": "websocket.receive", "text": '{"type":"session.start","protocolVersion":1}'},
+            {"type": "websocket.receive", "text": '{"type":"session.start","protocolVersion":2}'},
             {"type": "websocket.disconnect"},
         ]
     )
@@ -346,7 +346,7 @@ async def test_relay_and_route(plugin: Any) -> None:
     assert browser.accepted
     assert browser.closed == [1000]
     assert browser.sent == []
-    assert upstream.sent == ['{"type":"session.start","protocolVersion":1}']
+    assert upstream.sent == ['{"type":"session.start","protocolVersion":2}']
     assert captured["url"] == "wss://voice.example:9443/v1/live"
     assert captured["options"]["proxy"] is None
     assert captured["options"]["max_size"] == plugin.MAX_MESSAGE_BYTES
@@ -354,9 +354,9 @@ async def test_relay_and_route(plugin: Any) -> None:
     assert captured["options"]["additional_headers"] == {"Authorization": "Bearer server-owned-secret"}
 
     browser = _BrowserSocket()
-    upstream = _Upstream(['{"type":"session.ready","protocolVersion":1}'])
+    upstream = _Upstream(['{"type":"session.ready","protocolVersion":2}'])
     await plugin._relay_gateway_to_browser(upstream, browser)
-    assert browser.sent == ['{"type":"session.ready","protocolVersion":1}']
+    assert browser.sent == ['{"type":"session.ready","protocolVersion":2}']
 
     browser = _BrowserSocket([{"type": "websocket.receive", "bytes": b"binary"}])
     try:

--- a/scripts/gateway-smoke.mjs
+++ b/scripts/gateway-smoke.mjs
@@ -86,7 +86,7 @@ try {
   const inbox = createInbox(socket);
   await waitForOpen(socket, 5_000);
 
-  socket.send(JSON.stringify({ type: "session.start", profileId: "smoke", userLabel: "gateway-smoke" }));
+  socket.send(JSON.stringify({ type: "session.start", protocolVersion: 2, profileId: "smoke", userLabel: "gateway-smoke" }));
   const ready = await inbox.next("session.ready");
   if (ready.model !== "mock-live") {
     throw new Error(`Gateway session advertised unexpected model: ${JSON.stringify(ready.model)}.`);

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -157,6 +157,13 @@ try {
     throw new Error(`Installed CLI help failed with status ${help.status ?? "null"}\n${help.stdout}\n${help.stderr}`);
   }
 
+  const version = spawnSync(bin, ["--version"], { encoding: "utf8" });
+  if (version.status !== 0 || version.stdout.trim() !== packageJson.version) {
+    throw new Error(
+      `Installed CLI version failed with status ${version.status ?? "null"}; expected ${packageJson.version}.\n${version.stdout}\n${version.stderr}`,
+    );
+  }
+
   const hermesPluginsDir = join(workDir, "hermes-plugins");
   mkdirSync(hermesPluginsDir, { recursive: true });
   const pluginInstall = spawnSync(bin, ["plugin", "install", "--dir", hermesPluginsDir], {

--- a/src/adapters/inbound/http/server.ts
+++ b/src/adapters/inbound/http/server.ts
@@ -2,6 +2,7 @@ import { createHash, timingSafeEqual } from "node:crypto";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import type { AddressInfo } from "node:net";
 import { dirname, join } from "node:path";
+import type { Duplex } from "node:stream";
 import { fileURLToPath } from "node:url";
 import { WebSocketServer } from "ws";
 import { assertGatewayExposureConfig, assertHermesApiConfig, assertRealtimeProviderConfig, type AppConfig } from "../../../config.js";
@@ -61,7 +62,16 @@ export async function startServer({ config, logger, hermes: providedHermes, live
 
   const wss = new WebSocketServer({ noServer: true, maxPayload: clientWebSocketMaxPayload(config) });
   server.on("upgrade", (req, socket, head) => {
-    const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
+    let url: URL;
+    try {
+      url = parseRequestTarget(req.url);
+      if (!parseHttpHost(req.headers.host, "http:")) {
+        throw new TypeError("Invalid Host header");
+      }
+    } catch {
+      rejectMalformedUpgrade(socket);
+      return;
+    }
     if (url.pathname !== "/v1/live") {
       socket.destroy();
       return;
@@ -84,7 +94,9 @@ export async function startServer({ config, logger, hermes: providedHermes, live
     wss.handleUpgrade(req, socket, head, (ws) => {
       const session = new LiveGatewaySession(new WebSocketClientConnection(ws), { config, hermes, liveModel, logger });
       sessions.add(session);
-      ws.once("close", () => sessions.delete(session));
+      ws.once("close", () => {
+        void session.close().finally(() => sessions.delete(session));
+      });
       session.bind();
       wss.emit("connection", ws, req);
     });
@@ -135,7 +147,7 @@ async function handleHttp(
     res.end();
     return;
   }
-  const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
+  const url = parseRequestTarget(req.url);
 
   if (url.pathname === "/health") {
     if (!isGetOrHead(req)) {
@@ -286,6 +298,14 @@ function parseHttpHost(host: string | undefined, protocol: "http:" | "https:"): 
   }
 }
 
+function parseRequestTarget(target: string | undefined): URL {
+  return new URL(target ?? "/", "http://localhost");
+}
+
+function rejectMalformedUpgrade(socket: Duplex): void {
+  socket.end("HTTP/1.1 400 Bad Request\r\nConnection: close\r\nContent-Length: 0\r\n\r\n", () => socket.destroy());
+}
+
 function isLoopbackHostname(hostname: string): boolean {
   const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, "").replace(/\.$/, "");
   if (normalized === "localhost" || normalized === "::1") {
@@ -372,7 +392,7 @@ function secureTokenEqual(actual: string | null | undefined, expected: string): 
 
 function clientWebSocketMaxPayload(config: AppConfig): number {
   const base64AudioBytes = Math.ceil((config.server.maxAudioBytes * 4) / 3);
-  const textBytes = config.server.maxTextChars * 4;
+  const textBytes = config.server.maxTextChars * 6;
   return Math.max(base64AudioBytes, textBytes) + 4096;
 }
 

--- a/src/adapters/inbound/http/websocket-client-connection.ts
+++ b/src/adapters/inbound/http/websocket-client-connection.ts
@@ -1,6 +1,10 @@
 import type WebSocket from "ws";
 import type { ClientConnectionPort, ClientInboundFrame } from "../../../application/live-gateway/ports/client-connection.port.js";
 
+// Keep enough headroom for multiple default-sized audio frames, but never let a
+// stalled client turn provider output into an unbounded process-level buffer.
+export const MAX_CLIENT_BUFFERED_BYTES = 8 * 1024 * 1024;
+
 export class WebSocketClientConnection implements ClientConnectionPort {
   constructor(private readonly socket: WebSocket) {}
 
@@ -17,8 +21,22 @@ export class WebSocketClientConnection implements ClientConnectionPort {
   }
 
   sendText(payload: string): void {
-    if (this.socket.readyState === this.socket.OPEN) {
+    if (this.socket.readyState !== this.socket.OPEN) {
+      return;
+    }
+
+    const payloadBytes = Buffer.byteLength(payload, "utf8");
+    if (this.socket.bufferedAmount + payloadBytes > MAX_CLIENT_BUFFERED_BYTES) {
+      this.socket.terminate();
+      return;
+    }
+
+    try {
       this.socket.send(payload);
+    } catch {
+      // The socket can leave OPEN between the readyState check and send(). A
+      // hard close is safe here and ensures the session observes termination.
+      this.socket.terminate();
     }
   }
 

--- a/src/adapters/outbound/hermes/hermes-runs.client.ts
+++ b/src/adapters/outbound/hermes/hermes-runs.client.ts
@@ -11,6 +11,9 @@ import type {
 } from "../../../application/live-gateway/ports/hermes-runs.port.js";
 import { parseSseStream } from "./sse.js";
 
+export const MAX_HERMES_JSON_RESPONSE_BYTES = 1_000_000;
+const MAX_HERMES_ERROR_DETAIL_CHARS = 2_000;
+
 export class HermesClient implements HermesRunsPort {
   readonly baseUrl: string;
   private readonly apiKey: string | undefined;
@@ -61,11 +64,25 @@ export class HermesClient implements HermesRunsPort {
       headers: this.sessionHeaders(params.sessionKey),
       ...signalInit(signal),
     });
-    const runId = response.run_id ?? response.runId;
-    if (!runId) {
-      throw new Error("Hermes did not return a run_id.");
+    if (response?.run_id !== undefined && !isBoundedHermesIdentifier(response.run_id)) {
+      throw new Error("Hermes returned an invalid run_id.");
     }
-    return { runId, status: response.status ?? "started" };
+    if (response?.runId !== undefined && !isBoundedHermesIdentifier(response.runId)) {
+      throw new Error("Hermes returned an invalid runId alias.");
+    }
+    if (response?.run_id !== undefined && response.runId !== undefined && response.run_id !== response.runId) {
+      throw new Error("Hermes returned conflicting run identifiers.");
+    }
+    const runId = response?.run_id ?? response?.runId;
+    if (!isBoundedHermesIdentifier(runId)) {
+      throw new Error("Hermes did not return a valid bounded run_id.");
+    }
+    return {
+      runId,
+      status: typeof response.status === "string" && response.status.length <= 128
+        ? response.status
+        : "started",
+    };
   }
 
   async getRun(runId: string, options?: AbortSignal | HermesRequestOptions): Promise<Record<string, unknown>> {
@@ -116,7 +133,10 @@ export class HermesClient implements HermesRunsPort {
         signal: requestSignal.signal,
       });
       if (!response.ok) {
-        throw new Error(`Hermes events request failed: ${response.status} ${await response.text()}`);
+        const detail = await readBoundedResponseText(response, MAX_HERMES_JSON_RESPONSE_BYTES);
+        throw new Error(
+          `Hermes events request failed: ${response.status} ${detail.slice(0, MAX_HERMES_ERROR_DETAIL_CHARS)}`.trim(),
+        );
       }
       if (!response.body) {
         throw new Error("Hermes events response did not include a body.");
@@ -139,9 +159,17 @@ export class HermesClient implements HermesRunsPort {
         headers: this.headers(init.headers),
       });
       if (!response.ok) {
-        throw new Error(`Hermes request failed: ${response.status} ${await response.text()}`);
+        const detail = await readBoundedResponseText(response, MAX_HERMES_JSON_RESPONSE_BYTES);
+        throw new Error(
+          `Hermes request failed: ${response.status} ${detail.slice(0, MAX_HERMES_ERROR_DETAIL_CHARS)}`.trim(),
+        );
       }
-      return (await response.json()) as T;
+      const body = await readBoundedResponseText(response, MAX_HERMES_JSON_RESPONSE_BYTES);
+      try {
+        return JSON.parse(body) as T;
+      } catch {
+        throw new Error(`Hermes returned invalid JSON for ${path}.`);
+      }
     } catch (error) {
       throw requestSignal.timedOut() ? new Error(`Hermes request timed out after ${this.timeoutMs}ms: ${path}`) : error;
     } finally {
@@ -163,11 +191,48 @@ export class HermesClient implements HermesRunsPort {
   }
 }
 
+async function readBoundedResponseText(response: Response, maximumBytes: number): Promise<string> {
+  const declaredLength = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declaredLength) && declaredLength > maximumBytes) {
+    await response.body?.cancel().catch(() => undefined);
+    throw new Error(`Hermes response exceeded the ${maximumBytes}-byte safety limit.`);
+  }
+  if (!response.body) return "";
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let bytes = 0;
+  let text = "";
+  let reachedEof = false;
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) {
+        reachedEof = true;
+        break;
+      }
+      bytes += value.byteLength;
+      if (bytes > maximumBytes) {
+        throw new Error(`Hermes response exceeded the ${maximumBytes}-byte safety limit.`);
+      }
+      text += decoder.decode(value, { stream: true });
+    }
+    return text + decoder.decode();
+  } finally {
+    if (!reachedEof) await reader.cancel().catch(() => undefined);
+    reader.releaseLock();
+  }
+}
+
 function normalizeHermesRequestOptions(options: AbortSignal | HermesRequestOptions | undefined): HermesRequestOptions {
   if (!options) {
     return {};
   }
   return "aborted" in options && "addEventListener" in options ? { signal: options } : options;
+}
+
+function isBoundedHermesIdentifier(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0 && value.length <= 256 && !/[\u0000-\u001f\u007f]/u.test(value);
 }
 
 function signalInit(signal: AbortSignal | undefined): Pick<RequestInit, "signal"> {

--- a/src/adapters/outbound/hermes/sse.ts
+++ b/src/adapters/outbound/hermes/sse.ts
@@ -1,6 +1,9 @@
 import type { HermesRunEvent } from "../../../domain/protocol/server-protocol.js";
 
+export const MAX_SSE_EVENT_BYTES = 1_000_000;
+
 export function parseSseEventBlock(block: string): HermesRunEvent | null {
+  assertSseEventSize(block);
   const dataLines: string[] = [];
   let eventName: string | undefined;
   for (const line of block.split(/\r?\n/)) {
@@ -36,11 +39,13 @@ export async function* parseSseStream(stream: ReadableStream<Uint8Array>): Async
   const reader = stream.getReader();
   const decoder = new TextDecoder();
   let buffer = "";
+  let reachedEof = false;
 
   try {
     while (true) {
       const { value, done } = await reader.read();
       if (done) {
+        reachedEof = true;
         break;
       }
       buffer += decoder.decode(value, { stream: true });
@@ -54,16 +59,27 @@ export async function* parseSseStream(stream: ReadableStream<Uint8Array>): Async
         }
         boundary = findBoundary(buffer);
       }
+      assertSseEventSize(buffer);
     }
     buffer += decoder.decode();
     if (buffer.trim()) {
+      assertSseEventSize(buffer);
       const event = parseSseEventBlock(buffer);
       if (event) {
         yield event;
       }
     }
   } finally {
+    if (!reachedEof) {
+      await reader.cancel().catch(() => undefined);
+    }
     reader.releaseLock();
+  }
+}
+
+function assertSseEventSize(value: string): void {
+  if (Buffer.byteLength(value, "utf8") > MAX_SSE_EVENT_BYTES) {
+    throw new Error(`Hermes SSE event exceeded the ${MAX_SSE_EVENT_BYTES}-byte safety limit.`);
   }
 }
 

--- a/src/adapters/outbound/realtime/gemini-live.adapter.ts
+++ b/src/adapters/outbound/realtime/gemini-live.adapter.ts
@@ -204,7 +204,6 @@ export function normalizeGeminiLiveMessage(message: unknown): LiveModelEvent[] {
   } else if (serverContent?.turnComplete === true || serverContent?.turn_complete === true) {
     events.push({ type: "response", status: "completed" });
   }
-  events.push({ type: "raw", message });
   return events;
 }
 

--- a/src/adapters/outbound/realtime/openai-realtime.adapter.ts
+++ b/src/adapters/outbound/realtime/openai-realtime.adapter.ts
@@ -17,6 +17,11 @@ import type {
 } from "../../../application/live-gateway/ports/realtime-model.port.js";
 
 const OPENAI_REALTIME_PCM_INPUT_SAMPLE_RATE = 24_000;
+const OPENAI_CANCEL_ACK_TIMEOUT_MS = 2_000;
+const OPENAI_HANDSHAKE_TIMEOUT_MS = 10_000;
+const OPENAI_MAX_EVENT_BYTES = 16 * 1024 * 1024;
+const OPENAI_MAX_BUFFERED_BYTES = 8 * 1024 * 1024;
+const OPENAI_MAX_HANDLED_TOOL_CALLS = 4_096;
 
 export class OpenAIRealtimeAdapter implements LiveModelAdapter {
   constructor(private readonly config: AppConfig["openai"]) {}
@@ -30,7 +35,11 @@ export class OpenAIRealtimeAdapter implements LiveModelAdapter {
     if (params.safetyIdentifier) {
       headers["OpenAI-Safety-Identifier"] = params.safetyIdentifier;
     }
-    const ws = new WebSocket(url, { headers });
+    const ws = new WebSocket(url, {
+      headers,
+      handshakeTimeout: OPENAI_HANDSHAKE_TIMEOUT_MS,
+      maxPayload: OPENAI_MAX_EVENT_BYTES,
+    });
     const session = new OpenAIRealtimeSession(ws, this.config, params.callbacks);
 
     return await new Promise<LiveModelSession>((resolve, reject) => {
@@ -56,11 +65,14 @@ export class OpenAIRealtimeAdapter implements LiveModelAdapter {
       const onOpen = () => session.configure(params.systemInstruction);
       const onInitialMessage = (raw: WebSocket.RawData) => {
         const event = parseOpenAIEvent(raw);
-        if (event?.type === "session.updated") {
+        if (!event) {
+          onInitialError(new Error("OpenAI Realtime event was not valid JSON."));
+        } else if (event.type === "session.updated") {
+          session.markReady();
           cleanup();
           params.callbacks.onOpen?.();
           resolve(session);
-        } else if (event?.type === "error") {
+        } else if (event.type === "error") {
           onInitialError(event.error ?? event);
         }
       };
@@ -74,9 +86,13 @@ export class OpenAIRealtimeAdapter implements LiveModelAdapter {
 }
 
 class OpenAIRealtimeSession implements LiveModelSession {
-  private readonly handledToolCalls = new Set<string>();
+  private readonly handledToolCalls = new Map<string, string>();
   private responseActive = false;
   private responsePending = false;
+  private responseCreateQueued = false;
+  private cancellationPending = false;
+  private cancelAckTimeout?: ReturnType<typeof setTimeout>;
+  private ready = false;
 
   constructor(
     private readonly ws: WebSocket,
@@ -84,12 +100,19 @@ class OpenAIRealtimeSession implements LiveModelSession {
     private readonly callbacks: LiveModelCallbacks,
   ) {
     this.ws.on("message", (raw) => this.handleMessage(raw));
-    this.ws.on("close", (code, reason) => callbacks.onClose?.({ code, reason: reason.toString("utf8") }));
+    this.ws.on("close", (code, reason) => {
+      this.clearCancelAckTimeout();
+      callbacks.onClose?.({ code, reason: reason.toString("utf8") });
+    });
     this.ws.on("error", (error) => callbacks.onError?.(error));
   }
 
   configure(systemInstruction: string): void {
     this.sendJson(buildOpenAISessionUpdate(this.config, systemInstruction));
+  }
+
+  markReady(): void {
+    this.ready = true;
   }
 
   async sendRealtimeAudio(audio: LiveModelAudio): Promise<void> {
@@ -101,7 +124,7 @@ class OpenAIRealtimeSession implements LiveModelSession {
       type: "conversation.item.create",
       item: { type: "message", role: "user", content: [{ type: "input_text", text }] },
     });
-    this.createResponse();
+    this.requestResponse();
   }
 
   async sendAudioStreamEnd(): Promise<void> {
@@ -109,22 +132,20 @@ class OpenAIRealtimeSession implements LiveModelSession {
       return;
     }
     this.sendJson({ type: "input_audio_buffer.commit" });
-    this.createResponse();
+    this.requestResponse();
   }
 
   async cancelResponse(_reason?: string, truncate?: RealtimeResponseTruncation): Promise<boolean> {
-    const shouldCancel = this.responsePending || this.responseActive;
-    if (!shouldCancel && !truncate) {
+    const responseInFlight = this.responsePending || this.responseActive;
+    if (!responseInFlight && !this.cancellationPending && !truncate) {
       return false;
     }
-    if (shouldCancel) {
-      this.sendJson(buildOpenAIResponseCancel());
+    if (responseInFlight && !this.cancellationPending) {
+      this.beginCancellation();
     }
     if (truncate) {
       this.sendJson(buildOpenAIConversationItemTruncate(truncate));
     }
-    this.responsePending = false;
-    this.responseActive = false;
     return true;
   }
 
@@ -136,31 +157,57 @@ class OpenAIRealtimeSession implements LiveModelSession {
       type: "conversation.item.create",
       item: { type: "function_call_output", call_id: call.id, output: JSON.stringify(response) },
     });
-    this.createResponse();
+    this.requestResponse();
   }
 
   async close(): Promise<void> {
+    this.clearCancelAckTimeout();
+    this.responseCreateQueued = false;
     closeWebSocket(this.ws, 1000, "session closed");
   }
 
   private handleMessage(raw: WebSocket.RawData): void {
     const event = parseOpenAIEvent(raw);
     if (!event) {
-      this.callbacks.onError?.(new Error("OpenAI Realtime event was not valid JSON."));
+      this.handleProviderError(new Error("OpenAI Realtime event was not valid JSON."), true);
       return;
     }
-    this.trackResponseState(event);
     if ((event as { type?: string }).type === "error") {
-      this.callbacks.onError?.((event as { error?: unknown }).error ?? event);
+      this.handleProviderError((event as { error?: unknown }).error ?? event);
+      return;
     }
-    for (const modelEvent of normalizeOpenAIRealtimeEvent(event, this.config.outputAudioFormat)) {
+    const modelEvents = normalizeOpenAIRealtimeEvent(event, this.config.outputAudioFormat);
+    const deliverableEvents: LiveModelEvent[] = [];
+    for (const modelEvent of modelEvents) {
       if (modelEvent.type === "tool_call") {
-        const key = modelEvent.call.id ?? `${modelEvent.call.name}:${JSON.stringify(modelEvent.call.args)}`;
-        if (this.handledToolCalls.has(key)) {
+        const fingerprint = `${modelEvent.call.name}\0${JSON.stringify(modelEvent.call.args)}`;
+        const key = modelEvent.call.id ?? fingerprint;
+        const handledFingerprint = this.handledToolCalls.get(key);
+        if (handledFingerprint && handledFingerprint !== fingerprint) {
+          this.handleProviderError(
+            new Error("OpenAI Realtime reused a tool-call id for different tool data."),
+          );
+          return;
+        }
+        if (handledFingerprint) {
           continue;
         }
-        this.handledToolCalls.add(key);
+        if (this.handledToolCalls.size >= OPENAI_MAX_HANDLED_TOOL_CALLS) {
+          const oldest = this.handledToolCalls.keys().next().value;
+          if (oldest) this.handledToolCalls.delete(oldest);
+        }
+        this.handledToolCalls.set(key, fingerprint);
       }
+      deliverableEvents.push(modelEvent);
+    }
+    if (deliverableEvents.filter((modelEvent) => modelEvent.type === "tool_call").length > 1) {
+      this.handleProviderError(
+        new Error("OpenAI Realtime returned multiple tool calls in one response; this session requires serialized tools."),
+      );
+      return;
+    }
+    this.trackResponseState(event, deliverableEvents.some((modelEvent) => modelEvent.type === "tool_call"));
+    for (const modelEvent of deliverableEvents) {
       this.callbacks.onEvent(modelEvent);
     }
   }
@@ -169,15 +216,16 @@ class OpenAIRealtimeSession implements LiveModelSession {
     if (this.ws.readyState !== WebSocket.OPEN) {
       throw new Error("OpenAI Realtime WebSocket is not open.");
     }
-    this.ws.send(JSON.stringify(payload));
+    const serialized = JSON.stringify(payload);
+    const payloadBytes = Buffer.byteLength(serialized, "utf8");
+    if (this.ws.bufferedAmount + payloadBytes > OPENAI_MAX_BUFFERED_BYTES) {
+      this.ws.terminate();
+      throw new Error("OpenAI Realtime WebSocket exceeded the safe outbound buffer limit.");
+    }
+    this.ws.send(serialized);
   }
 
-  private createResponse(): void {
-    this.sendJson({ type: "response.create" });
-    this.responsePending = true;
-  }
-
-  private trackResponseState(event: any): void {
+  private trackResponseState(event: any, deferQueuedResponse = false): void {
     if (event?.type === "response.created") {
       this.responsePending = false;
       this.responseActive = true;
@@ -191,6 +239,84 @@ class OpenAIRealtimeSession implements LiveModelSession {
     ) {
       this.responsePending = false;
       this.responseActive = false;
+      this.cancellationPending = false;
+      this.clearCancelAckTimeout();
+      if (!deferQueuedResponse) this.flushQueuedResponse();
+    }
+  }
+
+  private requestResponse(): void {
+    if (this.responsePending || this.responseActive || this.cancellationPending) {
+      this.responseCreateQueued = true;
+      return;
+    }
+    this.responseCreateQueued = false;
+    this.createResponse();
+  }
+
+  private handleProviderError(error: unknown, closeBeforeReady = false): void {
+    this.callbacks.onError?.(error);
+    if (!this.ready && !closeBeforeReady) return;
+    this.responsePending = false;
+    this.responseActive = false;
+    this.responseCreateQueued = false;
+    this.cancellationPending = false;
+    this.clearCancelAckTimeout();
+    closeWebSocket(this.ws, 1011, "OpenAI Realtime provider error");
+  }
+
+  private flushQueuedResponse(): void {
+    if (
+      !this.responseCreateQueued ||
+      this.responsePending ||
+      this.responseActive ||
+      this.cancellationPending
+    ) {
+      return;
+    }
+    this.responseCreateQueued = false;
+    try {
+      this.createResponse();
+    } catch (error) {
+      this.callbacks.onError?.(error);
+    }
+  }
+
+  private createResponse(): void {
+    this.responsePending = true;
+    try {
+      this.sendJson({ type: "response.create" });
+    } catch (error) {
+      this.responsePending = false;
+      throw error;
+    }
+  }
+
+  private beginCancellation(): void {
+    this.cancellationPending = true;
+    this.cancelAckTimeout = setTimeout(() => {
+      this.cancelAckTimeout = undefined;
+      if (!this.cancellationPending) return;
+      const error = new Error(
+        `OpenAI Realtime did not confirm response cancellation within ${OPENAI_CANCEL_ACK_TIMEOUT_MS}ms.`,
+      );
+      this.callbacks.onError?.(error);
+      closeWebSocket(this.ws, 1011, "OpenAI Realtime cancel timeout");
+    }, OPENAI_CANCEL_ACK_TIMEOUT_MS);
+    this.cancelAckTimeout.unref?.();
+    try {
+      this.sendJson(buildOpenAIResponseCancel());
+    } catch (error) {
+      this.cancellationPending = false;
+      this.clearCancelAckTimeout();
+      throw error;
+    }
+  }
+
+  private clearCancelAckTimeout(): void {
+    if (this.cancelAckTimeout) {
+      clearTimeout(this.cancelAckTimeout);
+      this.cancelAckTimeout = undefined;
     }
   }
 }
@@ -199,7 +325,7 @@ function closeWebSocket(ws: WebSocket, code: number, reason: string): void {
   if (ws.readyState === WebSocket.OPEN) {
     ws.close(code, reason);
   } else if (ws.readyState === WebSocket.CONNECTING) {
-    ws.once("open", () => ws.close(code, reason));
+    ws.terminate();
   }
 }
 
@@ -209,9 +335,11 @@ export function normalizeOpenAIRealtimeEvent(
 ): LiveModelEvent[] {
   const events: LiveModelEvent[] = [];
   const root = event as any;
+  const calls = extractOpenAIFunctionCalls(root);
 
   const response = normalizeOpenAIResponseLifecycle(root);
-  if (response) events.push(response);
+  const deferTerminalResponse = calls.length > 0 && response?.status !== "started";
+  if (response && !deferTerminalResponse) events.push(response);
 
   if ((root?.type === "response.output_audio.delta" || root?.type === "response.audio.delta") && typeof root.delta === "string") {
     events.push({ type: "audio", audio: { data: root.delta, mimeType: openAiAudioMimeType(outputAudioFormat) } });
@@ -241,14 +369,16 @@ export function normalizeOpenAIRealtimeEvent(
       ...(typeof root.audio_start_ms === "number" ? { audioStartMs: root.audio_start_ms } : {}),
     });
   }
-  for (const call of extractOpenAIFunctionCalls(root)) {
+  for (const call of calls) {
     events.push({ type: "tool_call", call });
   }
-  events.push({ type: "raw", message: event });
+  if (response && deferTerminalResponse) events.push(response);
   return events;
 }
 
-function normalizeOpenAIResponseLifecycle(root: any): LiveModelEvent | undefined {
+function normalizeOpenAIResponseLifecycle(
+  root: any,
+): Extract<LiveModelEvent, { type: "response" }> | undefined {
   const responseId = typeof root?.response?.id === "string"
     ? root.response.id
     : typeof root?.response_id === "string"

--- a/src/application/live-gateway/live-gateway-session.ts
+++ b/src/application/live-gateway/live-gateway-session.ts
@@ -1,6 +1,6 @@
 import { createHash, randomUUID } from "node:crypto";
 import { errorToMessage } from "../../domain/error-message.js";
-import { isPcmMimeType } from "../../domain/audio/pcm.js";
+import { isPcmMimeType, requirePcmSampleRate } from "../../domain/audio/pcm.js";
 import { makeSessionKey, type AppConfig } from "../../config.js";
 import type { Logger } from "../../logger.js";
 import {
@@ -27,6 +27,25 @@ import {
 import { buildSystemInstruction } from "./system-instruction.js";
 
 const MAX_PENDING_APPROVALS = 128;
+const MAX_PROCESSED_APPROVAL_RESPONSES = 256;
+const MAX_PENDING_PROVIDER_EVENTS = 256;
+const MAX_PENDING_PROVIDER_EVENT_BYTES = 8 * 1024 * 1024;
+const MAX_PROVIDER_TRANSCRIPT_CHARS = 20_000;
+const MAX_HERMES_OUTPUT_CHARS = 200_000;
+const MAX_PUBLIC_RUN_EVENT_BYTES = 256_000;
+const MAX_PUBLIC_USAGE_BYTES = 64_000;
+const MAX_RUN_START_CLOSE_WAIT_MS = 5_000;
+const MAX_PROVIDER_CANCEL_WAIT_MS = 1_000;
+const MAX_PROVIDER_IO_WAIT_MS = 10_000;
+const MAX_PENDING_CLIENT_MESSAGES = 256;
+const MAX_PENDING_CLIENT_BYTES = 8 * 1024 * 1024;
+const MAX_CLIENT_MESSAGE_ERRORS = 16;
+const MAX_PENDING_PROVIDER_TOOL_CALLS = 32;
+const MAX_CONCURRENT_PROVIDER_TOOL_CALLS = 4;
+const MAX_PROCESSED_PROVIDER_TOOL_CALLS = 256;
+const MAX_PROVIDER_TOOL_CALL_ARGS_BYTES = 100_000;
+const MAX_PROVIDER_TOOL_RESPONSE_BYTES = 256_000;
+const MAX_CACHED_PROVIDER_TOOL_RESPONSE_BYTES = 4 * 1024 * 1024;
 
 export interface LiveGatewaySessionDeps {
   config: AppConfig;
@@ -38,6 +57,24 @@ export interface LiveGatewaySessionDeps {
 interface PendingApprovalEnvelope {
   runId: string;
   approval: HermesApprovalDetails;
+  sourceKey: string;
+  semanticFingerprint: string;
+}
+
+interface ProcessedApprovalResponse {
+  fingerprint: string;
+  response: Extract<ServerMessage, { type: "approval.responded" }>;
+}
+
+interface ProviderToolCallRecord {
+  fingerprint: string;
+  name: string;
+  state: "pending" | "done";
+  response?: Record<string, unknown>;
+  responseBytes?: number;
+  replayUnavailable?: boolean;
+  replayPending?: boolean;
+  startMarkerActive?: boolean;
 }
 
 export class LiveGatewaySession {
@@ -52,7 +89,38 @@ export class LiveGatewaySession {
   private activeRunId: string | undefined;
   private hermesRunActive = false;
   private pendingApprovals: PendingApprovalEnvelope[] = [];
+  private readonly processedApprovalResponses = new Map<string, ProcessedApprovalResponse>();
+  private readonly processedApprovalSources = new Map<string, string>();
+  private readonly stopRequestedRunIds = new Set<string>();
+  private readonly stopIntentRunIds = new Set<string>();
+  private readonly stopNotificationRunIds = new Set<string>();
+  private readonly stopRunOperations = new Map<
+    string,
+    Promise<Awaited<ReturnType<HermesRunsPort["stopRun"]>>>
+  >();
+  private approvalSubmissionInFlight = false;
+  private deferredProviderTerminal?: Extract<LiveModelEvent, { type: "response" }>;
+  private pendingRunStart?: Promise<Awaited<ReturnType<HermesRunsPort["startRun"]>>>;
+  private runStartController?: AbortController;
+  private pendingLiveConnect?: Promise<LiveModelSession>;
+  private readonly providerCloseOperations = new WeakMap<LiveModelSession, Promise<boolean>>();
+  private readonly pendingProviderCleanupOperations = new WeakMap<Promise<LiveModelSession>, Promise<boolean>>();
+  private closePromise?: Promise<void>;
+  private clientClosePromise?: Promise<void>;
+  private requestedClientClose?: { code: number; reason: string; requestId?: string };
+  private sessionShutdownUnconfirmed = false;
+  private readonly runContainmentOperations = new Map<string, Promise<void>>();
   private messageQueue: Promise<void> = Promise.resolve();
+  private pendingClientMessages = 0;
+  private pendingClientBytes = 0;
+  private clientInputOverflowed = false;
+  private clientMessageErrors = 0;
+  private readonly providerToolCalls = new Map<string, ProviderToolCallRecord>();
+  private readonly providerToolOperations: Array<() => Promise<void>> = [];
+  private activeProviderToolOperations = 0;
+  private pendingProviderToolCalls = 0;
+  private pendingStartToolCalls = 0;
+  private cachedProviderToolResponseBytes = 0;
 
   constructor(
     private readonly client: ClientConnectionPort,
@@ -61,7 +129,52 @@ export class LiveGatewaySession {
 
   bind(): void {
     this.client.onMessage((data) => {
-      this.messageQueue = this.messageQueue.then(() => this.handleRawMessage(data));
+      if (this.closing || this.clientInputOverflowed) return;
+      const bytes = clientInboundFrameBytes(data);
+      if (
+        this.pendingClientMessages >= MAX_PENDING_CLIENT_MESSAGES ||
+        this.pendingClientBytes + bytes > MAX_PENDING_CLIENT_BYTES
+      ) {
+        this.clientInputOverflowed = true;
+        this.fail(
+          "client_input_backpressure",
+          new Error("Client sent messages faster than the realtime session could process them."),
+          false,
+        );
+        void this.closeClientAfterCleanup(1009, "client input backpressure");
+        return;
+      }
+      let message: ClientMessage;
+      let requestId: string | undefined;
+      try {
+        const text = typeof data === "string" ? data : new TextDecoder().decode(data);
+        const parsed = JSON.parse(text) as unknown;
+        requestId = requestIdFromUnknown(parsed);
+        message = parseClientMessage(parsed);
+      } catch (error) {
+        this.handleClientMessageFailure(error, requestId);
+        return;
+      }
+      this.pendingClientMessages += 1;
+      this.pendingClientBytes += bytes;
+      const processMessage = async () => {
+        try {
+          if (!this.clientInputOverflowed && !this.closing) {
+            await this.handleClientMessage(message);
+            this.clientMessageErrors = 0;
+          }
+        } catch (error) {
+          this.handleClientMessageFailure(error, message.id);
+        } finally {
+          this.pendingClientMessages -= 1;
+          this.pendingClientBytes -= bytes;
+        }
+      };
+      if (isPreemptiveClientControl(message, Boolean(this.liveSession))) {
+        void processMessage();
+      } else {
+        this.messageQueue = this.messageQueue.then(processMessage);
+      }
     });
     this.client.onClose(() => {
       void this.close();
@@ -72,7 +185,7 @@ export class LiveGatewaySession {
   }
 
   async start(message: Extract<ClientMessage, { type: "session.start" }>): Promise<void> {
-    if (message.protocolVersion !== undefined && message.protocolVersion !== HERMES_LIVE_PROTOCOL_VERSION) {
+    if (message.protocolVersion !== HERMES_LIVE_PROTOCOL_VERSION) {
       this.fail(
         "unsupported_protocol_version",
         new Error(
@@ -91,6 +204,7 @@ export class LiveGatewaySession {
     this.starting = true;
     let liveSession: LiveModelSession | undefined;
     let clearProviderReadyTimeout = () => {};
+    let startupPhase: "hermes" | "realtime" = "hermes";
     try {
       this.profileId = this.deps.config.server.trustClientIdentity
         ? message.profileId ?? this.deps.config.server.defaultProfileId
@@ -100,7 +214,9 @@ export class LiveGatewaySession {
         : this.deps.config.server.defaultUserLabel;
       this.sessionKey = makeSessionKey(this.deps.config.server.sessionPrefix, this.profileId, this.userLabel);
       const capabilities = await this.deps.hermes.assertRunsSupported(this.abort.signal);
+      startupPhase = "realtime";
       const pendingEvents: LiveModelEvent[] = [];
+      let pendingEventBytes = 0;
       let providerOpen = false;
       let readySent = false;
       let providerStartupFailed = false;
@@ -135,17 +251,18 @@ export class LiveGatewaySession {
         return true;
       };
       const sendReady = () => {
-        if (readySent || !providerOpen || !this.liveSession || this.closing) {
+        if (
+          readySent ||
+          providerStartupFailed ||
+          providerReadyTimedOut ||
+          !providerOpen ||
+          !this.liveSession ||
+          this.closing
+        ) {
           return;
         }
         clearProviderReadyTimeout();
-        const hermesInfo: { model?: string; capabilities?: Record<string, unknown> } = {};
-        if (typeof capabilities.model === "string") {
-          hermesInfo.model = capabilities.model;
-        }
-        if (capabilities.features) {
-          hermesInfo.capabilities = capabilities.features;
-        }
+        const hermesInfo = publicHermesCapabilities(capabilities);
         this.send({
           type: "session.ready",
           protocolVersion: HERMES_LIVE_PROTOCOL_VERSION,
@@ -157,54 +274,82 @@ export class LiveGatewaySession {
         readySent = true;
         resolveProviderReady();
         for (const event of pendingEvents.splice(0)) {
-          this.handleLiveModelEvent(event);
+          this.dispatchLiveModelEvent(event);
         }
+        pendingEventBytes = 0;
       };
-      const connect = this.deps.liveModel
-        .connect({
-          sessionId: this.id,
-          systemInstruction: buildSystemInstruction(),
-          ...(this.sessionKey ? { safetyIdentifier: safetyIdentifierForSessionKey(this.sessionKey) } : {}),
-          callbacks: {
-            onOpen: () => {
-              providerOpen = true;
-              sendReady();
-            },
-            onClose: (event) => {
-              if (failProviderStartup(new Error("Realtime provider session closed before ready."))) {
-                return;
-              }
-              this.send({ type: "log", level: "info", message: "Realtime provider session closed", data: event });
-              if (!this.closing) {
-                this.fail("realtime_provider_closed", new Error("Realtime provider session closed."), true);
-                void this.close().finally(() => this.client.close(1011, "realtime provider closed"));
-              }
-            },
-            onError: (error) => {
-              if (failProviderStartup(error)) {
-                return;
-              }
-              this.fail("realtime_provider_error", error, true);
-            },
-            onEvent: (event) => {
-              if (!readySent) {
-                pendingEvents.push(event);
-                return;
-              }
-              this.handleLiveModelEvent(event);
-            },
+      const connect = this.deps.liveModel.connect({
+        sessionId: this.id,
+        systemInstruction: buildSystemInstruction(),
+        ...(this.sessionKey ? { safetyIdentifier: safetyIdentifierForSessionKey(this.sessionKey) } : {}),
+        callbacks: {
+          onOpen: () => {
+            providerOpen = true;
+            sendReady();
           },
-        })
-        .then(async (session) => {
-          if (providerReadyTimedOut || providerStartupFailed || this.closing) {
-            await session.close().catch(() => undefined);
-          }
-          return session;
-        });
+          onClose: (event) => {
+            if (failProviderStartup(new Error("Realtime provider session closed before ready."))) {
+              return;
+            }
+            this.deps.logger.info("realtime provider session closed", {
+              sessionId: this.id,
+              ...providerCloseLogDetail(event),
+            });
+            if (this.closing) return;
+            const closeDetail = publicProviderCloseEvent(event);
+            this.send({
+              type: "log",
+              level: "info",
+              message: "Realtime provider session closed",
+              ...(closeDetail ? { data: closeDetail } : {}),
+            });
+            this.fail("realtime_provider_closed", new Error("Realtime provider session closed."), true);
+            void this.closeClientAfterCleanup(1011, "realtime provider closed");
+          },
+          onError: (error) => {
+            if (failProviderStartup(error)) {
+              return;
+            }
+            this.deps.logger.warn("realtime provider reported an error", {
+              sessionId: this.id,
+              error: errorToMessage(error),
+            });
+            if (this.closing) return;
+            this.fail(
+              "realtime_provider_error",
+              new Error("Realtime provider reported an error. Check the gateway logs."),
+              true,
+            );
+          },
+          onEvent: (event) => {
+            if (this.closing) return;
+            if (!readySent) {
+              const eventBytes = safeJsonByteLength(event);
+              if (
+                pendingEvents.length >= MAX_PENDING_PROVIDER_EVENTS ||
+                !Number.isFinite(eventBytes) ||
+                eventBytes > MAX_PENDING_PROVIDER_EVENT_BYTES - pendingEventBytes
+              ) {
+                failProviderStartup(new Error("Realtime provider exceeded the safe pre-ready event queue limit."));
+                return;
+              }
+              pendingEvents.push(event);
+              pendingEventBytes += eventBytes;
+              return;
+            }
+            this.dispatchLiveModelEvent(event);
+          },
+        },
+      });
+      this.pendingLiveConnect = connect;
+      void connect.catch(() => {
+        if (this.pendingLiveConnect === connect) this.pendingLiveConnect = undefined;
+      });
       liveSession = await Promise.race([connect, providerReadyDeadline, providerReadyFailure]);
+      if (this.pendingLiveConnect === connect) this.pendingLiveConnect = undefined;
       if (this.closing) {
         clearProviderReadyTimeout();
-        await liveSession.close().catch(() => undefined);
+        await this.closeProviderSessionWithinDeadline(liveSession, "session close during realtime startup");
         return;
       }
       this.liveSession = liveSession;
@@ -212,12 +357,46 @@ export class LiveGatewaySession {
       await Promise.race([providerReady, providerReadyDeadline, providerReadyFailure]);
     } catch (error) {
       clearProviderReadyTimeout();
-      await liveSession?.close().catch(() => undefined);
+      const startupCleanupDeadlineMs = this.providerStartupCleanupDeadlineMs();
+      let providerCleanupConfirmed = liveSession
+        ? await this.closeProviderSessionWithinDeadline(
+            liveSession,
+            "realtime startup failure",
+            startupCleanupDeadlineMs,
+          )
+        : true;
+      const pendingConnect = this.pendingLiveConnect;
+      if (pendingConnect) {
+        providerCleanupConfirmed = (
+          await this.closePendingProviderConnectWithinDeadline(
+            pendingConnect,
+            "realtime startup failure",
+            startupCleanupDeadlineMs,
+          )
+        ) && providerCleanupConfirmed;
+      }
       if (liveSession && this.liveSession === liveSession) {
         this.liveSession = undefined;
       }
       if (!this.closing) {
-        this.fail("session_start_failed", error, true, message.id);
+        this.deps.logger.warn("live session startup failed", {
+          sessionId: this.id,
+          phase: startupPhase,
+          error: errorToMessage(error),
+        });
+        this.fail(
+          "session_start_failed",
+          new Error(
+            startupPhase === "hermes"
+              ? "Hermes API readiness check failed. Check the gateway logs."
+              : publicRealtimeStartupError(error),
+          ),
+          providerCleanupConfirmed,
+          message.id,
+        );
+        if (!providerCleanupConfirmed) {
+          await this.closeClientAfterCleanup(1011, "realtime provider startup cleanup unconfirmed", message.id);
+        }
       }
     } finally {
       this.starting = false;
@@ -225,33 +404,258 @@ export class LiveGatewaySession {
   }
 
   async close(): Promise<void> {
-    if (this.closing) {
-      return;
-    }
+    if (this.closePromise) return this.closePromise;
     this.closing = true;
-    this.clearPendingApprovals();
-    if (this.activeRunId) {
-      await this.deps.hermes.stopRun(this.activeRunId, this.hermesRequestOptions()).catch(() => undefined);
-    }
-    this.abort.abort();
-    await this.liveSession?.close().catch(() => undefined);
+    this.closePromise = this.performClose();
+    return this.closePromise;
   }
 
-  private async handleRawMessage(raw: ClientInboundFrame): Promise<void> {
-    let requestId: string | undefined;
+  private closeClientAfterCleanup(code: number, reason: string, requestId?: string): Promise<void> {
+    const correlatedRequestId = requestId ?? this.requestedClientClose?.requestId;
+    const requested = { code, reason, ...(correlatedRequestId ? { requestId: correlatedRequestId } : {}) };
+    if (
+      !this.requestedClientClose ||
+      clientCloseSeverity(requested.code) > clientCloseSeverity(this.requestedClientClose.code)
+    ) {
+      this.requestedClientClose = requested;
+    } else if (requestId && !this.requestedClientClose.requestId) {
+      this.requestedClientClose.requestId = requestId;
+    }
+    if (this.clientClosePromise) return this.clientClosePromise;
+    this.clientClosePromise = (async () => {
+      await this.close();
+      const outcome = this.requestedClientClose ?? requested;
+      if (this.sessionShutdownUnconfirmed) {
+        this.send({
+          type: "session.error",
+          code: "session_shutdown_unconfirmed",
+          message: "The gateway could not confirm complete session shutdown. Verify any active task state in Hermes.",
+          recoverable: false,
+          ...(outcome.requestId ? { requestId: outcome.requestId } : {}),
+        });
+        this.client.close(1011, "session shutdown unconfirmed");
+        return;
+      }
+      this.client.close(outcome.code, outcome.reason);
+    })();
+    return this.clientClosePromise;
+  }
+
+  private async performClose(): Promise<void> {
+    this.clearPendingApprovals();
+    this.deferredProviderTerminal = undefined;
+    this.providerToolOperations.length = 0;
+    if (this.approvalSubmissionInFlight) {
+      this.sessionShutdownUnconfirmed = true;
+      this.deps.logger.error("approval submission was still in flight while closing the voice session", {
+        sessionId: this.id,
+        runId: this.activeRunId,
+      });
+    }
+    const providerClose = this.closeProviderResourcesForSessionClose();
+    this.abort.abort();
+    const pendingStart = this.pendingRunStart;
+    let startedDuringCloseRunId: string | undefined;
+    if (pendingStart) {
+      let startRejected = false;
+      const observedStart = pendingStart.then(
+        (started) => {
+          startedDuringCloseRunId = started.runId;
+          return started;
+        },
+        (error) => {
+          startRejected = true;
+          throw error;
+        },
+      );
+      const settled = await settlesWithin(
+        observedStart,
+        Math.min(this.deps.config.hermes.timeoutMs, MAX_RUN_START_CLOSE_WAIT_MS),
+      );
+      if (!settled) {
+        this.sessionShutdownUnconfirmed = true;
+        this.deps.logger.error("Hermes run start did not settle before session close deadline", {
+          sessionId: this.id,
+        });
+        void pendingStart
+          .then((started) => this.stopLateStartedRun(started.runId))
+          .catch(() => undefined);
+        this.runStartController?.abort(new Error("Voice session closed before Hermes returned a run id."));
+      } else if (startRejected) {
+        this.sessionShutdownUnconfirmed = true;
+        this.deps.logger.error("Hermes run start rejected while session close was in progress", {
+          sessionId: this.id,
+        });
+      }
+    }
+    const ownedRunId = this.activeRunId ?? startedDuringCloseRunId;
+    if (ownedRunId && !this.stopRequestedRunIds.has(ownedRunId)) {
+      const runId = ownedRunId;
+      try {
+        await this.stopOwnedRunForClose(runId);
+      } catch (error) {
+        this.sessionShutdownUnconfirmed = true;
+        this.deps.logger.error("failed to stop owned Hermes run while closing", {
+          sessionId: this.id,
+          runId,
+          error: errorToMessage(error),
+        });
+      }
+    }
+    await providerClose;
+  }
+
+  private async closeProviderResourcesForSessionClose(): Promise<void> {
+    const operations: Promise<unknown>[] = [];
+    if (this.liveSession) {
+      operations.push(this.closeProviderSessionWithinDeadline(this.liveSession, "voice session close"));
+    }
+
+    const pendingConnect = this.pendingLiveConnect;
+    if (pendingConnect) {
+      operations.push(this.closePendingProviderConnectWithinDeadline(
+        pendingConnect,
+        "voice session close",
+        this.providerStartupCleanupDeadlineMs(),
+      ));
+    }
+
+    await Promise.all(operations);
+  }
+
+  private closePendingProviderConnectWithinDeadline(
+    pendingConnect: Promise<LiveModelSession>,
+    context: string,
+    timeoutMs: number,
+  ): Promise<boolean> {
+    const existing = this.pendingProviderCleanupOperations.get(pendingConnect);
+    if (existing) return existing;
+    const lateCleanup = pendingConnect.then(
+      (session) => this.closeProviderSessionWithinDeadline(session, `late connection after ${context}`, timeoutMs),
+      () => true,
+    ).finally(() => {
+      if (this.pendingLiveConnect === pendingConnect) this.pendingLiveConnect = undefined;
+    });
+    const operation = withDeadline(
+      lateCleanup,
+      timeoutMs,
+      "Realtime provider connection and cleanup did not settle before the safety deadline.",
+    ).then(
+      (confirmed) => confirmed,
+      (error) => {
+        this.sessionShutdownUnconfirmed = true;
+        this.deps.logger.error("failed to confirm pending realtime provider connection cleanup", {
+          sessionId: this.id,
+          context,
+          error: errorToMessage(error),
+        });
+        return false;
+      },
+    );
+    this.pendingProviderCleanupOperations.set(pendingConnect, operation);
+    return operation;
+  }
+
+  private closeProviderSessionWithinDeadline(
+    session: LiveModelSession,
+    context: string,
+    timeoutMs = MAX_RUN_START_CLOSE_WAIT_MS,
+  ): Promise<boolean> {
+    const existing = this.providerCloseOperations.get(session);
+    if (existing) return existing;
+    const operation = withDeadline(
+      Promise.resolve().then(() => session.close()),
+      timeoutMs,
+      "Realtime provider session close did not settle before the safety deadline.",
+    ).then(
+      () => true,
+      (error) => {
+        this.sessionShutdownUnconfirmed = true;
+        this.deps.logger.error("failed to confirm realtime provider session close", {
+          sessionId: this.id,
+          context,
+          error: errorToMessage(error),
+        });
+        return false;
+      },
+    );
+    this.providerCloseOperations.set(session, operation);
+    return operation;
+  }
+
+  private providerStartupCleanupDeadlineMs(): number {
+    return Math.max(
+      1,
+      Math.min(this.deps.config.server.providerReadyTimeoutMs, MAX_RUN_START_CLOSE_WAIT_MS),
+    );
+  }
+
+  private async stopOwnedRunForClose(runId: string): Promise<void> {
+    if (this.stopRequestedRunIds.has(runId)) return;
+    const pending = this.stopRunOperations.get(runId);
+    if (pending) {
+      const settled = await settlesWithin(
+        pending,
+        Math.max(1, Math.min(this.deps.config.hermes.timeoutMs, 5_000)),
+      );
+      if (settled) {
+        try {
+          await pending;
+          return;
+        } catch {
+          // Retry below with a detached deadline if the session-scoped request was aborted.
+        }
+      } else {
+        if (this.stopRunOperations.get(runId) === pending) {
+          this.stopRunOperations.delete(runId);
+        }
+        this.deps.logger.error("Hermes stop request did not settle before the session close deadline", {
+          sessionId: this.id,
+          runId,
+        });
+      }
+    }
+    if (this.stopRequestedRunIds.has(runId)) return;
+    const deadlineMs = Math.max(1, Math.min(this.deps.config.hermes.timeoutMs, 5_000));
+    const controller = new AbortController();
+    const timeout = setTimeout(
+      () => controller.abort(new Error("Hermes stop deadline exceeded while closing the voice session.")),
+      deadlineMs,
+    );
+    timeout.unref?.();
     try {
-      const text = typeof raw === "string" ? raw : new TextDecoder().decode(raw);
-      const parsed = JSON.parse(text) as unknown;
-      requestId = requestIdFromUnknown(parsed);
-      await this.handleClientMessage(parseClientMessage(parsed));
+      await withDeadline(
+        this.requestHermesStop(runId, {
+          signal: controller.signal,
+          ...this.hermesDetachedRequestOptions(),
+        }),
+        deadlineMs,
+        "Hermes stop request did not settle before the session close deadline.",
+      );
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  private async stopLateStartedRun(runId: string): Promise<void> {
+    try {
+      await this.stopOwnedRunForClose(runId);
     } catch (error) {
-      this.fail("client_message_failed", error, false, requestId);
+      this.deps.logger.error("failed to stop Hermes run that started after session close deadline", {
+        sessionId: this.id,
+        runId,
+        error: errorToMessage(error),
+      });
     }
   }
 
   private async handleClientMessage(message: ClientMessage): Promise<void> {
     if (message.type === "session.start") {
       await this.start(message);
+      return;
+    }
+    if (message.type === "session.close") {
+      await this.closeClientAfterCleanup(1000, "session closed", message.id);
       return;
     }
     if (!this.liveSession) {
@@ -261,14 +665,17 @@ export class LiveGatewaySession {
     switch (message.type) {
       case "audio.input":
         validateAudioFrame(message.data, message.mimeType, this.deps.config.server.maxAudioBytes);
-        await this.liveSession.sendRealtimeAudio({ data: message.data, mimeType: message.mimeType });
+        await this.forwardRealtimeClientInput(
+          "audio",
+          () => this.liveSession!.sendRealtimeAudio({ data: message.data, mimeType: message.mimeType }),
+        );
         break;
       case "audio.end":
-        await this.liveSession.sendAudioStreamEnd();
+        await this.forwardRealtimeClientInput("audio turn", () => this.liveSession!.sendAudioStreamEnd());
         break;
       case "text.input":
         validateText(message.text, this.deps.config.server.maxTextChars, "Text input");
-        await this.liveSession.sendText(message.text);
+        await this.forwardRealtimeClientInput("text", () => this.liveSession!.sendText(message.text));
         break;
       case "response.cancel":
         await this.cancelRealtimeResponse(message.reason, message.truncate);
@@ -277,20 +684,16 @@ export class LiveGatewaySession {
         await this.handleApprovalResponse(message);
         break;
       case "run.stop":
-        await this.cancelRealtimeResponse(message.reason);
-        await this.stopRun(message.runId, message.reason);
-        break;
-      case "session.close":
-        await this.close();
-        this.client.close(1000, "session closed");
+        {
+          const stopOperation = this.stopRun(message.runId, message.reason);
+          void this.cancelRealtimeResponse(message.reason);
+          await stopOperation;
+        }
         break;
     }
   }
 
-  private async handleToolCall(call: LiveToolCall): Promise<void> {
-    if (!call.id) {
-      throw new Error(`Realtime tool call ${call.name || "<unknown>"} did not include an id.`);
-    }
+  private async executeToolCall(call: LiveToolCall): Promise<Record<string, unknown>> {
     switch (call.name) {
       case "start_hermes_run": {
         const message = stringArg(call, "message");
@@ -302,31 +705,147 @@ export class LiveGatewaySession {
         if (recentContext) {
           validateText(recentContext, this.deps.config.server.maxTextChars, "Recent voice context");
         }
-        const result = await this.startHermesRun(message, recentContext);
-        await this.liveSession?.sendToolResponse(call, result);
-        break;
+        return await this.startHermesRun(message, recentContext);
       }
       case "get_hermes_run_status": {
         const runId = this.resolveActiveRunId(stringArg(call, "run_id") || undefined);
-        const status = await this.deps.hermes.getRun(runId, this.hermesRequestOptions());
-        await this.liveSession?.sendToolResponse(call, { ok: true, status });
-        break;
+        try {
+          const status = await this.deps.hermes.getRun(runId, this.hermesRequestOptions());
+          assertHermesResponseRunCorrelation(status, runId, "status");
+          return { ok: true, status: publicHermesRunStatus(status, runId) };
+        } catch (error) {
+          this.deps.logger.warn("failed to read Hermes run status", {
+            sessionId: this.id,
+            runId,
+            error: errorToMessage(error),
+          });
+          throw new Error("Hermes run status could not be read. Check the gateway logs.");
+        }
       }
       case "stop_hermes_run": {
         const runId = stringArg(call, "run_id") || this.activeRunId;
-        const stopped = await this.stopRun(runId, stringArg(call, "reason"));
-        await this.liveSession?.sendToolResponse(call, stopped);
-        break;
+        return await this.stopRun(runId, stringArg(call, "reason"));
       }
       default:
-        await this.liveSession?.sendToolResponse(call, { ok: false, error: `Unknown hermes-live tool: ${call.name}` });
+        return { ok: false, error: `Unknown hermes-live tool: ${call.name}` };
     }
+  }
+
+  private enqueueProviderToolCall(call: LiveToolCall): void {
+    let id: string;
+    let fingerprint: string;
+    try {
+      id = requireProviderToolCallId(call);
+      fingerprint = providerToolCallFingerprint(call);
+    } catch (error) {
+      this.fail("tool_call_failed", error, false);
+      void this.closeClientAfterCleanup(1011, "invalid realtime tool call");
+      return;
+    }
+
+    const existing = this.providerToolCalls.get(id);
+    if (existing) {
+      if (existing.fingerprint !== fingerprint) {
+        this.fail(
+          "realtime_tool_call_conflict",
+          new Error("Realtime provider reused a tool-call id for different tool data."),
+          false,
+        );
+        void this.closeClientAfterCleanup(1011, "conflicting realtime tool call");
+        return;
+      }
+      if (existing.state === "done" && !existing.response) {
+        this.fail(
+          "realtime_tool_replay_unavailable",
+          new Error("A duplicate realtime tool call could not be replayed safely."),
+          false,
+        );
+        void this.closeClientAfterCleanup(1011, "realtime tool replay unavailable");
+        return;
+      }
+      if (existing.state === "done" && existing.response && !existing.replayPending) {
+        if (this.pendingProviderToolCalls >= MAX_PENDING_PROVIDER_TOOL_CALLS) {
+          this.failProviderToolQueueOverflow();
+          return;
+        }
+        existing.replayPending = true;
+        this.pendingProviderToolCalls += 1;
+        this.scheduleProviderToolOperation(async () => {
+          try {
+            await this.sendProviderToolResponse(call, existing.response!);
+          } finally {
+            existing.replayPending = false;
+            this.pendingProviderToolCalls -= 1;
+          }
+        });
+      }
+      return;
+    }
+
+    if (this.pendingProviderToolCalls >= MAX_PENDING_PROVIDER_TOOL_CALLS) {
+      this.failProviderToolQueueOverflow();
+      return;
+    }
+    if (this.providerToolCalls.size >= MAX_PROCESSED_PROVIDER_TOOL_CALLS) {
+      this.failProviderToolQueueOverflow();
+      return;
+    }
+
+    const record: ProviderToolCallRecord = {
+      fingerprint,
+      name: call.name,
+      state: "pending",
+      ...(call.name === "start_hermes_run" ? { startMarkerActive: true } : {}),
+    };
+    this.providerToolCalls.set(id, record);
+    this.pendingProviderToolCalls += 1;
+    if (call.name === "start_hermes_run") this.pendingStartToolCalls += 1;
+    this.scheduleProviderToolOperation(async () => {
+      let response: Record<string, unknown>;
+      try {
+        response = await this.executeToolCall(call);
+      } catch (error) {
+        const publicError = boundedText(errorToMessage(error), 2_000);
+        response = { ok: false, error: publicError };
+        this.fail("tool_call_failed", new Error(publicError), true);
+      }
+      response = boundedProviderToolResponse(response);
+      const responseBytes = safeJsonByteLength(response);
+      if (responseBytes <= MAX_CACHED_PROVIDER_TOOL_RESPONSE_BYTES - this.cachedProviderToolResponseBytes) {
+        record.response = response;
+        record.responseBytes = responseBytes;
+        this.cachedProviderToolResponseBytes += responseBytes;
+      } else {
+        record.replayUnavailable = true;
+      }
+      record.state = "done";
+      try {
+        await this.sendProviderToolResponse(call, response);
+      } finally {
+        this.pendingProviderToolCalls -= 1;
+        if (call.name === "start_hermes_run") {
+          this.releaseProviderStartMarker(record);
+        }
+      }
+    });
   }
 
   private handleLiveModelEvent(event: LiveModelEvent): void {
     if (event.type === "audio") {
-      this.send({ type: "audio.output", ...event.audio });
+      validateAudioFrame(event.audio.data, event.audio.mimeType, this.deps.config.server.maxAudioBytes);
+      const itemId = publicProviderIdentifier(event.audio.itemId);
+      const contentIndex = publicContentIndex(event.audio.contentIndex);
+      this.send({
+        type: "audio.output",
+        data: event.audio.data,
+        mimeType: event.audio.mimeType,
+        ...(itemId ? { itemId } : {}),
+        ...(contentIndex === undefined ? {} : { contentIndex }),
+      });
     } else if (event.type === "text") {
+      if (event.text.length > MAX_PROVIDER_TRANSCRIPT_CHARS) {
+        throw new Error(`Realtime provider transcript delta exceeds ${MAX_PROVIDER_TRANSCRIPT_CHARS} characters.`);
+      }
       this.send({
         type: "transcript.delta",
         speaker: event.speaker ?? "assistant",
@@ -334,34 +853,57 @@ export class LiveGatewaySession {
         ...(event.final === undefined ? {} : { final: event.final }),
       });
     } else if (event.type === "tool_call") {
-      void this.handleToolCall(event.call).catch(async (error) => {
-        this.fail("tool_call_failed", error, true);
-        if (event.call.id) {
-          await this.sendToolFailure(event.call, error);
-        }
-      });
+      this.enqueueProviderToolCall(event.call);
     } else if (event.type === "input_speech_started") {
+      const itemId = publicProviderIdentifier(event.itemId);
+      const audioStartMs = publicAudioStartMs(event.audioStartMs);
       this.send({
         type: "input.speech_started",
         provider: event.provider,
-        ...(event.itemId ? { itemId: event.itemId } : {}),
-        ...(event.audioStartMs === undefined ? {} : { audioStartMs: event.audioStartMs }),
+        ...(itemId ? { itemId } : {}),
+        ...(audioStartMs === undefined ? {} : { audioStartMs }),
       });
     } else if (event.type === "response") {
+      if (
+        event.status !== "started" &&
+        (this.hermesRunActive || this.pendingStartToolCalls > 0) &&
+        !this.activeRunId
+      ) {
+        this.deferredProviderTerminal = event;
+        return;
+      }
       if (event.status === "failed") {
+        this.deps.logger.warn("realtime provider response failed", {
+          sessionId: this.id,
+          error: boundedText(event.error ?? "Realtime response failed.", 2_000),
+        });
+        const responseId = publicProviderIdentifier(event.responseId);
         this.send({
           type: "response.failed",
-          ...(event.responseId ? { responseId: event.responseId } : {}),
-          error: event.error ?? "Realtime response failed.",
+          ...(responseId ? { responseId } : {}),
+          error: "Realtime provider response failed. Check the gateway logs.",
         });
       } else {
-        const responseId = event.responseId ? { responseId: event.responseId } : {};
+        const boundedResponseId = publicProviderIdentifier(event.responseId);
+        const responseId = boundedResponseId ? { responseId: boundedResponseId } : {};
         if (event.status === "started") this.send({ type: "response.started", ...responseId });
         else if (event.status === "completed") this.send({ type: "response.completed", ...responseId });
         else this.send({ type: "response.cancelled", ...responseId });
       }
-    } else {
-      this.send({ type: "realtime.message", message: event.message });
+    }
+  }
+
+  private dispatchLiveModelEvent(event: LiveModelEvent): void {
+    if (this.closing) return;
+    try {
+      this.handleLiveModelEvent(event);
+    } catch (error) {
+      this.fail(
+        "realtime_provider_event_invalid",
+        new Error(`Realtime provider emitted an invalid event: ${errorToMessage(error)}`),
+        false,
+      );
+      void this.closeClientAfterCleanup(1011, "invalid realtime provider event");
     }
   }
 
@@ -371,6 +913,9 @@ export class LiveGatewaySession {
     }
     if (this.hermesRunActive) {
       return { ok: false, error: "A Hermes run is already active for this voice session." };
+    }
+    if (this.closing) {
+      return { ok: false, error: "The voice session is closing and cannot start another Hermes run." };
     }
 
     this.clearPendingApprovals();
@@ -385,33 +930,60 @@ export class LiveGatewaySession {
     };
 
     try {
-      const started = await this.deps.hermes.startRun(runParams, this.abort.signal);
+      const runStartController = new AbortController();
+      this.runStartController = runStartController;
+      const pendingStart = this.deps.hermes.startRun(runParams, runStartController.signal).then((started) => {
+        if (!isRecordValue(started) || !isBoundedRunId(started.runId)) {
+          throw new Error("Hermes returned an invalid run start response.");
+        }
+        const normalized = {
+          runId: started.runId,
+          status: typeof started.status === "string" && started.status.length <= 128
+            ? started.status
+            : "started",
+        };
+        this.activeRunId = normalized.runId;
+        return normalized;
+      });
+      this.pendingRunStart = pendingStart;
+      let started: Awaited<typeof pendingStart>;
+      try {
+        started = await pendingStart;
+      } finally {
+        if (this.pendingRunStart === pendingStart) this.pendingRunStart = undefined;
+        if (this.runStartController === runStartController) this.runStartController = undefined;
+      }
       runId = started.runId;
-      this.activeRunId = runId;
+      if (this.closing) {
+        return { ok: false, run_id: runId, status: "cancelled" };
+      }
       this.send({ type: "run.started", runId, sessionId: this.id });
+      this.releaseOldestProviderStartMarker();
 
-      const transcript: string[] = [];
+      let transcript = "";
       let finalOutput = "";
       let usage: Record<string, unknown> | undefined;
-      let terminal = false;
 
       for await (const event of this.deps.hermes.streamRunEvents(runId, this.hermesRequestOptions())) {
+        assertHermesRunEventCorrelation(event, runId);
         this.forwardRunEvent(runId, event);
         if (event.event === "message.delta" && typeof event.delta === "string") {
-          transcript.push(event.delta);
+          transcript = appendBoundedText(transcript, event.delta, MAX_HERMES_OUTPUT_CHARS);
         } else if (event.event === "run.completed") {
-          terminal = true;
           this.clearPendingApprovals(runId);
-          finalOutput = typeof event.output === "string" ? event.output : transcript.join("");
-          usage = event.usage;
+          finalOutput = boundedText(
+            typeof event.output === "string" ? event.output : transcript,
+            MAX_HERMES_OUTPUT_CHARS,
+          );
+          usage = boundedUsage(event.usage);
           this.send({
             type: "run.completed",
             runId,
-            output: finalOutput || transcript.join(""),
+            output: finalOutput || transcript,
             ...(usage ? { usage } : {}),
           });
+          return { ok: true, run_id: runId, output: finalOutput || transcript, usage };
         } else if (event.event === "run.failed") {
-          terminal = true;
           this.clearPendingApprovals(runId);
           this.deps.logger.warn("Hermes run reported failure", {
             sessionId: this.id,
@@ -422,26 +994,25 @@ export class LiveGatewaySession {
             ok: false,
             run_id: runId,
             status: "failed",
-            output: transcript.join(""),
+            output: transcript,
             error: "Hermes run failed. Check the gateway logs for details.",
           };
         } else if (event.event === "run.cancelled") {
-          terminal = true;
           this.clearPendingApprovals(runId);
           return { ok: false, run_id: runId, status: "cancelled" };
         }
       }
 
-      if (!terminal) {
-        const output = transcript.join("");
-        const error = "Hermes run event stream ended before a terminal event.";
-        this.send({ type: "run.failed", runId, error });
-        return { ok: false, run_id: runId, status: "incomplete", output, error };
+      const output = transcript;
+      const error = "Hermes run event stream ended before a terminal event.";
+      if (this.closing) {
+        return { ok: false, run_id: runId, status: "cancelled", output };
       }
-
-      return { ok: true, run_id: runId, output: finalOutput || transcript.join(""), usage };
+      await this.containBrokenRun(runId, error);
+      return { ok: false, run_id: runId, status: "indeterminate", output, error };
     } catch (error) {
-      if (this.abort.signal.aborted) {
+      if (!runId) this.sessionShutdownUnconfirmed = true;
+      if (this.abort.signal.aborted || this.closing) {
         return {
           ok: false,
           ...(runId ? { run_id: runId } : {}),
@@ -449,37 +1020,104 @@ export class LiveGatewaySession {
         };
       }
       if (!runId) {
-        throw error;
+        this.deferredProviderTerminal = undefined;
+        this.deps.logger.warn("Hermes run failed to start", {
+          sessionId: this.id,
+          error: errorToMessage(error),
+        });
+        this.fail(
+          "hermes_run_start_outcome_indeterminate",
+          new Error("Hermes did not confirm whether the run started. Verify task state in Hermes before retrying."),
+          false,
+        );
+        await this.closeClientAfterCleanup(1011, "Hermes run start outcome indeterminate");
+        return { ok: false, status: "indeterminate", error: "Hermes run start outcome could not be confirmed." };
       }
       this.deps.logger.warn("Hermes run bridge failed", { sessionId: this.id, runId, error: errorToMessage(error) });
       const publicMessage = "Hermes run failed. Check the gateway logs for details.";
-      this.send({ type: "run.failed", runId, error: publicMessage });
-      return { ok: false, run_id: runId, status: "failed", error: publicMessage };
+      await this.containBrokenRun(runId, error);
+      return { ok: false, run_id: runId, status: "indeterminate", error: publicMessage };
     } finally {
       if (runId) {
         this.clearPendingApprovals(runId);
+        this.clearProcessedApprovalSources(runId);
       }
       this.hermesRunActive = false;
       if (runId && this.activeRunId === runId) {
         this.activeRunId = undefined;
       }
+      if (runId && !this.closing) {
+        this.stopRequestedRunIds.delete(runId);
+        this.stopNotificationRunIds.delete(runId);
+        this.stopIntentRunIds.delete(runId);
+      }
     }
   }
 
+  private containBrokenRun(runId: string, cause: unknown): Promise<void> {
+    const existing = this.runContainmentOperations.get(runId);
+    if (existing) return existing;
+    const operation = this.performBrokenRunContainment(runId, cause);
+    this.runContainmentOperations.set(runId, operation);
+    return operation;
+  }
+
+  private async performBrokenRunContainment(runId: string, cause: unknown): Promise<void> {
+    let stopRequested = false;
+    try {
+      await this.stopOwnedRunForClose(runId);
+      stopRequested = true;
+      this.clearPendingApprovals(runId);
+    } catch (stopError) {
+      this.deps.logger.error("Hermes run ownership became indeterminate", {
+        sessionId: this.id,
+        runId,
+        cause: errorToMessage(cause),
+        stopError: errorToMessage(stopError),
+      });
+    }
+    this.fail(
+      "hermes_run_outcome_indeterminate",
+      new Error(
+        stopRequested
+          ? "Hermes run events ended unexpectedly. A stop was requested, and the session is closing until terminal state can be confirmed."
+          : "Hermes run status could not be confirmed. The session is closing to prevent further work.",
+      ),
+      false,
+    );
+    await this.closeClientAfterCleanup(1011, "Hermes run outcome indeterminate");
+  }
+
+  private flushDeferredProviderTerminal(): void {
+    const deferred = this.deferredProviderTerminal;
+    if (!deferred) return;
+    this.deferredProviderTerminal = undefined;
+    if (this.closing) return;
+    this.handleLiveModelEvent(deferred);
+  }
+
   private forwardRunEvent(runId: string, event: HermesRunEvent): void {
+    if (
+      event.event === "approval.request" &&
+      (
+        this.stopIntentRunIds.has(runId) ||
+        this.stopRequestedRunIds.has(runId) ||
+        this.stopRunOperations.has(runId)
+      )
+    ) {
+      return;
+    }
     const publicEvent = publicHermesRunEvent(event, this.deps.config.server.runEventDetail);
     if (publicEvent) {
       this.send({ type: "run.event", runId, event: publicEvent });
     }
     if (event.event === "approval.request") {
-      const envelope: Extract<ServerMessage, { type: "approval.request" }> = {
-        type: "approval.request",
+      const envelope = this.trackPendingApproval(
         runId,
-        event: publicEvent ?? publicHermesRunEvent(event, "summary")!,
-        approval: publicApprovalDetails(event),
-      };
-      this.trackPendingApproval(envelope);
-      this.send(envelope);
+        event,
+        publicEvent ?? publicHermesRunEvent(event, "summary")!,
+      );
+      if (envelope) this.send(envelope);
     } else if (event.event === "run.failed") {
       this.send({ type: "run.failed", runId, error: "Hermes run failed. Check the gateway logs for details." });
     } else if (event.event === "run.cancelled") {
@@ -488,14 +1126,37 @@ export class LiveGatewaySession {
   }
 
   private async handleApprovalResponse(message: Extract<ClientMessage, { type: "approval.respond" }>): Promise<void> {
-    const runId = this.resolveActiveRunId(message.runId);
     if (message.resolveAll === true) {
       throw new Error("Bulk approval resolution is not supported; answer each approval in FIFO order.");
+    }
+
+    const fingerprint = approvalResponseFingerprint(message);
+    const processed = this.processedApprovalResponses.get(message.id);
+    if (processed) {
+      if (processed.fingerprint !== fingerprint) {
+        throw new Error("Approval response request id was already used for different approval data.");
+      }
+      this.send(processed.response);
+      return;
+    }
+    const runId = this.resolveActiveRunId(message.runId);
+    if (
+      this.stopIntentRunIds.has(runId) ||
+      this.stopRequestedRunIds.has(runId) ||
+      this.stopRunOperations.has(runId)
+    ) {
+      throw new Error("The Hermes run is stopping and no longer accepts approval responses.");
+    }
+    if (this.approvalSubmissionInFlight) {
+      throw new Error("An approval response is already being submitted; wait for its result.");
     }
 
     const pending = this.pendingApprovals[0];
     if (!pending || pending.runId !== runId) {
       throw new Error("No pending approval is available for the active Hermes run.");
+    }
+    if (pending.approval.approvalId !== message.approvalId) {
+      throw new Error("Approval response does not match the oldest pending request.");
     }
     if (
       message.choice === "always" &&
@@ -507,28 +1168,193 @@ export class LiveGatewaySession {
       throw new Error(`Approval choice ${message.choice} was not offered for the pending request.`);
     }
 
-    const result = await this.deps.hermes.submitApproval(runId, message.choice, this.hermesRequestOptions());
-    const resolved = safeResolvedCount(result.resolved);
-    this.pendingApprovals.splice(0, Math.min(resolved, this.pendingApprovals.length));
-    this.send({
+    this.approvalSubmissionInFlight = true;
+    let result: Awaited<ReturnType<HermesRunsPort["submitApproval"]>>;
+    try {
+      result = await withAbortAndDeadline(
+        this.deps.hermes.submitApproval(runId, message.choice, this.hermesRequestOptions()),
+        this.abort.signal,
+        this.deps.config.hermes.timeoutMs,
+        "Hermes approval submission did not settle before the safety deadline.",
+      );
+    } catch (error) {
+      await this.failClosedApprovalSubmission(message, error);
+      return;
+    } finally {
+      this.approvalSubmissionInFlight = false;
+    }
+
+    if (!isRecordValue(result)) {
+      await this.failClosedApprovalSubmission(
+        message,
+        new Error("Hermes returned a malformed approval response."),
+      );
+      return;
+    }
+    if (result.resolved !== 1) {
+      await this.failClosedApprovalSubmission(
+        message,
+        new Error(`Hermes returned an invalid approval resolution count: ${String(result.resolved)}.`),
+      );
+      return;
+    }
+    if (
+      (result.run_id !== undefined && (!isBoundedRunId(result.run_id) || result.run_id !== runId)) ||
+      (result.runId !== undefined && (!isBoundedRunId(result.runId) || result.runId !== runId)) ||
+      (result.choice !== undefined && result.choice !== message.choice)
+    ) {
+      await this.failClosedApprovalSubmission(
+        message,
+        new Error("Hermes returned approval correlation data that did not match the submitted response."),
+      );
+      return;
+    }
+
+    const current = this.pendingApprovals[0];
+    if (
+      current &&
+      (current.runId !== runId || current.approval.approvalId !== message.approvalId)
+    ) {
+      await this.failClosedApprovalSubmission(
+        message,
+        new Error("Pending approval state changed while Hermes was processing the response."),
+      );
+      return;
+    }
+    if (current) {
+      try {
+        this.rememberProcessedApprovalSource(current);
+      } catch (error) {
+        await this.failClosedApprovalSubmission(message, error);
+        return;
+      }
+      this.pendingApprovals.shift();
+    }
+
+    const response: Extract<ServerMessage, { type: "approval.responded" }> = {
       type: "approval.responded",
+      requestId: message.id,
       runId,
+      approvalId: message.approvalId,
       choice: message.choice,
-      resolved,
+      resolved: 1,
+    };
+    this.rememberApprovalResponse(message.id, fingerprint, response);
+    this.send(response);
+  }
+
+  private async failClosedApprovalSubmission(
+    message: Extract<ClientMessage, { type: "approval.respond" }>,
+    error: unknown,
+  ): Promise<void> {
+    this.deps.logger.error("approval outcome became indeterminate", {
+      sessionId: this.id,
+      runId: message.runId,
+      approvalId: message.approvalId,
+      error: errorToMessage(error),
     });
+    this.clearPendingApprovals(message.runId);
+    this.fail(
+      "approval_outcome_indeterminate",
+      new Error("Hermes approval outcome could not be confirmed. The run is being stopped and this session is closing."),
+      false,
+      message.id,
+    );
+    await this.closeClientAfterCleanup(1011, "approval outcome indeterminate");
+  }
+
+  private rememberApprovalResponse(
+    requestId: string,
+    fingerprint: string,
+    response: Extract<ServerMessage, { type: "approval.responded" }>,
+  ): void {
+    if (this.processedApprovalResponses.size >= MAX_PROCESSED_APPROVAL_RESPONSES) {
+      const oldest = this.processedApprovalResponses.keys().next().value;
+      if (oldest) this.processedApprovalResponses.delete(oldest);
+    }
+    this.processedApprovalResponses.set(requestId, { fingerprint, response });
   }
 
   private async stopRun(runId: string | undefined, reason?: string): Promise<Record<string, unknown>> {
     const target = this.resolveActiveRunId(runId);
-    const result = await this.deps.hermes.stopRun(target, this.hermesRequestOptions());
+    this.stopIntentRunIds.add(target);
     this.clearPendingApprovals(target);
-    this.send({ type: "run.stopped", runId: target, status: result.status ?? "stopping" });
-    this.send({ type: "log", level: "info", message: "Hermes run stop requested", data: { runId: target, reason } });
-    return { ok: true, run_id: target, status: result.status ?? "stopping" };
+    let result: Awaited<ReturnType<HermesRunsPort["stopRun"]>>;
+    try {
+      result = await this.requestHermesStop(target, this.hermesRequestOptions());
+    } catch (error) {
+      if (this.activeRunId !== target || !this.hermesRunActive) {
+        this.stopRequestedRunIds.delete(target);
+        this.stopNotificationRunIds.delete(target);
+        return { ok: true, run_id: target, status: "terminal" };
+      }
+      this.deps.logger.warn("Hermes run stop request failed", {
+        sessionId: this.id,
+        runId: target,
+        error: errorToMessage(error),
+      });
+      await this.containBrokenRun(target, error);
+      return { ok: false, run_id: target, status: "indeterminate" };
+    }
+    if (this.activeRunId !== target || !this.hermesRunActive) {
+      this.stopRequestedRunIds.delete(target);
+      this.stopNotificationRunIds.delete(target);
+      return { ok: true, run_id: target, status: "terminal" };
+    }
+    if (!this.stopNotificationRunIds.has(target)) {
+      this.stopNotificationRunIds.add(target);
+      this.send({ type: "run.stopping", runId: target, status: publicRunStatus(result.status) });
+      this.send({ type: "log", level: "info", message: "Hermes run stop requested", data: { runId: target, reason } });
+    }
+    return { ok: true, run_id: target, status: publicRunStatus(result.status) };
+  }
+
+  private requestHermesStop(
+    runId: string,
+    options: { signal?: AbortSignal; sessionKey?: string },
+  ): Promise<Awaited<ReturnType<HermesRunsPort["stopRun"]>>> {
+    if (this.stopRequestedRunIds.has(runId)) {
+      return Promise.resolve({ run_id: runId, status: "stopping" });
+    }
+    const existing = this.stopRunOperations.get(runId);
+    if (existing) return existing;
+
+    let operation!: Promise<Awaited<ReturnType<HermesRunsPort["stopRun"]>>>;
+    operation = (async () => {
+      try {
+        const rawResult = await this.deps.hermes.stopRun(runId, options);
+        if (!isRecordValue(rawResult)) {
+          throw new Error("Hermes returned a malformed stop response.");
+        }
+        assertHermesResponseRunCorrelation(rawResult, runId, "stop");
+        if (
+          rawResult.status !== undefined &&
+          (typeof rawResult.status !== "string" || rawResult.status.length === 0 || rawResult.status.length > 128)
+        ) {
+          throw new Error("Hermes returned an invalid stop status.");
+        }
+        const result = {
+          ...(typeof rawResult.run_id === "string" ? { run_id: rawResult.run_id } : {}),
+          ...(typeof rawResult.status === "string" ? { status: rawResult.status } : {}),
+        };
+        this.stopRequestedRunIds.add(runId);
+        return result;
+      } finally {
+        if (this.stopRunOperations.get(runId) === operation) {
+          this.stopRunOperations.delete(runId);
+        }
+      }
+    })();
+    this.stopRunOperations.set(runId, operation);
+    return operation;
   }
 
   private hermesRequestOptions(): { signal: AbortSignal; sessionKey?: string } {
     return { signal: this.abort.signal, ...(this.sessionKey ? { sessionKey: this.sessionKey } : {}) };
+  }
+
+  private hermesDetachedRequestOptions(): { sessionKey?: string } {
+    return this.sessionKey ? { sessionKey: this.sessionKey } : {};
   }
 
   private resolveActiveRunId(requestedRunId: string | undefined): string {
@@ -541,22 +1367,58 @@ export class LiveGatewaySession {
     return this.activeRunId;
   }
 
-  private trackPendingApproval(envelope: Extract<ServerMessage, { type: "approval.request" }>): void {
-    const approvalId = envelope.approval.approvalId;
-    const existingIndex = approvalId
-      ? this.pendingApprovals.findIndex(
-          (pending) => pending.runId === envelope.runId && pending.approval.approvalId === approvalId,
-        )
-      : -1;
-    const pending = { runId: envelope.runId, approval: envelope.approval };
-    if (existingIndex >= 0) {
-      this.pendingApprovals[existingIndex] = pending;
-    } else {
-      if (this.pendingApprovals.length >= MAX_PENDING_APPROVALS) {
-        throw new Error("Hermes exceeded the safe pending approval queue limit.");
-      }
-      this.pendingApprovals.push(pending);
+  private trackPendingApproval(
+    runId: string,
+    event: HermesRunEvent,
+    publicEvent: HermesRunEvent,
+  ): Extract<ServerMessage, { type: "approval.request" }> | undefined {
+    const sourceKey = approvalSourceKey(event.approval_id);
+    if (!sourceKey) {
+      throw new Error("Hermes approval request did not include a bounded approval_id.");
     }
+    const projectedApproval = publicApprovalDetails(event, "pending");
+    const semanticFingerprint = approvalSemanticFingerprint(projectedApproval);
+    const processedKey = `${runId}:${sourceKey}`;
+    const processedFingerprint = this.processedApprovalSources.get(processedKey);
+    if (processedFingerprint) {
+      if (processedFingerprint !== semanticFingerprint) {
+        throw new Error("Hermes reused a resolved approval id for different approval semantics.");
+      }
+      return undefined;
+    }
+    const existingIndex = this.pendingApprovals.findIndex(
+      (pending) => pending.runId === runId && pending.sourceKey === sourceKey,
+    );
+    const existing = existingIndex >= 0 ? this.pendingApprovals[existingIndex] : undefined;
+    if (existing && existing.semanticFingerprint !== semanticFingerprint) {
+      throw new Error("Hermes reused an approval id for different approval semantics.");
+    }
+    if (existing) return undefined;
+    if (
+      this.processedApprovalSources.size + this.pendingApprovals.length >=
+      MAX_PROCESSED_APPROVAL_RESPONSES
+    ) {
+      throw new Error("Hermes exceeded the safe resolved approval correlation limit.");
+    }
+    const approvalId = `approval_${randomUUID().replaceAll("-", "")}`;
+    const approval = { ...projectedApproval, approvalId };
+    const envelope: Extract<ServerMessage, { type: "approval.request" }> = {
+      type: "approval.request",
+      runId,
+      event: publicEvent,
+      approval,
+    };
+    const pending: PendingApprovalEnvelope = {
+      runId,
+      approval,
+      sourceKey,
+      semanticFingerprint,
+    };
+    if (this.pendingApprovals.length >= MAX_PENDING_APPROVALS) {
+      throw new Error("Hermes exceeded the safe pending approval queue limit.");
+    }
+    this.pendingApprovals.push(pending);
+    return envelope;
   }
 
   private clearPendingApprovals(runId?: string): void {
@@ -567,9 +1429,33 @@ export class LiveGatewaySession {
     this.pendingApprovals = this.pendingApprovals.filter((pending) => pending.runId !== runId);
   }
 
+  private rememberProcessedApprovalSource(pending: PendingApprovalEnvelope): void {
+    const key = `${pending.runId}:${pending.sourceKey}`;
+    const existing = this.processedApprovalSources.get(key);
+    if (existing && existing !== pending.semanticFingerprint) {
+      throw new Error("Resolved approval correlation changed unexpectedly.");
+    }
+    if (!existing && this.processedApprovalSources.size >= MAX_PROCESSED_APPROVAL_RESPONSES) {
+      throw new Error("Hermes exceeded the safe resolved approval correlation limit.");
+    }
+    this.processedApprovalSources.set(key, pending.semanticFingerprint);
+  }
+
+  private clearProcessedApprovalSources(runId: string): void {
+    const prefix = `${runId}:`;
+    for (const key of this.processedApprovalSources.keys()) {
+      if (key.startsWith(prefix)) this.processedApprovalSources.delete(key);
+    }
+  }
+
   private async cancelRealtimeResponse(reason?: string, truncate?: RealtimeResponseTruncation): Promise<void> {
     try {
-      const cancelled = (await this.liveSession?.cancelResponse(reason, truncate)) ?? false;
+      const cancelled = (await withDeadline(
+        Promise.resolve(this.liveSession?.cancelResponse(reason, truncate) ?? false),
+        MAX_PROVIDER_CANCEL_WAIT_MS,
+        "Realtime provider cancellation did not settle before the safety deadline.",
+      )) ?? false;
+      if (this.closing) return;
       this.send({
         type: "log",
         level: cancelled ? "info" : "debug",
@@ -581,24 +1467,121 @@ export class LiveGatewaySession {
         sessionId: this.id,
         error: errorToMessage(error),
       });
+      if (this.closing) return;
       this.send({ type: "log", level: "warn", message: "Realtime response cancellation failed", data: { reason } });
     }
   }
 
-  private async sendToolFailure(call: LiveToolCall, error: unknown): Promise<void> {
+  private async forwardRealtimeClientInput(label: string, operation: () => Promise<void>): Promise<void> {
     try {
-      await this.liveSession?.sendToolResponse(call, { ok: false, error: errorToMessage(error) });
-    } catch (toolError) {
-      this.deps.logger.warn("failed to send realtime tool failure", {
+      await withAbortAndDeadline(
+        operation(),
+        this.abort.signal,
+        MAX_PROVIDER_IO_WAIT_MS,
+        `Realtime provider ${label} input did not settle before the safety deadline.`,
+      );
+    } catch (error) {
+      if (this.closing || this.abort.signal.aborted) return;
+      this.deps.logger.warn("realtime provider rejected client input", {
+        sessionId: this.id,
+        input: label,
+        error: errorToMessage(error),
+      });
+      this.fail(
+        "realtime_provider_input_failed",
+        new Error(`Realtime provider could not safely confirm ${label} input. Check the gateway logs.`),
+        false,
+      );
+      await this.closeClientAfterCleanup(1011, "realtime provider input failed");
+    }
+  }
+
+  private async sendProviderToolResponse(call: LiveToolCall, response: Record<string, unknown>): Promise<void> {
+    if (this.closing) return;
+    try {
+      if (!this.liveSession) throw new Error("Realtime provider session is unavailable.");
+      await withAbortAndDeadline(
+        this.liveSession.sendToolResponse(call, response),
+        this.abort.signal,
+        MAX_PROVIDER_IO_WAIT_MS,
+        "Realtime provider tool response did not settle before the safety deadline.",
+      );
+    } catch (error) {
+      if (this.closing) return;
+      this.deps.logger.warn("failed to send realtime tool response", {
         sessionId: this.id,
         callId: call.id,
-        error: errorToMessage(toolError),
+        error: errorToMessage(error),
+      });
+      this.fail(
+        "realtime_tool_response_failed",
+        new Error("Realtime provider could not accept the Hermes tool result. Check the gateway logs."),
+        false,
+      );
+      await this.closeClientAfterCleanup(1011, "realtime tool response failed");
+    }
+  }
+
+  private releaseOldestProviderStartMarker(): void {
+    const record = [...this.providerToolCalls.values()].find((candidate) => candidate.startMarkerActive);
+    if (record) this.releaseProviderStartMarker(record);
+  }
+
+  private releaseProviderStartMarker(record: ProviderToolCallRecord): void {
+    if (!record.startMarkerActive) return;
+    record.startMarkerActive = false;
+    this.pendingStartToolCalls = Math.max(0, this.pendingStartToolCalls - 1);
+    if (this.activeRunId || this.pendingStartToolCalls === 0) {
+      this.flushDeferredProviderTerminal();
+    }
+  }
+
+  private scheduleProviderToolOperation(operation: () => Promise<void>): void {
+    this.providerToolOperations.push(operation);
+    this.drainProviderToolOperations();
+  }
+
+  private drainProviderToolOperations(): void {
+    while (
+      !this.closing &&
+      this.activeProviderToolOperations < MAX_CONCURRENT_PROVIDER_TOOL_CALLS &&
+      this.providerToolOperations.length > 0
+    ) {
+      const operation = this.providerToolOperations.shift()!;
+      this.activeProviderToolOperations += 1;
+      void operation().catch((error) => {
+        this.deps.logger.error("unexpected realtime tool operation failure", {
+          sessionId: this.id,
+          error: errorToMessage(error),
+        });
+      }).finally(() => {
+        this.activeProviderToolOperations -= 1;
+        this.drainProviderToolOperations();
       });
     }
   }
 
+  private failProviderToolQueueOverflow(): void {
+    if (this.closing) return;
+    this.fail(
+      "realtime_tool_queue_overflow",
+      new Error("Realtime provider exceeded the safe pending tool-call limit."),
+      false,
+    );
+    void this.closeClientAfterCleanup(1011, "realtime tool queue overflow");
+  }
+
   private send(message: ServerMessage): void {
     this.client.sendText(serverMessage(message));
+  }
+
+  private handleClientMessageFailure(error: unknown, requestId?: string): void {
+    if (this.closing) return;
+    this.clientMessageErrors += 1;
+    this.fail("client_message_failed", error, false, requestId);
+    if (this.clientMessageErrors >= MAX_CLIENT_MESSAGE_ERRORS) {
+      void this.closeClientAfterCleanup(1008, "too many invalid client messages");
+    }
   }
 
   private fail(code: string, error: unknown, recoverable = false, requestId?: string): void {
@@ -609,18 +1592,74 @@ export class LiveGatewaySession {
 }
 
 function validateAudioFrame(data: string, mimeType: string, maxBytes: number): void {
-  const decoded = decodeBase64Audio(data);
+  if (typeof mimeType !== "string" || mimeType.length === 0 || mimeType.length > 128) {
+    throw new Error("Audio frame MIME type is invalid.");
+  }
+  const decoded = decodeBase64Audio(data, maxBytes);
   if (decoded.length > maxBytes) {
     throw new Error("Audio frame exceeds HERMES_LIVE_MAX_AUDIO_BYTES.");
   }
-  if (isPcmMimeType(mimeType) && decoded.length % 2 !== 0) {
-    throw new Error("PCM16 audio frames must contain an even number of bytes.");
+  if (isPcmMimeType(mimeType)) {
+    requirePcmSampleRate(mimeType);
+    if (decoded.length % 2 !== 0) {
+      throw new Error("PCM16 audio frames must contain an even number of bytes.");
+    }
   }
 }
 
-function decodeBase64Audio(data: string): Buffer {
+function clientInboundFrameBytes(frame: ClientInboundFrame): number {
+  return typeof frame === "string" ? Buffer.byteLength(frame, "utf8") : frame.byteLength;
+}
+
+function isRecordValue(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isBoundedRunId(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0 && value.length <= 256 && !/[\u0000-\u001f\u007f]/u.test(value);
+}
+
+function clientCloseSeverity(code: number): number {
+  if (code === 1000) return 0;
+  if (code === 1008 || code === 1009) return 1;
+  return 2;
+}
+
+function assertHermesRunEventCorrelation(event: HermesRunEvent, runId: string): void {
+  if (event.run_id === undefined) return;
+  if (!isBoundedRunId(event.run_id) || event.run_id !== runId) {
+    throw new Error("Hermes emitted an event that did not match the active run stream.");
+  }
+}
+
+function assertHermesResponseRunCorrelation(
+  value: Record<string, unknown>,
+  runId: string,
+  label: string,
+): void {
+  if (value.run_id !== undefined && (!isBoundedRunId(value.run_id) || value.run_id !== runId)) {
+    throw new Error(`Hermes ${label} response did not match the active run.`);
+  }
+  if (value.runId !== undefined && (!isBoundedRunId(value.runId) || value.runId !== runId)) {
+    throw new Error(`Hermes ${label} response alias did not match the active run.`);
+  }
+}
+
+function isPreemptiveClientControl(message: ClientMessage, sessionReady: boolean): boolean {
+  if (message.type === "session.close") return true;
+  return sessionReady && (
+    message.type === "response.cancel" ||
+    message.type === "run.stop" ||
+    message.type === "approval.respond"
+  );
+}
+
+function decodeBase64Audio(data: string, maxBytes: number): Buffer {
   if (!/^[A-Za-z0-9+/]*={0,2}$/.test(data) || data.length % 4 === 1) {
     throw new Error("Audio frame data must be base64 encoded.");
+  }
+  if (data.length > Math.ceil((maxBytes * 4) / 3) + 4) {
+    throw new Error("Audio frame exceeds HERMES_LIVE_MAX_AUDIO_BYTES.");
   }
   return Buffer.from(data, "base64");
 }
@@ -648,83 +1687,231 @@ function stringArg(call: LiveToolCall, name: string): string {
   return typeof value === "string" ? value : "";
 }
 
+function requireProviderToolCallId(call: LiveToolCall): string {
+  if (
+    typeof call.name !== "string" ||
+    call.name.length === 0 ||
+    call.name.length > 128 ||
+    !/^[A-Za-z0-9_.:-]+$/u.test(call.name)
+  ) {
+    throw new Error("Realtime provider emitted a tool call with an invalid name.");
+  }
+  if (
+    typeof call.id !== "string" ||
+    call.id.length === 0 ||
+    call.id.length > 256 ||
+    /[\u0000-\u001f\u007f]/u.test(call.id)
+  ) {
+    throw new Error("Realtime provider emitted a tool call without a bounded id.");
+  }
+  return call.id;
+}
+
+function providerToolCallFingerprint(call: LiveToolCall): string {
+  let args: string;
+  try {
+    args = JSON.stringify(call.args);
+  } catch {
+    throw new Error("Realtime provider tool-call arguments were not serializable.");
+  }
+  if (Buffer.byteLength(args, "utf8") > MAX_PROVIDER_TOOL_CALL_ARGS_BYTES) {
+    throw new Error("Realtime provider tool-call arguments exceeded the safe size limit.");
+  }
+  return createHash("sha256").update(call.name).update("\0").update(args).digest("hex");
+}
+
+function boundedProviderToolResponse(response: Record<string, unknown>): Record<string, unknown> {
+  return safeJsonByteLength(response) <= MAX_PROVIDER_TOOL_RESPONSE_BYTES
+    ? response
+    : { ok: false, error: "Hermes tool result exceeded the safe provider response limit." };
+}
+
+function publicHermesRunStatus(value: Record<string, unknown>, runId: string): Record<string, unknown> {
+  return { run_id: runId, status: publicRunStatus(value.status, "unknown") };
+}
+
+function publicRunStatus(value: unknown, fallback = "stopping"): string {
+  if (typeof value !== "string") return fallback;
+  const normalized = value.trim().toLowerCase();
+  return [
+    "queued",
+    "started",
+    "in_progress",
+    "running",
+    "requires_action",
+    "stopping",
+    "cancelled",
+    "canceled",
+    "completed",
+    "failed",
+  ].includes(normalized)
+    ? normalized
+    : fallback;
+}
+
+function publicHermesCapabilities(
+  capabilities: Awaited<ReturnType<HermesRunsPort["capabilities"]>>,
+): { model?: string; capabilities?: Record<string, unknown> } {
+  const model = boundedDisplayText(capabilities.model, 256);
+  const source = capabilities.features;
+  const projected: Record<string, unknown> = {};
+  if (source && typeof source === "object" && !Array.isArray(source)) {
+    for (const key of ["run_submission", "run_events_sse", "run_stop", "run_approval_response"]) {
+      if (typeof source[key] === "boolean") projected[key] = source[key];
+    }
+  }
+  return {
+    ...(model ? { model } : {}),
+    ...(Object.keys(projected).length > 0 ? { capabilities: projected } : {}),
+  };
+}
+
+function publicRealtimeStartupError(error: unknown): string {
+  const message = errorToMessage(error);
+  if (
+    message.startsWith("Realtime provider did not become ready within ") ||
+    message === "Realtime provider session closed before ready." ||
+    message === "Realtime provider exceeded the safe pre-ready event queue limit."
+  ) {
+    return boundedText(message, 500);
+  }
+  return "Realtime provider session failed to start. Check the gateway logs.";
+}
+
 function publicHermesRunEvent(
   event: HermesRunEvent,
   detail: AppConfig["server"]["runEventDetail"],
 ): HermesRunEvent | undefined {
   if (detail === "raw") {
-    return event;
+    const serialized = safeJsonByteLength(event);
+    if (serialized <= MAX_PUBLIC_RUN_EVENT_BYTES) return event;
+    return {
+      ...summarizeHermesRunEvent(event),
+      truncated: true,
+      original_bytes: serialized,
+    };
   }
   if (detail === "none") {
     return undefined;
   }
 
+  return summarizeHermesRunEvent(event);
+}
+
+function summarizeHermesRunEvent(event: HermesRunEvent): HermesRunEvent {
   const summary: Record<string, unknown> = {};
   for (const key of ["event", "run_id", "timestamp", "status", "approval_id"] as const) {
     const value = event[key];
-    if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    if (typeof value === "string") {
+      summary[key] = boundedText(value, 512);
+    } else if (typeof value === "number" || typeof value === "boolean") {
       summary[key] = value;
     }
   }
   return summary as HermesRunEvent;
 }
 
-function publicApprovalDetails(event: HermesRunEvent): HermesApprovalDetails {
-  const approvalId = boundedString(event.approval_id, 256);
-  const command = boundedString(event.command, 4_000);
-  const description = boundedString(event.description, 2_000);
-  const patternKey = boundedInspectablePattern(event.pattern_key, 256);
-  const patternKeys = Array.isArray(event.pattern_keys)
-    ? [
-        ...new Set(
-          event.pattern_keys
-            .map((value) => boundedInspectablePattern(value, 256))
-            .filter((value): value is string => Boolean(value)),
-        ),
-      ].slice(0, 32)
-    : undefined;
-  const informed = Boolean(command || description);
-  const hasInspectablePermanentPattern = Boolean(patternKey || (patternKeys && patternKeys.length > 0));
-  const suppliedChoices = Array.isArray(event.choices)
-    ? event.choices.filter((choice): choice is "once" | "session" | "always" | "deny" =>
-        typeof choice === "string" && ["once", "session", "always", "deny"].includes(choice),
-      )
-    : [];
-  const fallbackChoices: Array<"once" | "session" | "always" | "deny"> = informed
-    ? ["once", "session", "always", "deny"]
+function publicApprovalDetails(event: HermesRunEvent, approvalId: string): HermesApprovalDetails {
+  const commandProjection = exactApprovalDisplayText(event.command, 4_000);
+  const descriptionProjection = exactApprovalDisplayText(event.description, 2_000);
+  const command = commandProjection.value;
+  const description = descriptionProjection.value;
+  const displayComplete = commandProjection.exact && descriptionProjection.exact && Boolean(command || description);
+  const patterns = exactApprovalPatterns(event);
+  const patternKey = displayComplete ? patterns.values[0] : undefined;
+  const patternKeys = displayComplete && patterns.values.length > 1 ? patterns.values.slice(1) : undefined;
+  const hasInspectablePermanentPattern = displayComplete && patterns.exact && patterns.values.length > 0;
+  const fallbackChoices: Array<"once" | "session" | "always" | "deny"> = !displayComplete
+    ? ["deny"]
     : ["once", "deny"];
+  const allowedChoices = ["once", "session", "always", "deny"] as const;
+  const suppliedChoices: Array<typeof allowedChoices[number]> = event.choices === undefined
+    ? fallbackChoices
+    : Array.isArray(event.choices) &&
+        event.choices.length > 0 &&
+        event.choices.every((choice) =>
+          typeof choice === "string" && allowedChoices.includes(choice as typeof allowedChoices[number]),
+        )
+      ? event.choices as Array<typeof allowedChoices[number]>
+      : ["deny"];
   const choices: Array<"once" | "session" | "always" | "deny"> = (
-    suppliedChoices.length > 0 ? suppliedChoices : fallbackChoices
+    suppliedChoices
   )
     .filter(
       (choice) =>
-        (informed || choice === "once" || choice === "deny") &&
-        (choice !== "always" || (hasInspectablePermanentPattern && event.allow_permanent !== false)),
+        (displayComplete || choice === "deny") &&
+        ((choice !== "session" && choice !== "always") || hasInspectablePermanentPattern) &&
+        (choice !== "always" || (hasInspectablePermanentPattern && event.allow_permanent === true)),
     )
     .filter((choice, index, all) => all.indexOf(choice) === index);
   if (!choices.includes("deny")) {
     choices.push("deny");
   }
   return {
-    ...(approvalId ? { approvalId } : {}),
+    approvalId,
     ...(command ? { command } : {}),
     ...(description ? { description } : {}),
     ...(patternKey ? { patternKey } : {}),
     ...(patternKeys && patternKeys.length > 0 ? { patternKeys } : {}),
     choices,
-    allowPermanent: hasInspectablePermanentPattern && event.allow_permanent !== false && choices.includes("always"),
+    allowPermanent: hasInspectablePermanentPattern && event.allow_permanent === true && choices.includes("always"),
   };
 }
 
-function boundedString(value: unknown, maximum: number): string | undefined {
+function exactApprovalDisplayText(value: unknown, maximum: number): { value?: string; exact: boolean } {
+  if (value === undefined || value === null || value === "") return { exact: true };
+  if (typeof value !== "string" || /[\r\n\t]/u.test(value)) return { exact: false };
+  const projected = boundedDisplayText(value, maximum);
+  return projected && projected === value && /[\p{L}\p{N}\p{P}\p{S}]/u.test(projected)
+    ? { value: projected, exact: true }
+    : { exact: false };
+}
+
+function exactApprovalPatterns(event: HermesRunEvent): { values: string[]; exact: boolean } {
+  const rawValues: unknown[] = [];
+  if (event.pattern_key !== undefined && event.pattern_key !== null && event.pattern_key !== "") {
+    rawValues.push(event.pattern_key);
+  }
+  if (event.pattern_keys !== undefined && event.pattern_keys !== null) {
+    if (!Array.isArray(event.pattern_keys) || event.pattern_keys.length > 32) return { values: [], exact: false };
+    rawValues.push(...event.pattern_keys);
+  }
+  if (rawValues.length > 32) return { values: [], exact: false };
+
+  const values: string[] = [];
+  for (const raw of rawValues) {
+    const projected = boundedInspectablePattern(raw, 256);
+    if (typeof raw !== "string" || !projected || projected !== raw) return { values: [], exact: false };
+    if (!values.includes(projected)) values.push(projected);
+  }
+  return { values, exact: true };
+}
+
+function boundedDisplayText(value: unknown, maximum: number): string | undefined {
   if (typeof value !== "string") return undefined;
-  const normalized = value.trim();
-  return normalized ? normalized.slice(0, maximum) : undefined;
+  const boundedInput = value.slice(0, maximum * 4 + 4_096);
+  const withoutTerminalSequences = boundedInput
+    .replace(/\u001b\][^\u0007]*(?:\u0007|\u001b\\|$)/g, "")
+    .replace(/(?:\u001b\[|\u009b)[0-?]*[ -/]*[@-~]/g, "")
+    .replace(/\u001b[@-_]/g, "")
+    .replace(/\r\n?/g, "\n");
+  const printable = Array.from(withoutTerminalSequences.normalize("NFC"))
+    .filter(
+      (character) =>
+        character === "\n" ||
+        character === "\t" ||
+        !/[\p{Cc}\p{Cf}\p{Cs}\p{Co}\p{Cn}]/u.test(character),
+    )
+    .slice(0, maximum)
+    .join("")
+    .trim();
+  return printable || undefined;
 }
 
 function boundedInspectablePattern(value: unknown, maximum: number): string | undefined {
   if (typeof value !== "string") return undefined;
-  const withoutTerminalSequences = value
+  const boundedInput = value.slice(0, maximum * 4 + 4_096);
+  const withoutTerminalSequences = boundedInput
     .replace(/\u001b\][^\u0007]*(?:\u0007|\u001b\\|$)/g, "")
     .replace(/(?:\u001b\[|\u009b)[0-?]*[ -/]*[@-~]/g, "")
     .replace(/\u001b[@-_]/g, "");
@@ -741,6 +1928,157 @@ function canApprovePermanently(approval: HermesApprovalDetails): boolean {
   return approval.allowPermanent && Boolean(approval.patternKey || approval.patternKeys?.length);
 }
 
-function safeResolvedCount(value: unknown): number {
-  return Number.isSafeInteger(value) && Number(value) >= 0 ? Number(value) : 0;
+function approvalSourceKey(value: unknown): string | undefined {
+  if (typeof value !== "string" || value.length === 0 || value.length > 4_000) return undefined;
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function approvalResponseFingerprint(
+  message: Extract<ClientMessage, { type: "approval.respond" }>,
+): string {
+  return createHash("sha256")
+    .update(message.runId)
+    .update("\0")
+    .update(message.approvalId)
+    .update("\0")
+    .update(message.choice)
+    .digest("hex");
+}
+
+function approvalSemanticFingerprint(approval: HermesApprovalDetails): string {
+  return createHash("sha256")
+    .update(JSON.stringify({
+      command: approval.command ?? null,
+      description: approval.description ?? null,
+      patternKey: approval.patternKey ?? null,
+      patternKeys: approval.patternKeys ?? [],
+      choices: approval.choices,
+      allowPermanent: approval.allowPermanent,
+    }))
+    .digest("hex");
+}
+
+function appendBoundedText(current: string, addition: string, maximum: number): string {
+  if (current.length >= maximum || addition.length === 0) return current;
+  return `${current}${addition.slice(0, maximum - current.length)}`;
+}
+
+function boundedText(value: string, maximum: number): string {
+  return value.length <= maximum ? value : value.slice(0, maximum);
+}
+
+function boundedUsage(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  return safeJsonByteLength(value) <= MAX_PUBLIC_USAGE_BYTES
+    ? value as Record<string, unknown>
+    : { truncated: true };
+}
+
+function publicProviderCloseEvent(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  const code = typeof record.code === "number" && Number.isSafeInteger(record.code)
+    ? record.code
+    : undefined;
+  return code === undefined ? undefined : { code };
+}
+
+function providerCloseLogDetail(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  const record = value as Record<string, unknown>;
+  const code = typeof record.code === "number" && Number.isSafeInteger(record.code) ? record.code : undefined;
+  const reason = boundedDisplayText(record.reason, 2_000);
+  return { ...(code === undefined ? {} : { providerCode: code }), ...(reason ? { providerReason: reason } : {}) };
+}
+
+function publicProviderIdentifier(value: unknown): string | undefined {
+  if (typeof value !== "string" || value.length === 0 || value.length > 256 || /[\r\n\t]/u.test(value)) {
+    return undefined;
+  }
+  const projected = boundedDisplayText(value, 256);
+  return projected === value && /[\p{L}\p{N}\p{P}\p{S}]/u.test(value) ? value : undefined;
+}
+
+function publicContentIndex(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 && value <= 100
+    ? value
+    : undefined;
+}
+
+function publicAudioStartMs(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 && value <= 60 * 60 * 1_000
+    ? value
+    : undefined;
+}
+
+function safeJsonByteLength(value: unknown): number {
+  try {
+    return Buffer.byteLength(JSON.stringify(value), "utf8");
+  } catch {
+    return Number.POSITIVE_INFINITY;
+  }
+}
+
+async function settlesWithin(promise: Promise<unknown>, timeoutMs: number): Promise<boolean> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise.then(
+        () => true,
+        () => true,
+      ),
+      new Promise<boolean>((resolve) => {
+        timeout = setTimeout(() => resolve(false), Math.max(1, timeoutMs));
+        timeout.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+async function withDeadline<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => reject(new Error(message)), Math.max(1, timeoutMs));
+        timeout.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+async function withAbortAndDeadline<T>(
+  promise: Promise<T>,
+  signal: AbortSignal,
+  timeoutMs: number,
+  message: string,
+): Promise<T> {
+  if (signal.aborted) throw signal.reason ?? new DOMException("Aborted", "AbortError");
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  let rejectAbort: ((reason?: unknown) => void) | undefined;
+  const aborted = new Promise<never>((_, reject) => {
+    rejectAbort = reject;
+  });
+  const onAbort = (): void => {
+    rejectAbort?.(signal.reason ?? new DOMException("Aborted", "AbortError"));
+  };
+  signal.addEventListener("abort", onAbort, { once: true });
+  try {
+    return await Promise.race([
+      promise,
+      aborted,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => reject(new Error(message)), Math.max(1, timeoutMs));
+        timeout.unref?.();
+      }),
+    ]);
+  } finally {
+    signal.removeEventListener("abort", onAbort);
+    if (timeout) clearTimeout(timeout);
+  }
 }

--- a/src/application/live-gateway/ports/realtime-model.port.ts
+++ b/src/application/live-gateway/ports/realtime-model.port.ts
@@ -18,8 +18,7 @@ export type LiveModelEvent =
   | { type: "text"; text: string; speaker?: "user" | "assistant" | "system"; final?: boolean }
   | { type: "response"; status: "started" | "completed" | "cancelled" | "failed"; responseId?: string; error?: string }
   | { type: "tool_call"; call: LiveToolCall }
-  | { type: "input_speech_started"; provider: "openai"; itemId?: string; audioStartMs?: number }
-  | { type: "raw"; message: unknown };
+  | { type: "input_speech_started"; provider: "openai"; itemId?: string; audioStartMs?: number };
 
 export interface LiveModelCallbacks {
   onEvent(event: LiveModelEvent): void;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
+import { randomUUID } from "node:crypto";
 import { constants as fsConstants } from "node:fs";
 import { access, cp, lstat, mkdir, readlink, rm, symlink } from "node:fs/promises";
+import { createRequire } from "node:module";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { stdin as input, stderr as approvalOutput } from "node:process";
@@ -16,9 +18,15 @@ import { startServer } from "./adapters/inbound/http/server.js";
 import { runLiveProviderSmoke } from "./live-provider-smoke.js";
 import { errorToMessage } from "./domain/error-message.js";
 import { promptForOneShotApproval } from "./cli/one-shot-approval.js";
-import { normalizeGatewayWebSocketUrl, runInteractiveTerminal } from "./cli/terminal-session.js";
+import { normalizeGatewayWebSocketUrl, runInteractiveTerminal, sanitizeTerminalText } from "./cli/terminal-session.js";
 
 const logger = createLogger((process.env.HERMES_LIVE_LOG_LEVEL as any) ?? "info");
+const packageRequire = createRequire(import.meta.url);
+const PACKAGE_VERSION = (packageRequire("../package.json") as { version: string }).version;
+const DEFAULT_TEXT_CLIENT_READY_TIMEOUT_MS = 10_000;
+const MIN_TEXT_CLIENT_SERVER_MESSAGE_BYTES = 2_000_000;
+const MAX_TEXT_CLIENT_OUTPUT_CHARS = 200_000;
+const MAX_TEXT_CLIENT_ID_CHARS = 256;
 
 async function main(): Promise<void> {
   const command = process.argv[2] ?? "serve";
@@ -30,6 +38,11 @@ async function main(): Promise<void> {
 
   if (command === "help" || command === "--help" || command === "-h") {
     printHelp();
+    return;
+  }
+
+  if (command === "version" || command === "--version" || command === "-V") {
+    console.log(PACKAGE_VERSION);
     return;
   }
 
@@ -127,6 +140,7 @@ function printHelp(): void {
   console.log(`hermes-live
 
 Usage:
+  hermes-live --version     Print the installed package version
   hermes-live serve         Start the realtime gateway and web demo
   hermes-live dev           Alias for serve
   hermes-live client "..."  Send one text prompt through a running gateway
@@ -157,6 +171,7 @@ Optional:
   HERMES_LIVE_PROVIDER      gemini, openai, or mock; default gemini
   HERMES_LIVE_PROVIDER_READY_TIMEOUT_MS  Provider session ready timeout, default 15000
   HERMES_LIVE_PROVIDER_SMOKE_TIMEOUT_MS  Optional timeout for provider-smoke
+  HERMES_LIVE_CLIENT_READY_TIMEOUT_MS  One-shot client handshake timeout, default 10000
   OPENAI_REALTIME_MODEL     OpenAI Realtime model, default gpt-realtime-2.1
   OPENAI_REALTIME_TURN_DETECTION disabled, semantic_vad, or server_vad
 
@@ -311,42 +326,84 @@ async function fileExists(path: string): Promise<boolean> {
 async function runTextClient(config: AppConfig, text: string): Promise<void> {
   const url = normalizeGatewayWebSocketUrl(process.env.HERMES_LIVE_URL ?? defaultGatewayWebSocketUrl(config));
   const headers = config.server.authToken ? { authorization: `Bearer ${config.server.authToken}` } : undefined;
-  const ws = new WebSocket(url, { headers });
+  const readyTimeoutMs = positiveInt(
+    process.env.HERMES_LIVE_CLIENT_READY_TIMEOUT_MS,
+    DEFAULT_TEXT_CLIENT_READY_TIMEOUT_MS,
+  );
+  const ws = new WebSocket(url, {
+    ...(headers ? { headers } : {}),
+    handshakeTimeout: readyTimeoutMs,
+    followRedirects: false,
+    maxPayload: textClientServerMessageBytes(config),
+    perMessageDeflate: false,
+  });
   const approvalReader = createInterface({ input, output: approvalOutput });
-  const state: TextClientState = { directTranscript: [], hermesRunStarted: false };
+  const state: TextClientState = {
+    directTranscript: [],
+    directTranscriptChars: 0,
+    hermesRunStarted: false,
+    sessionReady: false,
+    finished: false,
+  };
 
   try {
     await new Promise<void>((resolve, reject) => {
-      let finished = false;
-      const finish = (error?: Error) => {
-        if (finished) {
+      let inboundQueue = Promise.resolve();
+      let readyTimeout: NodeJS.Timeout | undefined;
+      const clearReadyTimeout = (): void => {
+        if (!readyTimeout) return;
+        clearTimeout(readyTimeout);
+        readyTimeout = undefined;
+      };
+      const finish = (error?: Error, terminate = false) => {
+        if (state.finished) {
           return;
         }
-        finished = true;
-        if (ws.readyState === WebSocket.OPEN) {
+        state.finished = true;
+        clearReadyTimeout();
+        if (terminate && ws.readyState !== WebSocket.CLOSED) {
+          ws.terminate();
+        } else if (ws.readyState === WebSocket.OPEN) {
           ws.close(1000, "client complete");
         }
         error ? reject(error) : resolve();
       };
+      const markSessionReady = (): void => {
+        clearReadyTimeout();
+      };
+
+      readyTimeout = setTimeout(() => {
+        finish(
+          new Error(`Gateway did not complete the WebSocket/session.ready handshake within ${readyTimeoutMs}ms.`),
+          true,
+        );
+      }, readyTimeoutMs);
+      readyTimeout.unref?.();
 
       ws.once("open", () => {
-        ws.send(JSON.stringify({
-          type: "session.start",
-          protocolVersion: HERMES_LIVE_PROTOCOL_VERSION,
-          profileId: "terminal",
-          userLabel: process.env.USER ?? "terminal",
-        }));
+        if (state.finished) return;
+        try {
+          sendTextClientMessage(ws, {
+            type: "session.start",
+            protocolVersion: HERMES_LIVE_PROTOCOL_VERSION,
+            profileId: "terminal",
+            userLabel: process.env.USER ?? "terminal",
+          });
+        } catch (error) {
+          finish(error instanceof Error ? error : new Error(String(error)), true);
+        }
       });
-      ws.once("error", (error) => finish(error instanceof Error ? error : new Error(String(error))));
+      ws.once("error", (error) => finish(error instanceof Error ? error : new Error(String(error)), true));
       ws.once("close", (code, reason) => {
-        if (!finished) {
+        if (!state.finished) {
           finish(new Error(`Gateway WebSocket closed before completing the request: ${code} ${reason.toString("utf8")}`));
         }
       });
       ws.on("message", (raw) => {
-        void handleClientServerMessage(ws, raw, text, approvalReader, state, finish).catch((error) =>
-          finish(error instanceof Error ? error : new Error(String(error))),
-        );
+        if (state.finished) return;
+        inboundQueue = inboundQueue
+          .then(() => handleClientServerMessage(ws, raw, text, approvalReader, state, markSessionReady, finish))
+          .catch((error) => finish(error instanceof Error ? error : new Error(String(error)), true));
       });
     });
   } finally {
@@ -360,49 +417,96 @@ async function handleClientServerMessage(
   text: string,
   approvalReader: ReturnType<typeof createInterface>,
   state: TextClientState,
+  markSessionReady: () => void,
   finish: (error?: Error) => void,
 ): Promise<void> {
-  const message = JSON.parse(raw.toString("utf8")) as any;
+  if (state.finished) return;
+  const message = parseTextClientServerMessage(raw);
+  if (!state.sessionReady && message.type !== "session.ready" && message.type !== "session.error") {
+    throw new Error(`Gateway sent ${message.type} before session.ready.`);
+  }
   switch (message.type) {
-    case "session.ready":
-      ws.send(JSON.stringify({ type: "text.input", text }));
+    case "session.ready": {
+      if (state.sessionReady) throw new Error("Gateway sent duplicate session.ready messages.");
+      const protocolVersion = requiredInteger(message, "protocolVersion", "session.ready");
+      if (protocolVersion !== HERMES_LIVE_PROTOCOL_VERSION) {
+        throw new Error(
+          `Gateway protocol mismatch: expected v${HERMES_LIVE_PROTOCOL_VERSION}, received ${String(protocolVersion)}.`,
+        );
+      }
+      requiredString(message, "sessionId", "session.ready", MAX_TEXT_CLIENT_ID_CHARS);
+      state.sessionReady = true;
+      markSessionReady();
+      sendTextClientMessage(ws, { type: "text.input", text });
       break;
-    case "run.started":
+    }
+    case "run.started": {
+      const runId = requiredString(message, "runId", "run.started", MAX_TEXT_CLIENT_ID_CHARS);
+      if (state.hermesRunStarted) throw new Error("Gateway sent duplicate run.started messages.");
       state.hermesRunStarted = true;
-      console.error(`Hermes run started: ${message.runId}`);
+      state.activeRunId = runId;
+      console.error(`Hermes run started: ${sanitizeTerminalText(runId, MAX_TEXT_CLIENT_ID_CHARS)}`);
       break;
-    case "transcript.delta":
-      if (!state.hermesRunStarted && typeof message.text === "string") {
-        state.directTranscript.push(message.text);
+    }
+    case "transcript.delta": {
+      const speaker = requiredString(message, "speaker", "transcript.delta", 16);
+      if (!(["user", "assistant", "system"] as string[]).includes(speaker)) {
+        throw new Error("Gateway transcript.delta speaker is invalid.");
+      }
+      const delta = requiredString(message, "text", "transcript.delta", MAX_TEXT_CLIENT_OUTPUT_CHARS, true);
+      if (!state.hermesRunStarted && speaker === "assistant") {
+        state.directTranscriptChars += delta.length;
+        if (state.directTranscriptChars > MAX_TEXT_CLIENT_OUTPUT_CHARS) {
+          throw new Error("Gateway direct transcript exceeded the one-shot client output limit.");
+        }
+        state.directTranscript.push(delta);
       }
       break;
-    case "realtime.message":
-      if (!state.hermesRunStarted && isRealtimeResponseComplete(message.message)) {
-        finishDirectResponse(state, finish);
-      }
-      break;
+    }
     case "response.completed":
       if (!state.hermesRunStarted) finishDirectResponse(state, finish);
       break;
     case "response.failed":
-      if (!state.hermesRunStarted) finish(new Error(message.error ?? "Realtime provider response failed."));
+      if (!state.hermesRunStarted) {
+        finish(new Error(requiredString(message, "error", "response.failed", 2_000)));
+      }
       break;
-    case "approval.request":
-      await respondToApproval(ws, approvalReader, String(message.runId), message.approval ?? message.event);
+    case "response.cancelled":
+      if (!state.hermesRunStarted) finish(new Error("Realtime provider response was cancelled."));
       break;
-    case "run.completed":
-      console.log(String(message.output ?? ""));
+    case "approval.request": {
+      const runId = requiredString(message, "runId", "approval.request", MAX_TEXT_CLIENT_ID_CHARS);
+      if (state.activeRunId && runId !== state.activeRunId) {
+        throw new Error("Gateway approval.request did not match the active Hermes run.");
+      }
+      const approval = recordValue(message.approval) ?? recordValue(message.event);
+      if (!approval) throw new Error("Gateway approval.request did not include approval details.");
+      await respondToApproval(ws, approvalReader, runId, approval);
+      break;
+    }
+    case "run.completed": {
+      assertActiveRunMessage(message, state, "run.completed");
+      const output = requiredString(message, "output", "run.completed", MAX_TEXT_CLIENT_OUTPUT_CHARS, true);
+      console.log(sanitizeTerminalText(output, MAX_TEXT_CLIENT_OUTPUT_CHARS));
       finish();
       break;
+    }
     case "run.failed":
+      assertActiveRunMessage(message, state, "run.failed");
+      finish(new Error(requiredString(message, "error", "run.failed", 2_000)));
+      break;
+    case "run.stopped":
+      assertActiveRunMessage(message, state, "run.stopped");
+      finish(new Error(`Hermes run stopped: ${requiredString(message, "status", "run.stopped", 256)}`));
+      break;
     case "session.error":
-      finish(new Error(message.message ?? message.error ?? "Gateway request failed."));
+      finish(new Error(requiredString(message, "message", "session.error", 2_000)));
       break;
   }
 }
 
 function finishDirectResponse(state: TextClientState, finish: (error?: Error) => void): void {
-  const output = state.directTranscript.join("").trim();
+  const output = sanitizeTerminalText(state.directTranscript.join(""), MAX_TEXT_CLIENT_OUTPUT_CHARS).trim();
   if (output) {
     console.log(output);
     finish();
@@ -413,25 +517,68 @@ function finishDirectResponse(state: TextClientState, finish: (error?: Error) =>
 
 interface TextClientState {
   directTranscript: string[];
+  directTranscriptChars: number;
   hermesRunStarted: boolean;
+  sessionReady: boolean;
+  finished: boolean;
+  activeRunId?: string;
 }
 
-function isRealtimeResponseComplete(message: unknown): boolean {
-  const root = unwrapRealtimeMessage(message);
-  return (
-    root?.type === "response.done" ||
-    root?.serverContent?.turnComplete === true ||
-    root?.server_content?.turn_complete === true ||
-    root?.data?.serverContent?.turnComplete === true ||
-    root?.data?.server_content?.turn_complete === true
-  );
-}
-
-function unwrapRealtimeMessage(message: unknown): any {
-  if (message && typeof message === "object" && "data" in message) {
-    return (message as { data: unknown }).data;
+function parseTextClientServerMessage(raw: WebSocket.RawData): Record<string, unknown> & { type: string } {
+  let value: unknown;
+  try {
+    value = JSON.parse(raw.toString("utf8")) as unknown;
+  } catch {
+    throw new Error("Gateway sent invalid JSON.");
   }
-  return message;
+  const message = recordValue(value);
+  if (!message || typeof message.type !== "string" || !message.type || message.type.length > 128) {
+    throw new Error("Gateway sent an invalid protocol message.");
+  }
+  return message as Record<string, unknown> & { type: string };
+}
+
+function requiredString(
+  message: Record<string, unknown>,
+  field: string,
+  type: string,
+  maxChars: number,
+  allowEmpty = false,
+): string {
+  const value = message[field];
+  if (typeof value !== "string" || (!allowEmpty && !value) || value.length > maxChars) {
+    throw new Error(`Gateway ${type} ${field} must be ${allowEmpty ? "a" : "a non-empty"} bounded string.`);
+  }
+  return value;
+}
+
+function requiredInteger(message: Record<string, unknown>, field: string, type: string): number {
+  const value = message[field];
+  if (!Number.isSafeInteger(value)) throw new Error(`Gateway ${type} ${field} must be an integer.`);
+  return value as number;
+}
+
+function recordValue(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function assertActiveRunMessage(message: Record<string, unknown>, state: TextClientState, type: string): void {
+  const runId = requiredString(message, "runId", type, MAX_TEXT_CLIENT_ID_CHARS);
+  if (!state.activeRunId || runId !== state.activeRunId) {
+    throw new Error(`Gateway ${type} did not match the active Hermes run.`);
+  }
+}
+
+function sendTextClientMessage(ws: WebSocket, message: Record<string, unknown>): void {
+  if (ws.readyState !== WebSocket.OPEN) throw new Error("Gateway WebSocket is not open.");
+  ws.send(JSON.stringify(message));
+}
+
+function textClientServerMessageBytes(config: AppConfig): number {
+  const base64AudioBytes = Math.ceil((config.server.maxAudioBytes * 4) / 3) + 4_096;
+  return Math.max(MIN_TEXT_CLIENT_SERVER_MESSAGE_BYTES, base64AudioBytes);
 }
 
 async function respondToApproval(
@@ -440,12 +587,24 @@ async function respondToApproval(
   runId: string,
   event: unknown,
 ): Promise<void> {
-  console.error(`Approval requested for ${runId}:`);
+  const approvalId = typeof (event as { approvalId?: unknown })?.approvalId === "string"
+    ? (event as { approvalId: string }).approvalId
+    : "";
+  if (!approvalId || approvalId.length > 256) {
+    throw new Error("Gateway approval request did not include a valid approval id.");
+  }
+  console.error(`Approval requested for ${sanitizeTerminalText(runId, MAX_TEXT_CLIENT_ID_CHARS)}:`);
   const choice = await promptForOneShotApproval(approvalReader, event, {
     interactive: input.isTTY === true,
     writeLine: (line) => console.error(line),
   });
-  ws.send(JSON.stringify({ type: "approval.respond", runId, choice }));
+  sendTextClientMessage(ws, {
+    type: "approval.respond",
+    id: `client_approval_${randomUUID().replaceAll("-", "")}`,
+    runId,
+    approvalId,
+    choice,
+  });
 }
 
 function defaultGatewayWebSocketUrl(config: AppConfig): string {

--- a/src/cli/one-shot-approval.ts
+++ b/src/cli/one-shot-approval.ts
@@ -49,6 +49,10 @@ export async function promptForOneShotApproval(
     return "deny";
   }
   writeLine(`[approval] Available choices: ${approval.choices.join(", ")}. Deny is the safe default.`);
+  if (approval.choices.length === 1 && approval.choices[0] === "deny") {
+    writeLine("[approval] The request details were incomplete or unsafe; denial is the only available choice.");
+    return "deny";
+  }
 
   if (!options.interactive) {
     writeLine("[approval] Standard input is not interactive; denying by default.");
@@ -86,35 +90,46 @@ export async function promptForOneShotApproval(
 
 export function sanitizeOneShotApproval(value: unknown): SanitizedOneShotApproval {
   const approval = recordValue(value);
-  const command = boundedSingleLine(approval?.command, MAX_COMMAND_CHARS);
-  const description = boundedSingleLine(approval?.description, MAX_DESCRIPTION_CHARS);
-  const patternKeys = uniqueStrings([
-    boundedSingleLine(approval?.patternKey, MAX_PATTERN_CHARS),
-    ...(Array.isArray(approval?.patternKeys)
-      ? approval.patternKeys.map((pattern) => boundedSingleLine(pattern, MAX_PATTERN_CHARS))
-      : []),
-  ]).slice(0, MAX_PATTERN_KEYS);
-  const allowPermanent = approval?.allowPermanent === true && patternKeys.length > 0;
-  const choices = uniqueChoices(approval?.choices).filter(
-    (choice) => choice !== "always" || allowPermanent,
-  );
+  const commandProjection = exactDisplayText(approval?.command, MAX_COMMAND_CHARS);
+  const descriptionProjection = exactDisplayText(approval?.description, MAX_DESCRIPTION_CHARS);
+  const command = commandProjection.value;
+  const description = descriptionProjection.value;
+  const displayComplete = commandProjection.exact && descriptionProjection.exact && Boolean(command || description);
+  const patterns = exactPatterns(approval);
+  const patternKeys = displayComplete && patterns.exact ? patterns.values : [];
+  const hasInspectablePermanentPattern = displayComplete && patterns.exact && patternKeys.length > 0;
+  const suppliedChoices = exactChoices(approval?.choices);
+  const choices = suppliedChoices
+    .filter(
+      (choice) =>
+        (displayComplete || choice === "deny") &&
+        ((choice !== "session" && choice !== "always") || hasInspectablePermanentPattern) &&
+        (choice !== "always" || (hasInspectablePermanentPattern && approval?.allowPermanent === true)),
+    )
+    .filter((choice, index, all) => all.indexOf(choice) === index);
+  if (!choices.includes("deny")) choices.push("deny");
+  const allowPermanent = hasInspectablePermanentPattern &&
+    approval?.allowPermanent === true &&
+    choices.includes("always");
 
   return {
     ...(command ? { command } : {}),
     ...(description ? { description } : {}),
     patternKeys,
     choices,
-    allowPermanent: allowPermanent && choices.includes("always"),
+    allowPermanent,
   };
 }
 
-function uniqueChoices(value: unknown): ApprovalChoice[] {
-  if (!Array.isArray(value)) return [];
-  const choices = value.flatMap((choice) => {
+function exactChoices(value: unknown): ApprovalChoice[] {
+  if (!Array.isArray(value) || value.length === 0) return ["deny"];
+  const choices: ApprovalChoice[] = [];
+  for (const choice of value) {
     const parsed = ApprovalChoiceSchema.safeParse(choice);
-    return parsed.success ? [parsed.data] : [];
-  });
-  return [...new Set(choices)];
+    if (!parsed.success) return ["deny"];
+    choices.push(parsed.data);
+  }
+  return choices;
 }
 
 function normalizeChoice(value: string): ApprovalChoice | undefined {
@@ -122,36 +137,57 @@ function normalizeChoice(value: string): ApprovalChoice | undefined {
   return parsed.success ? parsed.data : undefined;
 }
 
-function uniqueStrings(values: Array<string | undefined>): string[] {
-  return [...new Set(values.filter((value): value is string => Boolean(value)))];
+function exactDisplayText(value: unknown, maxChars: number): { value?: string; exact: boolean } {
+  if (value === undefined || value === null || value === "") return { exact: true };
+  if (typeof value !== "string" || /[\r\n\t]/u.test(value)) return { exact: false };
+  const projected = boundedSingleLine(value, maxChars);
+  return projected && projected === value && /[\p{L}\p{N}\p{P}\p{S}]/u.test(projected)
+    ? { value: projected, exact: true }
+    : { exact: false };
+}
+
+function exactPatterns(approval: Record<string, unknown> | undefined): { values: string[]; exact: boolean } {
+  const rawValues: unknown[] = [];
+  if (approval?.patternKey !== undefined && approval.patternKey !== null && approval.patternKey !== "") {
+    rawValues.push(approval.patternKey);
+  }
+  if (approval?.patternKeys !== undefined && approval.patternKeys !== null) {
+    if (!Array.isArray(approval.patternKeys) || approval.patternKeys.length > MAX_PATTERN_KEYS) {
+      return { values: [], exact: false };
+    }
+    rawValues.push(...approval.patternKeys);
+  }
+  if (rawValues.length > MAX_PATTERN_KEYS) return { values: [], exact: false };
+
+  const values: string[] = [];
+  for (const raw of rawValues) {
+    const projected = boundedSingleLine(raw, MAX_PATTERN_CHARS);
+    if (
+      typeof raw !== "string" ||
+      !projected ||
+      projected !== raw ||
+      !/[\p{L}\p{N}\p{P}\p{S}]/u.test(projected)
+    ) {
+      return { values: [], exact: false };
+    }
+    if (!values.includes(projected)) values.push(projected);
+  }
+  return { values, exact: true };
 }
 
 function boundedSingleLine(value: unknown, maxChars: number): string | undefined {
   if (typeof value !== "string") return undefined;
-  const withoutTerminalSequences = value
+  const boundedInput = value.slice(0, maxChars * 4 + 4_096);
+  const withoutTerminalSequences = boundedInput
     .replace(/\u001b\][^\u0007]*(?:\u0007|\u001b\\|$)/g, "")
     .replace(/(?:\u001b\[|\u009b)[0-?]*[ -/]*[@-~]/g, "")
     .replace(/\u001b[@-_]/g, "");
-  const sanitized: string[] = [];
-  for (const character of withoutTerminalSequences) {
-    if (sanitized.length >= maxChars) break;
-    const code = character.charCodeAt(0);
-    if (character === "\n" || character === "\r" || character === "\t") {
-      sanitized.push(" ");
-    } else if (
-      code >= 32 &&
-      code !== 127 &&
-      !(code >= 128 && code <= 159) &&
-      code !== 0x061c &&
-      code !== 0x200e &&
-      code !== 0x200f &&
-      !(code >= 0x202a && code <= 0x202e) &&
-      !(code >= 0x2066 && code <= 0x2069)
-    ) {
-      sanitized.push(character);
-    }
-  }
-  const normalized = sanitized.join("").replace(/\s+/g, " ").trim();
+  const normalized = Array.from(withoutTerminalSequences.normalize("NFC"))
+    .filter((character) => !/[\p{Cc}\p{Cf}\p{Cs}\p{Co}\p{Cn}]/u.test(character))
+    .slice(0, maxChars)
+    .join("")
+    .replace(/\s+/gu, " ")
+    .trim();
   return normalized || undefined;
 }
 

--- a/src/cli/terminal-session.ts
+++ b/src/cli/terminal-session.ts
@@ -4,9 +4,10 @@ import WebSocket from "ws";
 import type { ApprovalChoice } from "../domain/protocol/client-protocol.js";
 import { ApprovalChoiceSchema } from "../domain/protocol/client-protocol.js";
 import { HERMES_LIVE_PROTOCOL_VERSION } from "../domain/protocol/version.js";
+import { sanitizeOneShotApproval } from "./one-shot-approval.js";
 
 const DEFAULT_CONNECT_TIMEOUT_MS = 10_000;
-const MAX_SERVER_MESSAGE_BYTES = 2_000_000;
+const MAX_SERVER_MESSAGE_BYTES = 8_000_000;
 const MAX_TERMINAL_TEXT_CHARS = 20_000;
 const MAX_RENDERED_TEXT_CHARS = 20_000;
 const MAX_PENDING_APPROVALS = 128;
@@ -26,7 +27,7 @@ export interface InteractiveTerminalOptions extends TerminalGatewaySessionOption
 
 export interface PendingTerminalApproval {
   runId: string;
-  approvalId?: string;
+  approvalId: string;
   command?: string;
   description?: string;
   patternKeys: string[];
@@ -262,15 +263,15 @@ export class TerminalGatewaySession {
     }
     if (socket.readyState === WebSocket.OPEN) {
       socket.send(JSON.stringify({ type: "session.close", id: this.nextRequestId() }));
-      socket.close(1000, "terminal session closed");
     } else if (socket.readyState === WebSocket.CONNECTING) {
       socket.terminate();
     }
 
-    await Promise.race([this.closed, delay(750)]);
+    await Promise.race([this.closed, delay(Math.max(12_000, this.connectTimeoutMs))]);
     if (!this.closedResolved) {
       socket.terminate();
       await this.closed;
+      throw new Error("The gateway did not confirm session shutdown; verify any active Hermes task before reconnecting.");
     }
   }
 
@@ -339,6 +340,9 @@ export class TerminalGatewaySession {
       case "run.failed":
         this.renderRunTerminal("failed", message);
         break;
+      case "run.stopping":
+        this.line(`[Hermes] Task stop requested (${safeMessage(message.status, "stopping")}); waiting for terminal confirmation.`);
+        break;
       case "run.stopped":
         this.renderRunTerminal("stopped", message);
         break;
@@ -383,28 +387,24 @@ export class TerminalGatewaySession {
       return;
     }
     const approval = recordValue(message.approval);
-    const command = stringValue(approval?.command);
-    const description = stringValue(approval?.description);
-    const patternKeys = approvalPatternKeys(approval);
-    const informed = Boolean(command || description);
-    const allowPermanent = approval?.allowPermanent === true && patternKeys.length > 0;
-    let choices = approvalChoices(approval?.choices).filter((choice) =>
-      (informed || choice === "once" || choice === "deny") &&
-      (choice !== "always" || allowPermanent),
-    );
-    if (choices.length === 0) choices = ["once", "deny"];
+    const rawApprovalId = stringValue(approval?.approvalId) ?? "";
+    const approvalId = singleLine(rawApprovalId, 256);
+    if (!approvalId || approvalId !== rawApprovalId || !/[\p{L}\p{N}\p{P}\p{S}]/u.test(approvalId)) {
+      throw new Error("Gateway approval request did not include a safe approval id.");
+    }
+    const projected = sanitizeOneShotApproval(approval);
     const pending: PendingTerminalApproval = {
       runId,
-      ...(stringValue(approval?.approvalId) ? { approvalId: stringValue(approval?.approvalId) } : {}),
-      ...(command ? { command } : {}),
-      ...(description ? { description } : {}),
-      patternKeys,
-      choices,
-      allowPermanent: allowPermanent && choices.includes("always"),
+      approvalId,
+      ...(projected.command ? { command: projected.command } : {}),
+      ...(projected.description ? { description: projected.description } : {}),
+      patternKeys: projected.patternKeys,
+      choices: projected.choices,
+      allowPermanent: projected.allowPermanent,
     };
-    const existingIndex = pending.approvalId
-      ? this.pendingApprovals.findIndex((entry) => entry.runId === runId && entry.approvalId === pending.approvalId)
-      : -1;
+    const existingIndex = this.pendingApprovals.findIndex(
+      (entry) => entry.runId === runId && entry.approvalId === pending.approvalId,
+    );
     if (existingIndex >= 0) this.pendingApprovals[existingIndex] = pending;
     else {
       if (this.pendingApprovals.length >= MAX_PENDING_APPROVALS) {
@@ -456,6 +456,7 @@ export class TerminalGatewaySession {
         type: "approval.respond",
         id: this.nextRequestId(),
         runId: pending.runId,
+        approvalId: pending.approvalId,
         choice,
       })
     ) {
@@ -466,16 +467,11 @@ export class TerminalGatewaySession {
 
   private resolvePendingApprovals(message: Record<string, unknown>): void {
     const runId = stringValue(message.runId);
-    if (!runId) return;
-    const suppliedResolved = message.resolved;
-    let remaining = Number.isInteger(suppliedResolved) && Number(suppliedResolved) >= 0
-      ? Number(suppliedResolved)
-      : 1;
-    this.pendingApprovals = this.pendingApprovals.filter((entry) => {
-      if (entry.runId !== runId || remaining <= 0) return true;
-      remaining -= 1;
-      return false;
-    });
+    const approvalId = stringValue(message.approvalId);
+    if (!runId || !approvalId || message.resolved !== 1) return;
+    this.pendingApprovals = this.pendingApprovals.filter(
+      (entry) => entry.runId !== runId || entry.approvalId !== approvalId,
+    );
   }
 
   private renderActionableApproval(pending: PendingTerminalApproval): void {
@@ -483,6 +479,8 @@ export class TerminalGatewaySession {
     if (pending.command) this.line(`[approval] Command: ${singleLine(pending.command, 1_000)}`);
     if (pending.patternKeys.length > 0) {
       this.line(`[approval] Permission pattern: ${pending.patternKeys.map((value) => singleLine(value, 256)).join(", ")}`);
+    } else if (!pending.command && !pending.description) {
+      this.line("[approval] Hermes did not provide enough inspectable action details; this request can only be denied.");
     } else {
       this.line("[approval] Hermes did not provide an inspectable permission pattern; permanent approval is unavailable.");
     }
@@ -721,28 +719,8 @@ function sanitizeMetadata(value: string): string {
   return singleLine(value, 256) || "terminal";
 }
 
-function approvalChoices(value: unknown): ApprovalChoice[] {
-  if (!Array.isArray(value)) return ["once", "deny"];
-  const choices = value.flatMap((choice) => {
-    const parsed = ApprovalChoiceSchema.safeParse(choice);
-    return parsed.success ? [parsed.data] : [];
-  });
-  return choices.length > 0 ? [...new Set(choices)] : ["once", "deny"];
-}
-
-function approvalPatternKeys(approval: Record<string, unknown> | undefined): string[] {
-  const values = [
-    stringValue(approval?.patternKey),
-    ...(Array.isArray(approval?.patternKeys) ? approval.patternKeys.map(stringValue) : []),
-  ]
-    .map((value) => value ? singleLine(value, 256) : undefined)
-    .filter((value): value is string => Boolean(value));
-  return [...new Set(values)].slice(0, 32);
-}
-
 function pendingApprovalIdentity(pending: PendingTerminalApproval): string {
-  const key = pending.approvalId ?? (pending.patternKeys.join("|") || pending.command || "approval");
-  return `${pending.runId}:${key}`;
+  return `${pending.runId}:${pending.approvalId}`;
 }
 
 function clonePendingApproval(pending: PendingTerminalApproval): PendingTerminalApproval {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
 
+export const MAX_COMPATIBLE_AUDIO_FRAME_BYTES = 5_900_000;
+export const MAX_COMPATIBLE_TEXT_CHARS = 1_000_000;
+
 const EnvSchema = z.object({
   NODE_ENV: z.string().optional(),
   HERMES_LIVE_HOST: z.string().default("127.0.0.1"),
@@ -14,8 +17,18 @@ const EnvSchema = z.object({
   HERMES_LIVE_TRUST_CLIENT_IDENTITY: z.string().optional(),
   HERMES_LIVE_RUN_EVENT_DETAIL: z.enum(["summary", "raw", "none"]).default("summary"),
   HERMES_LIVE_MAX_SESSIONS: z.coerce.number().int().positive().default(8),
-  HERMES_LIVE_MAX_AUDIO_BYTES: z.coerce.number().int().positive().default(2_000_000),
-  HERMES_LIVE_MAX_TEXT_CHARS: z.coerce.number().int().positive().default(20_000),
+  HERMES_LIVE_MAX_AUDIO_BYTES: z.coerce
+    .number()
+    .int()
+    .positive()
+    .max(MAX_COMPATIBLE_AUDIO_FRAME_BYTES)
+    .default(2_000_000),
+  HERMES_LIVE_MAX_TEXT_CHARS: z.coerce
+    .number()
+    .int()
+    .positive()
+    .max(MAX_COMPATIBLE_TEXT_CHARS)
+    .default(20_000),
   HERMES_LIVE_PROVIDER_READY_TIMEOUT_MS: z.coerce.number().int().positive().default(15_000),
   HERMES_LIVE_DEMO_ENABLED: z.string().optional(),
 

--- a/src/domain/audio/pcm.ts
+++ b/src/domain/audio/pcm.ts
@@ -1,5 +1,12 @@
 export const GEMINI_LIVE_INPUT_SAMPLE_RATE = 16_000;
 export const CLIENT_CAPTURE_SAMPLE_RATE = 24_000;
+export const MIN_PCM_SAMPLE_RATE = 8_000;
+export const MAX_PCM_SAMPLE_RATE = 192_000;
+
+// Resampling can amplify an inbound frame by up to 24x across the supported
+// rate range. Keep the resulting allocation bounded even if an upstream frame
+// limit is raised or this helper is called outside the gateway.
+export const MAX_RESAMPLED_PCM16_BYTES = 16 * 1024 * 1024;
 
 export interface PcmAudioFrame {
   data: string;
@@ -10,7 +17,8 @@ export function normalizePcm16Audio<T extends PcmAudioFrame>(audio: T, targetRat
   if (!isPcmMimeType(audio.mimeType)) {
     throw new Error(`Unsupported audio mime type for PCM normalization: ${audio.mimeType}`);
   }
-  const sourceRate = parsePcmSampleRate(audio.mimeType) ?? targetRate;
+  const sourceRate = requirePcmSampleRate(audio.mimeType);
+  validatePcmSampleRate(targetRate, "Target PCM sample rate");
   const mimeType = pcmMimeType(targetRate);
   if (sourceRate === targetRate) {
     return { ...audio, mimeType };
@@ -23,14 +31,49 @@ export function parsePcmSampleRate(mimeType: string): number | undefined {
   if (!isPcmMimeType(mimeType)) {
     return undefined;
   }
+
+  const rates: number[] = [];
   for (const param of params) {
-    const [key, value] = param.split("=").map((part) => part.trim());
-    if (key === "rate" && value) {
-      const rate = Number(value);
-      return Number.isFinite(rate) && rate > 0 ? rate : undefined;
+    const separator = param.indexOf("=");
+    const key = (separator === -1 ? param : param.slice(0, separator)).trim();
+    if (key !== "rate") {
+      continue;
     }
+
+    const value = separator === -1 ? "" : param.slice(separator + 1).trim();
+    const rate = Number(value);
+    if (!value || !isValidPcmSampleRate(rate)) {
+      return undefined;
+    }
+    rates.push(rate);
   }
-  return undefined;
+
+  return rates.length === 1 ? rates[0] : undefined;
+}
+
+export function requirePcmSampleRate(mimeType: string): number {
+  const sampleRate = parsePcmSampleRate(mimeType);
+  if (sampleRate === undefined) {
+    throw new Error(
+      `PCM audio mime type must include exactly one integer rate between ${MIN_PCM_SAMPLE_RATE} and ${MAX_PCM_SAMPLE_RATE} Hz.`,
+    );
+  }
+  return sampleRate;
+}
+
+export function isValidPcmSampleRate(sampleRate: unknown): sampleRate is number {
+  return (
+    typeof sampleRate === "number" &&
+    Number.isInteger(sampleRate) &&
+    sampleRate >= MIN_PCM_SAMPLE_RATE &&
+    sampleRate <= MAX_PCM_SAMPLE_RATE
+  );
+}
+
+export function validatePcmSampleRate(sampleRate: unknown, label = "PCM sample rate"): asserts sampleRate is number {
+  if (!isValidPcmSampleRate(sampleRate)) {
+    throw new Error(`${label} must be an integer between ${MIN_PCM_SAMPLE_RATE} and ${MAX_PCM_SAMPLE_RATE} Hz.`);
+  }
 }
 
 export function isPcmMimeType(mimeType: string): boolean {
@@ -38,20 +81,24 @@ export function isPcmMimeType(mimeType: string): boolean {
 }
 
 export function pcmMimeType(sampleRate: number): string {
+  validatePcmSampleRate(sampleRate);
   return `audio/pcm;rate=${sampleRate}`;
 }
 
 export function resamplePcm16Base64(data: string, sourceRate: number, targetRate: number): string {
-  if (sourceRate <= 0 || targetRate <= 0) {
-    throw new Error("PCM sample rates must be positive.");
-  }
+  validatePcmSampleRate(sourceRate, "Source PCM sample rate");
+  validatePcmSampleRate(targetRate, "Target PCM sample rate");
   const source = decodePcm16Base64(data);
   if (source.length === 0 || sourceRate === targetRate) {
     return data;
   }
 
   const outputLength = Math.max(1, Math.round((source.length * targetRate) / sourceRate));
-  const output = Buffer.alloc(outputLength * 2);
+  const outputBytes = outputLength * Int16Array.BYTES_PER_ELEMENT;
+  if (!Number.isSafeInteger(outputBytes) || outputBytes > MAX_RESAMPLED_PCM16_BYTES) {
+    throw new Error(`Resampled PCM16 audio exceeds the ${MAX_RESAMPLED_PCM16_BYTES}-byte allocation limit.`);
+  }
+  const output = Buffer.alloc(outputBytes);
   const scale = sourceRate / targetRate;
 
   for (let i = 0; i < outputLength; i += 1) {

--- a/src/domain/protocol/client-protocol.ts
+++ b/src/domain/protocol/client-protocol.ts
@@ -7,6 +7,7 @@ const CLIENT_MIME_TYPE_MAX_CHARS = 128;
 const MAX_TRUNCATION_AUDIO_MS = 60 * 60 * 1_000;
 
 const RequestIdSchema = z.string().max(REQUEST_ID_MAX_CHARS).optional();
+const RequiredRequestIdSchema = z.string().min(1).max(REQUEST_ID_MAX_CHARS);
 const ClientMetadataStringSchema = z.string().max(CLIENT_METADATA_MAX_CHARS);
 const ClientRequiredMetadataStringSchema = z.string().min(1).max(CLIENT_METADATA_MAX_CHARS);
 const ClientReasonSchema = z.string().max(CLIENT_REASON_MAX_CHARS);
@@ -45,8 +46,9 @@ export const ClientMessageSchema = z.discriminatedUnion("type", [
   }),
   z.object({
     type: z.literal("approval.respond"),
-    id: RequestIdSchema,
+    id: RequiredRequestIdSchema,
     runId: ClientRequiredMetadataStringSchema,
+    approvalId: ClientRequiredMetadataStringSchema,
     choice: ApprovalChoiceSchema,
     resolveAll: z.boolean().optional(),
   }),

--- a/src/domain/protocol/server-protocol.ts
+++ b/src/domain/protocol/server-protocol.ts
@@ -12,7 +12,7 @@ export interface RealtimeClientCapabilities {
 }
 
 export interface HermesApprovalDetails {
-  approvalId?: string;
+  approvalId: string;
   command?: string;
   description?: string;
   patternKey?: string;
@@ -38,13 +38,20 @@ export type ServerMessage =
   | { type: "response.completed"; responseId?: string }
   | { type: "response.cancelled"; responseId?: string }
   | { type: "response.failed"; responseId?: string; error: string }
-  | { type: "realtime.message"; message: unknown }
   | { type: "run.started"; runId: string; sessionId: string }
   | { type: "run.event"; runId: string; event: HermesRunEvent }
   | { type: "approval.request"; runId: string; event: HermesRunEvent; approval: HermesApprovalDetails }
-  | { type: "approval.responded"; runId: string; choice: ApprovalChoice; resolved?: number }
+  | {
+      type: "approval.responded";
+      requestId: string;
+      runId: string;
+      approvalId: string;
+      choice: ApprovalChoice;
+      resolved: 1;
+    }
   | { type: "run.completed"; runId: string; output: string; usage?: Record<string, unknown> }
   | { type: "run.failed"; runId: string; error: string }
+  | { type: "run.stopping"; runId: string; status: string }
   | { type: "run.stopped"; runId: string; status: string }
   | { type: "log"; level: "debug" | "info" | "warn" | "error"; message: string; data?: unknown };
 

--- a/src/domain/protocol/version.ts
+++ b/src/domain/protocol/version.ts
@@ -1,3 +1,3 @@
-export const HERMES_LIVE_PROTOCOL_VERSION = 1 as const;
+export const HERMES_LIVE_PROTOCOL_VERSION = 2 as const;
 
 export type HermesLiveProtocolVersion = typeof HERMES_LIVE_PROTOCOL_VERSION;

--- a/src/live-provider-smoke.ts
+++ b/src/live-provider-smoke.ts
@@ -133,10 +133,6 @@ function summarizeLiveEvent(event: LiveModelEvent): Record<string, unknown> {
       return { type: "input_speech_started", provider: event.provider };
     case "response":
       return { type: "response", status: event.status };
-    case "raw": {
-      const message = event.message as any;
-      return { type: "raw", messageType: message?.type ?? message?.serverContent?.turnComplete ?? "unknown" };
-    }
   }
 }
 

--- a/test/audio-pcm.test.ts
+++ b/test/audio-pcm.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { normalizePcm16Audio, parsePcmSampleRate, pcmMimeType, resamplePcm16Base64 } from "../src/domain/audio/pcm.js";
+import {
+  MAX_RESAMPLED_PCM16_BYTES,
+  normalizePcm16Audio,
+  parsePcmSampleRate,
+  pcmMimeType,
+  requirePcmSampleRate,
+  resamplePcm16Base64,
+  validatePcmSampleRate,
+} from "../src/domain/audio/pcm.js";
 
 describe("PCM audio helpers", () => {
   it("parses PCM sample rates", () => {
@@ -7,8 +15,23 @@ describe("PCM audio helpers", () => {
     expect(parsePcmSampleRate("audio/wav;rate=24000")).toBeUndefined();
   });
 
+  it.each([0, 24_000.5, 7_999, 192_001])("rejects invalid PCM sample rate %s", (sampleRate) => {
+    expect(parsePcmSampleRate(`audio/pcm;rate=${sampleRate}`)).toBeUndefined();
+    expect(() => validatePcmSampleRate(sampleRate)).toThrow(/integer between 8000 and 192000/);
+  });
+
+  it("requires explicit valid source rate metadata", () => {
+    expect(parsePcmSampleRate("audio/pcm")).toBeUndefined();
+    expect(() => requirePcmSampleRate("audio/pcm")).toThrow(/must include exactly one integer rate/);
+    expect(() => requirePcmSampleRate("audio/pcm;rate=not-a-number")).toThrow(/must include exactly one integer rate/);
+    expect(() => requirePcmSampleRate("audio/pcm;rate=24000;rate=16000")).toThrow(
+      /must include exactly one integer rate/,
+    );
+  });
+
   it("builds PCM mime types", () => {
     expect(pcmMimeType(16000)).toBe("audio/pcm;rate=16000");
+    expect(() => pcmMimeType(16_000.5)).toThrow(/integer between 8000 and 192000/);
   });
 
   it("keeps audio unchanged when rate already matches", () => {
@@ -19,14 +42,46 @@ describe("PCM audio helpers", () => {
     });
   });
 
+  it("does not infer missing or malformed source rates during normalization", () => {
+    const data = Buffer.from([0, 0]).toString("base64");
+
+    expect(() => normalizePcm16Audio({ data, mimeType: "audio/pcm" }, 24_000)).toThrow(/must include exactly one/);
+    expect(() => normalizePcm16Audio({ data, mimeType: "audio/pcm;rate=0" }, 24_000)).toThrow(
+      /must include exactly one/,
+    );
+  });
+
+  it("validates normalization target rates", () => {
+    const data = Buffer.from([0, 0]).toString("base64");
+
+    expect(() => normalizePcm16Audio({ data, mimeType: "audio/pcm;rate=24000" }, 0)).toThrow(
+      /Target PCM sample rate must be an integer/,
+    );
+  });
+
   it("resamples PCM16 base64", () => {
     const input = Buffer.alloc(4);
     input.writeInt16LE(-1000, 0);
     input.writeInt16LE(1000, 2);
 
-    const output = Buffer.from(resamplePcm16Base64(input.toString("base64"), 2, 4), "base64");
+    const output = Buffer.from(resamplePcm16Base64(input.toString("base64"), 8_000, 16_000), "base64");
 
     expect(output.length).toBe(8);
+  });
+
+  it("validates direct resampling rates", () => {
+    const input = Buffer.from([0, 0]).toString("base64");
+
+    expect(() => resamplePcm16Base64(input, 0, 24_000)).toThrow(/Source PCM sample rate must be an integer/);
+    expect(() => resamplePcm16Base64(input, 24_000, 192_000.5)).toThrow(/Target PCM sample rate must be an integer/);
+  });
+
+  it("caps resampled output allocation before amplification", () => {
+    const maximumInputBytes = Math.floor(MAX_RESAMPLED_PCM16_BYTES / (192_000 / 8_000));
+    const oversizedInputBytes = maximumInputBytes + (maximumInputBytes % 2 === 0 ? 2 : 1);
+    const input = Buffer.alloc(oversizedInputBytes).toString("base64");
+
+    expect(() => resamplePcm16Base64(input, 8_000, 192_000)).toThrow(/allocation limit/);
   });
 
   it("rejects odd PCM byte counts", () => {

--- a/test/browser-client.test.ts
+++ b/test/browser-client.test.ts
@@ -75,10 +75,52 @@ describe("HermesLiveClient", () => {
     const connection = client.connect();
     const socket = await nextSocket();
     socket.open();
-    socket.message({ type: "session.ready", protocolVersion: 1 });
+    socket.message({ type: "session.ready", protocolVersion: 2 });
 
     await expect(connection).rejects.toThrow(/requires sessionId/);
     expect(socket.closeCalls.at(-1)).toMatchObject({ code: 4000, reason: "invalid server message" });
+  });
+
+  it("never widens malformed approval details beyond deny-only", () => {
+    const transformed = validateServerMessage({
+      type: "approval.request",
+      runId: "run_approval",
+      event: { event: "approval.request" },
+      approval: {
+        approvalId: "approval_safe",
+        command: "git\u001b[2J push",
+        description: "Deploy\nproduction",
+        patternKey: "terminal:git-push\u001b[31m",
+        choices: ["once", "session", "always", "deny"],
+        allowPermanent: true,
+      },
+    });
+    const invalidChoices = validateServerMessage({
+      type: "approval.request",
+      runId: "run_approval",
+      event: { event: "approval.request" },
+      approval: {
+        approvalId: "approval_safe_2",
+        command: "git push",
+        patternKey: "terminal:git-push",
+        choices: ["once", "forever", "deny"],
+        allowPermanent: true,
+      },
+    });
+
+    const transformedApproval = (transformed as any).approval;
+    const invalidChoiceApproval = (invalidChoices as any).approval;
+    expect(transformedApproval).toMatchObject({
+      approvalId: "approval_safe",
+      choices: ["deny"],
+      allowPermanent: false,
+    });
+    expect(transformedApproval).not.toHaveProperty("patternKey");
+    expect(invalidChoiceApproval).toMatchObject({
+      approvalId: "approval_safe_2",
+      choices: ["deny"],
+      allowPermanent: false,
+    });
   });
 
   it("decodes only the addressed typed-array slice", async () => {
@@ -91,6 +133,18 @@ describe("HermesLiveClient", () => {
     socket.message(payload.subarray(4, payload.length - 4));
 
     await expect(connection).resolves.toMatchObject({ sessionId: "live_slice" });
+  });
+
+  it("applies inbound message limits in UTF-8 bytes", async () => {
+    const payload = JSON.stringify({ ...readyMessage("live_utf8"), model: "🙂".repeat(30) });
+    const client = createClient({ maxInboundMessageBytes: payload.length });
+    const connection = client.connect();
+    const socket = await nextSocket();
+    socket.open();
+    socket.message(payload);
+
+    await expect(connection).rejects.toThrow("server message exceeded the configured client limit");
+    expect(socket.closeCalls.at(-1)).toMatchObject({ code: 4000, reason: "invalid server message" });
   });
 
   it("drops microphone frames when the WebSocket is backed up", async () => {
@@ -142,6 +196,38 @@ describe("HermesLiveClient", () => {
     await connection;
   });
 
+  it("times out stalled ephemeral URL resolution before opening a socket", async () => {
+    vi.useFakeTimers();
+    try {
+      const client = createClient({
+        url: undefined,
+        webSocketUrlProvider: () => new Promise(() => undefined),
+        connectTimeoutMs: 25,
+      });
+      const connection = client.connect();
+      const result = expect(connection).rejects.toThrow("gateway URL or token did not resolve within 25ms");
+      await vi.advanceTimersByTimeAsync(25);
+
+      await result;
+      expect(FakeWebSocket.instances).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("aborts stalled ephemeral URL resolution", async () => {
+    const controller = new AbortController();
+    const client = createClient({
+      url: undefined,
+      webSocketUrlProvider: () => new Promise(() => undefined),
+    });
+    const connection = client.connect({ signal: controller.signal });
+    controller.abort();
+
+    await expect(connection).rejects.toMatchObject({ name: "AbortError" });
+    expect(FakeWebSocket.instances).toHaveLength(0);
+  });
+
   it("ignores messages from a replaced socket generation", async () => {
     const client = createClient();
     const firstConnection = client.connect();
@@ -149,10 +235,14 @@ describe("HermesLiveClient", () => {
     first.open();
     first.message(readyMessage("old"));
     await firstConnection;
-    await client.disconnect();
+    const disconnecting = client.disconnect();
+    await vi.waitFor(() => expect(first.sent.some((message) => message.type === "session.close")).toBe(true));
+    first.serverClose(1000, "session closed");
+    await disconnecting;
 
     const secondConnection = client.connect();
-    const second = await nextSocket();
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(2));
+    const second = FakeWebSocket.instances[1]!;
     first.message({ type: "run.started", runId: "stale", sessionId: "old" });
     second.open();
     second.message(readyMessage("new"));
@@ -178,7 +268,7 @@ describe("HermesLiveClient", () => {
     expect(unknown).toHaveBeenCalledWith({ type: "future.event", value: 42 });
   });
 
-  it("preserves approval FIFO order and removes only the resolved queue entries", async () => {
+  it("preserves approval FIFO order and resolves only the correlated approval id", async () => {
     const client = createClient();
     const connection = client.connect();
     const socket = await nextSocket();
@@ -193,22 +283,51 @@ describe("HermesLiveClient", () => {
       client.getSnapshot().pendingApprovals.map((entry: any) => entry.approval.command),
     ).toEqual(["updated first command", "second command"]));
 
-    socket.message({ type: "approval.responded", runId: "run_approval", choice: "once", resolved: 1 });
+    socket.message({
+      type: "approval.responded",
+      requestId: "response_1",
+      runId: "run_approval",
+      approvalId: "approval_1",
+      choice: "once",
+      resolved: 1,
+    });
     await flushMessages();
     expect(client.getSnapshot().pendingApprovals.map((entry: any) => entry.approval.command)).toEqual([
       "second command",
     ]);
 
     socket.message(approvalRequest("run_approval", "approval_3", "third command"));
-    socket.message({ type: "approval.responded", runId: "run_approval", choice: "deny", resolved: 0 });
+    socket.message({
+      type: "approval.responded",
+      requestId: "response_1",
+      runId: "run_approval",
+      approvalId: "approval_1",
+      choice: "once",
+      resolved: 1,
+    });
     await flushMessages();
     expect(client.getSnapshot().pendingApprovals).toHaveLength(2);
 
-    socket.message({ type: "approval.responded", runId: "run_approval", choice: "deny", resolved: 2 });
+    socket.message({
+      type: "approval.responded",
+      requestId: "response_2",
+      runId: "run_approval",
+      approvalId: "approval_2",
+      choice: "deny",
+      resolved: 1,
+    });
+    socket.message({
+      type: "approval.responded",
+      requestId: "response_3",
+      runId: "run_approval",
+      approvalId: "approval_3",
+      choice: "deny",
+      resolved: 1,
+    });
     await vi.waitFor(() => expect(client.getSnapshot().pendingApprovals).toEqual([]));
   });
 
-  it("bounds browser close reasons without failing disconnect cleanup", async () => {
+  it("waits for the gateway to confirm protocol shutdown", async () => {
     const client = createClient();
     const connection = client.connect();
     const socket = await nextSocket();
@@ -216,36 +335,50 @@ describe("HermesLiveClient", () => {
     socket.message(readyMessage("live_1"));
     await connection;
 
-    await expect(client.disconnect(`line one\n${"🚫".repeat(100)}`)).resolves.toBeUndefined();
-    const close = socket.closeCalls.at(-1);
-    expect(close?.code).toBe(1000);
-    expect(close?.reason).not.toContain("\n");
-    expect(Buffer.byteLength(close?.reason ?? "", "utf8")).toBeLessThanOrEqual(123);
+    const disconnecting = client.disconnect(`line one\n${"🚫".repeat(100)}`);
+    await vi.waitFor(() => expect(socket.sent.some((message) => message.type === "session.close")).toBe(true));
+    expect(socket.closeCalls).toEqual([]);
+    socket.serverClose(1000, "session closed");
+    await expect(disconnecting).resolves.toBeUndefined();
+  });
+
+  it("rejects abnormal shutdown with the gateway's actionable error", async () => {
+    const client = createClient();
+    const connection = client.connect();
+    const socket = await nextSocket();
+    socket.open();
+    socket.message(readyMessage("live_unconfirmed_close"));
+    await connection;
+
+    const disconnecting = client.disconnect();
+    await vi.waitFor(() => expect(socket.sent.some((message) => message.type === "session.close")).toBe(true));
+    socket.message({
+      type: "session.error",
+      code: "session_shutdown_unconfirmed",
+      message: "Verify the active task state in Hermes.",
+      recoverable: false,
+    });
+
+    await expect(disconnecting).rejects.toThrow("Verify the active task state in Hermes.");
+    expect(client.getSnapshot()).toMatchObject({ connection: "closed", run: { state: "idle" } });
   });
 
   it("recovers to a reconnectable state when a browser never emits close", async () => {
-    const client = createClient();
+    const client = createClient({ disconnectTimeoutMs: 25 });
     const connection = client.connect();
     const socket = await nextSocket();
     socket.open();
     socket.message(readyMessage("live_stuck_close"));
     await connection;
     socket.suppressCloseEvent = true;
-    vi.useFakeTimers();
 
-    try {
-      const disconnecting = client.disconnect("test stuck close");
-      await vi.advanceTimersByTimeAsync(1_001);
-      await disconnecting;
-      expect(client.getSnapshot()).toMatchObject({
-        connection: "closed",
-        run: { state: "idle" },
-        pendingApprovals: [],
-      });
-      expect(client.connected).toBe(false);
-    } finally {
-      vi.useRealTimers();
-    }
+    await expect(client.disconnect("test stuck close")).rejects.toThrow("did not confirm session shutdown");
+    expect(client.getSnapshot()).toMatchObject({
+      connection: "closed",
+      run: { state: "idle" },
+      pendingApprovals: [],
+    });
+    expect(client.connected).toBe(false);
   });
 });
 
@@ -383,6 +516,34 @@ describe("browser client utilities", () => {
   it("validates state-changing server messages", () => {
     expect(() => validateServerMessage({ type: "run.started", runId: "run" })).toThrow(/sessionId/);
   });
+
+  it("rejects out-of-contract enums from known server messages", () => {
+    expect(() => validateServerMessage({
+      ...readyMessage("live_invalid_provider"),
+      realtime: { ...readyMessage("x").realtime, provider: "other" },
+    })).toThrow(/unsupported provider/);
+    expect(() => validateServerMessage({
+      ...readyMessage("live_invalid_vad"),
+      realtime: {
+        ...readyMessage("x").realtime,
+        audio: { ...readyMessage("x").realtime.audio, turnDetection: "magic_vad" },
+      },
+    })).toThrow(/unsupported turnDetection/);
+    expect(() => validateServerMessage({ type: "transcript.delta", speaker: "tool", text: "hi" }))
+      .toThrow(/unsupported speaker/);
+    expect(() => validateServerMessage({ type: "input.speech_started", provider: "gemini" }))
+      .toThrow(/unsupported provider/);
+    expect(() => validateServerMessage({
+      type: "approval.responded",
+      requestId: "request_1",
+      runId: "run_1",
+      approvalId: "approval_1",
+      choice: "everything",
+      resolved: 1,
+    })).toThrow(/unsupported choice/);
+    expect(() => validateServerMessage({ type: "log", level: "fatal", message: "no" }))
+      .toThrow(/unsupported level/);
+  });
 });
 
 function createClient(overrides: Record<string, unknown> = {}): HermesLiveClient {
@@ -400,7 +561,7 @@ function createClient(overrides: Record<string, unknown> = {}): HermesLiveClient
 function readyMessage(sessionId: string) {
   return {
     type: "session.ready",
-    protocolVersion: 1,
+    protocolVersion: 2,
     sessionId,
     model: "mock-live",
     hermes: {},
@@ -487,6 +648,11 @@ class FakeWebSocket {
       this.readyState = 2;
       return;
     }
+    this.readyState = 3;
+    this.emit("close", { code, reason, wasClean: code === 1000 });
+  }
+
+  serverClose(code = 1000, reason = ""): void {
     this.readyState = 3;
     this.emit("close", { code, reason, wasClean: code === 1000 });
   }

--- a/test/cli-approval.test.ts
+++ b/test/cli-approval.test.ts
@@ -6,18 +6,18 @@ import {
 } from "../src/cli/one-shot-approval.js";
 
 describe("one-shot CLI approvals", () => {
-  it("renders sanitized request details and offers only supplied valid choices", async () => {
+  it("renders exact safe request details and offers only supplied valid choices", async () => {
     const questions = questioner("session");
     const lines: string[] = [];
 
     const choice = await promptForOneShotApproval(
       questions,
       {
-        command: "git\u001b[2J push\norigin main",
-        description: "Push the release\u0000 to origin",
-        patternKey: "git_push\u001b[31m",
+        command: "git push origin main",
+        description: "Push the release to origin",
+        patternKey: "git_push",
         patternKeys: ["git_push", "git_tag"],
-        choices: ["once", "invalid", "session", "session", "always", "deny"],
+        choices: ["once", "session", "session", "always", "deny"],
         allowPermanent: true,
       },
       { interactive: true, writeLine: (line) => lines.push(line) },
@@ -30,8 +30,28 @@ describe("one-shot CLI approvals", () => {
     expect(lines).toContain("[approval] Command: git push origin main");
     expect(lines).toContain("[approval] Permission pattern: git_push, git_tag");
     expect(lines).toContain("[approval] Available choices: once, session, always, deny. Deny is the safe default.");
-    expect(lines.join("\n")).not.toContain("invalid");
     expect(lines.every((line) => !/[\u0000-\u001f\u007f-\u009f]/.test(line))).toBe(true);
+  });
+
+  it("reduces transformed or partially invalid request details to deny-only", async () => {
+    const questions = questioner("once");
+    const lines: string[] = [];
+
+    const choice = await promptForOneShotApproval(
+      questions,
+      {
+        command: "git\u001b[2J push",
+        description: "Push\nproduction",
+        patternKey: "git_push\u001b[31m",
+        choices: ["once", "session", "always", "deny"],
+        allowPermanent: true,
+      },
+      { interactive: true, writeLine: (line) => lines.push(line) },
+    );
+
+    expect(choice).toBe("deny");
+    expect(questions.question).not.toHaveBeenCalled();
+    expect(lines).toContain("[approval] The request details were incomplete or unsafe; denial is the only available choice.");
   });
 
   it.each([
@@ -43,7 +63,7 @@ describe("one-shot CLI approvals", () => {
 
     const choice = await promptForOneShotApproval(
       questions,
-      { ...approval, choices: ["once", "always", "deny"] },
+      { command: "git push", ...approval, choices: ["once", "always", "deny"] },
       { interactive: true },
     );
 
@@ -56,6 +76,7 @@ describe("one-shot CLI approvals", () => {
     const cancelled = questioner("always", "no");
     const confirmed = questioner("always", "ALWAYS");
     const approval = {
+      command: "git push",
       choices: ["once", "always", "deny"],
       allowPermanent: true,
       patternKey: "git_push",
@@ -82,6 +103,7 @@ describe("one-shot CLI approvals", () => {
     const choice = await promptForOneShotApproval(
       questions,
       {
+        command: "git push",
         choices: ["always"],
         allowPermanent: true,
         patternKey: "git_push",
@@ -109,13 +131,14 @@ describe("one-shot CLI approvals", () => {
 
   it("deduplicates and bounds inspectable patterns before enabling always", () => {
     const approval = sanitizeOneShotApproval({
+      command: "release package",
       choices: ["always", "deny"],
       allowPermanent: true,
       patternKey: "same",
-      patternKeys: ["same", ...Array.from({ length: 40 }, (_, index) => `pattern_${index}`)],
+      patternKeys: ["same", ...Array.from({ length: 30 }, (_, index) => `pattern_${index}`)],
     });
 
-    expect(approval.patternKeys).toHaveLength(32);
+    expect(approval.patternKeys).toHaveLength(31);
     expect(approval.patternKeys.slice(0, 3)).toEqual(["same", "pattern_0", "pattern_1"]);
     expect(approval.choices).toEqual(["always", "deny"]);
     expect(approval.allowPermanent).toBe(true);

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { assertRuntimeConfig, loadConfig, makeSessionKey, realtimeProviderConfigured, sanitizeSessionComponent } from "../src/config.js";
+import {
+  MAX_COMPATIBLE_AUDIO_FRAME_BYTES,
+  MAX_COMPATIBLE_TEXT_CHARS,
+  assertRuntimeConfig,
+  loadConfig,
+  makeSessionKey,
+  realtimeProviderConfigured,
+  sanitizeSessionComponent,
+} from "../src/config.js";
 
 describe("config", () => {
   it("loads defaults and selects Gemini as the default provider", () => {
@@ -39,6 +47,20 @@ describe("config", () => {
     const config = loadConfig({ HERMES_LIVE_MAX_TEXT_CHARS: "1234" });
 
     expect(config.server.maxTextChars).toBe(1234);
+  });
+
+  it("keeps configured audio frames compatible with bundled clients", () => {
+    expect(loadConfig({ HERMES_LIVE_MAX_AUDIO_BYTES: String(MAX_COMPATIBLE_AUDIO_FRAME_BYTES) }).server.maxAudioBytes)
+      .toBe(MAX_COMPATIBLE_AUDIO_FRAME_BYTES);
+    expect(() => loadConfig({ HERMES_LIVE_MAX_AUDIO_BYTES: String(MAX_COMPATIBLE_AUDIO_FRAME_BYTES + 1) }))
+      .toThrow();
+  });
+
+  it("keeps configured text frames compatible with the bounded client queue", () => {
+    expect(loadConfig({ HERMES_LIVE_MAX_TEXT_CHARS: String(MAX_COMPATIBLE_TEXT_CHARS) }).server.maxTextChars)
+      .toBe(MAX_COMPATIBLE_TEXT_CHARS);
+    expect(() => loadConfig({ HERMES_LIVE_MAX_TEXT_CHARS: String(MAX_COMPATIBLE_TEXT_CHARS + 1) }))
+      .toThrow();
   });
 
   it("configures trusted identity, event detail, and session capacity explicitly", () => {

--- a/test/dashboard-plugin.test.ts
+++ b/test/dashboard-plugin.test.ts
@@ -63,6 +63,7 @@ describe("Hermes Dashboard plugin", () => {
     expect(source).toContain("Interrupt speech");
     expect(source).toContain("Stop Hermes task");
     expect(source).toContain('audio.interrupt("provider detected user speech")');
+    expect(source).toContain('audio.interrupt("new Dashboard text input")');
     expect(source).toContain("audio.clearPlayback()");
   });
 

--- a/test/gemini-live.test.ts
+++ b/test/gemini-live.test.ts
@@ -58,7 +58,7 @@ describe("Gemini Live adapter helpers", () => {
 
     expect(events).toContainEqual({ type: "text", text: "hello" });
     expect(events).toContainEqual({ type: "audio", audio: { data: "abc", mimeType: "audio/pcm;rate=24000" } });
-    expect(events.at(-1)).toMatchObject({ type: "raw" });
+    expect(events).toHaveLength(2);
   });
 
   it("normalizes top-level Gemini audio data", () => {
@@ -71,7 +71,7 @@ describe("Gemini Live adapter helpers", () => {
       type: "audio",
       audio: { data: "base64-audio", mimeType: "audio/pcm;rate=24000" },
     });
-    expect(events.at(-1)).toMatchObject({ type: "raw" });
+    expect(events).toHaveLength(2);
     expect(events).toContainEqual({ type: "response", status: "completed" });
   });
 

--- a/test/hermes-client.test.ts
+++ b/test/hermes-client.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { HermesClient } from "../src/adapters/outbound/hermes/hermes-runs.client.js";
+import {
+  HermesClient,
+  MAX_HERMES_JSON_RESPONSE_BYTES,
+} from "../src/adapters/outbound/hermes/hermes-runs.client.js";
 
 const fetchMock = vi.fn<typeof fetch>();
 
@@ -40,6 +43,23 @@ describe("HermesClient", () => {
       session_id: "live_1",
       instructions: "be brief",
     });
+  });
+
+  it.each([
+    ["missing ids", { status: "queued" }],
+    ["an unsafe snake-case id", { run_id: "run\nother", status: "queued" }],
+    ["an unsafe camel-case alias", { run_id: "run_123", runId: "run\nother", status: "queued" }],
+    ["conflicting aliases", { run_id: "run_123", runId: "run_other", status: "queued" }],
+  ])("rejects start responses with %s", async (_label, body) => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(body));
+    vi.stubGlobal("fetch", fetchMock);
+    const client = hermesClient();
+
+    await expect(client.startRun({
+      input: "check the repo",
+      sessionId: "live_1",
+      sessionKey: "agent:main:hermes-live:profile:default:user:alice",
+    })).rejects.toThrow(/run|identifier/i);
   });
 
   it("omits the Hermes session key header when the Hermes client is unauthenticated", async () => {
@@ -141,6 +161,26 @@ describe("HermesClient", () => {
     await vi.advanceTimersByTimeAsync(25);
 
     await result;
+  });
+
+  it("cancels Hermes JSON bodies that exceed the response safety limit", async () => {
+    let cancelled = false;
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(MAX_HERMES_JSON_RESPONSE_BYTES + 1));
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+    fetchMock.mockResolvedValueOnce(new Response(stream, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const client = hermesClient();
+
+    await expect(client.getRun("run_oversized")).rejects.toThrow(
+      `Hermes response exceeded the ${MAX_HERMES_JSON_RESPONSE_BYTES}-byte safety limit.`,
+    );
+    expect(cancelled).toBe(true);
   });
 
   it("streams run events through SSE with the Hermes session key header", async () => {

--- a/test/live-websocket.test.ts
+++ b/test/live-websocket.test.ts
@@ -10,6 +10,7 @@ import type {
   LiveModelAudio,
   LiveModelCallbacks,
   LiveModelConnectParams,
+  LiveModelEvent,
   LiveModelSession,
   LiveToolCall,
 } from "../src/application/live-gateway/ports/realtime-model.port.js";
@@ -54,6 +55,61 @@ describe("live gateway WebSocket", () => {
     });
   });
 
+  it("fails closed when a provider emits an oversized transcript delta", async () => {
+    const liveModel = new ManualProviderEventAdapter();
+    const server = await startServer({
+      config: testConfig(),
+      hermes: fakeHermes(),
+      liveModel,
+      logger: fakeLogger(),
+    });
+    openServers.push(server);
+    const socket = new WebSocket(toWebSocketUrl(server.url), { headers: { origin: server.url } });
+    openSockets.push(socket);
+
+    await waitForOpen(socket);
+    send(socket, { type: "session.start" });
+    await waitForMessage(socket, "session.ready");
+    const closed = waitForClose(socket);
+    liveModel.emit({ type: "text", text: "x".repeat(20_001) });
+
+    await expect(waitForMessage(socket, "session.error")).resolves.toMatchObject({
+      code: "realtime_provider_event_invalid",
+      recoverable: false,
+      message: expect.stringContaining("Realtime provider transcript delta exceeds 20000 characters"),
+    });
+    await expect(closed).resolves.toMatchObject({ code: 1011 });
+  });
+
+  it("fails closed when a provider emits an oversized audio frame", async () => {
+    const liveModel = new ManualProviderEventAdapter();
+    const server = await startServer({
+      config: testConfig({ server: { maxAudioBytes: 2 } }),
+      hermes: fakeHermes(),
+      liveModel,
+      logger: fakeLogger(),
+    });
+    openServers.push(server);
+    const socket = new WebSocket(toWebSocketUrl(server.url), { headers: { origin: server.url } });
+    openSockets.push(socket);
+
+    await waitForOpen(socket);
+    send(socket, { type: "session.start" });
+    await waitForMessage(socket, "session.ready");
+    const closed = waitForClose(socket);
+    liveModel.emit({
+      type: "audio",
+      audio: { data: Buffer.from([1, 2, 3, 4]).toString("base64"), mimeType: "audio/pcm;rate=24000" },
+    });
+
+    await expect(waitForMessage(socket, "session.error")).resolves.toMatchObject({
+      code: "realtime_provider_event_invalid",
+      recoverable: false,
+      message: expect.stringContaining("HERMES_LIVE_MAX_AUDIO_BYTES"),
+    });
+    await expect(closed).resolves.toMatchObject({ code: 1011 });
+  });
+
   it("runs the text protocol through the real gateway WebSocket", async () => {
     const hermes = fakeHermes();
     const server = await startServer({
@@ -72,7 +128,7 @@ describe("live gateway WebSocket", () => {
 
     expect(ready).toMatchObject({
       type: "session.ready",
-      protocolVersion: 1,
+      protocolVersion: 2,
       model: "mock-live",
       realtime: {
         provider: "mock",
@@ -98,6 +154,99 @@ describe("live gateway WebSocket", () => {
       }),
       expect.any(AbortSignal),
     );
+  });
+
+  it("returns the Hermes tool result immediately after a terminal completion event", async () => {
+    const iteratorClosed = deferred<void>();
+    const liveModel = new ManualToolAdapter();
+    const hermes = fakeHermes({
+      streamEvents: async function* () {
+        try {
+          yield { event: "run.completed", output: "Terminal result." };
+          await new Promise(() => undefined);
+        } finally {
+          iteratorClosed.resolve();
+        }
+      },
+    });
+    const server = await startServer({
+      config: testConfig(),
+      hermes,
+      liveModel,
+      logger: fakeLogger(),
+    });
+    openServers.push(server);
+    const socket = new WebSocket(toWebSocketUrl(server.url), { headers: { origin: server.url } });
+    openSockets.push(socket);
+
+    await waitForOpen(socket);
+    send(socket, { type: "session.start" });
+    await waitForMessage(socket, "session.ready");
+    send(socket, { type: "text.input", text: "Complete, then leave SSE open" });
+
+    await expect(liveModel.nextToolResponse()).resolves.toMatchObject({
+      response: { ok: true, run_id: "run_ws", output: "Terminal result." },
+    });
+    await iteratorClosed.promise;
+  });
+
+  it("orders run.started before a provider terminal event emitted during Hermes startup", async () => {
+    const startCalled = deferred<void>();
+    const startResult = deferred<{ runId: string; status: string }>();
+    const finishRun = deferred<void>();
+    const liveModel = new ManualToolAdapter();
+    const hermes = fakeHermes({
+      startRun: vi.fn(async () => {
+        startCalled.resolve();
+        return await startResult.promise;
+      }),
+      streamEvents: async function* () {
+        await finishRun.promise;
+        yield { event: "run.completed", output: "Finished." };
+      },
+    });
+    const server = await startServer({
+      config: testConfig(),
+      hermes,
+      liveModel,
+      logger: fakeLogger(),
+    });
+    openServers.push(server);
+    const socket = new WebSocket(toWebSocketUrl(server.url), { headers: { origin: server.url } });
+    openSockets.push(socket);
+    const observed: any[] = [];
+
+    await waitForOpen(socket);
+    send(socket, { type: "session.start" });
+    await waitForMessage(socket, "session.ready");
+    socket.on("message", (raw) => observed.push(JSON.parse(raw.toString("utf8"))));
+    send(socket, { type: "text.input", text: "Start slowly" });
+    await startCalled.promise;
+    liveModel.emitToolCall({
+      id: "parallel_start",
+      name: "start_hermes_run",
+      args: { message: "Do not start twice" },
+    });
+    await expect(liveModel.nextToolResponse()).resolves.toMatchObject({
+      call: { id: "parallel_start" },
+      response: { ok: false, error: "A Hermes run is already active for this voice session." },
+    });
+    expect(hermes.startRun).toHaveBeenCalledTimes(1);
+    liveModel.emitEvent({ type: "response", status: "completed", responseId: "provider_tool_turn" });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(observed.some((message) => message.type === "response.completed")).toBe(false);
+
+    const runStarted = waitForMessage(socket, "run.started");
+    const responseCompleted = waitForMessage(socket, "response.completed");
+    startResult.resolve({ runId: "run_ws", status: "started" });
+    await runStarted;
+    await responseCompleted;
+    const runStartedIndex = observed.findIndex((message) => message.type === "run.started");
+    const responseCompletedIndex = observed.findIndex((message) => message.type === "response.completed");
+    expect(runStartedIndex).toBeGreaterThanOrEqual(0);
+    expect(responseCompletedIndex).toBeGreaterThan(runStartedIndex);
+    finishRun.resolve();
+    await liveModel.nextToolResponse();
   });
 
   it("uses client-selected Hermes identity only when explicitly trusted", async () => {
@@ -161,6 +310,69 @@ describe("live gateway WebSocket", () => {
     await completed;
   });
 
+  it("bounds raw Hermes run events before forwarding them to clients", async () => {
+    const hermes = fakeHermes({
+      streamEvents: async function* () {
+        yield { event: "tool.started", run_id: "run_ws", args: { output: "x".repeat(300_000) } };
+        yield { event: "run.completed", output: "Finished." };
+      },
+    });
+    const server = await startServer({
+      config: testConfig({ server: { runEventDetail: "raw" } }),
+      hermes,
+      liveModel: new MockLiveAdapter(),
+      logger: fakeLogger(),
+    });
+    openServers.push(server);
+    const socket = new WebSocket(toWebSocketUrl(server.url), { headers: { origin: server.url } });
+    openSockets.push(socket);
+
+    await waitForOpen(socket);
+    send(socket, { type: "session.start" });
+    await waitForMessage(socket, "session.ready");
+    const completed = waitForMessage(socket, "run.completed");
+    send(socket, { type: "text.input", text: "Run a tool" });
+    const runEvent = await waitForMessage(socket, "run.event");
+
+    expect(runEvent.event).toMatchObject({
+      event: "tool.started",
+      run_id: "run_ws",
+      truncated: true,
+      original_bytes: expect.any(Number),
+    });
+    expect(JSON.stringify(runEvent)).not.toContain("x".repeat(1_000));
+    await completed;
+  });
+
+  it("bounds Hermes run output retained and returned by the bridge", async () => {
+    const liveModel = new ManualToolAdapter();
+    const hermes = fakeHermes({
+      streamEvents: async function* () {
+        yield { event: "run.completed", output: "x".repeat(250_000) };
+      },
+    });
+    const server = await startServer({
+      config: testConfig(),
+      hermes,
+      liveModel,
+      logger: fakeLogger(),
+    });
+    openServers.push(server);
+    const socket = new WebSocket(toWebSocketUrl(server.url), { headers: { origin: server.url } });
+    openSockets.push(socket);
+
+    await waitForOpen(socket);
+    send(socket, { type: "session.start" });
+    await waitForMessage(socket, "session.ready");
+    const completedPromise = waitForMessage(socket, "run.completed");
+    send(socket, { type: "text.input", text: "Generate a large result" });
+
+    const completed = await completedPromise;
+    const toolResponse = await liveModel.nextToolResponse();
+    expect(completed.output).toHaveLength(200_000);
+    expect(toolResponse.response.output).toHaveLength(200_000);
+  });
+
   it("reports Hermes startup failures as session start failures", async () => {
     const server = await startServer({
       config: testConfig(),
@@ -181,7 +393,7 @@ describe("live gateway WebSocket", () => {
 
     await expect(waitForMessage(socket, "session.error")).resolves.toMatchObject({
       code: "session_start_failed",
-      message: "Hermes capabilities unavailable",
+      message: "Hermes API readiness check failed. Check the gateway logs.",
       requestId: "req_start_1",
       recoverable: true,
     });
@@ -199,13 +411,13 @@ describe("live gateway WebSocket", () => {
     openSockets.push(socket);
 
     await waitForOpen(socket);
-    send(socket, { type: "session.start", id: "req_version", protocolVersion: 2 });
+    send(socket, { type: "session.start", id: "req_version", protocolVersion: 1 });
 
     await expect(waitForMessage(socket, "session.error")).resolves.toMatchObject({
       code: "unsupported_protocol_version",
       requestId: "req_version",
       recoverable: false,
-      message: expect.stringContaining("use 1"),
+      message: expect.stringContaining("use 2"),
     });
   });
 
@@ -267,14 +479,14 @@ describe("live gateway WebSocket", () => {
 
     await expect(waitForMessage(socket, "session.error")).resolves.toMatchObject({
       code: "session_start_failed",
-      message: "Provider did not connect",
+      message: "Realtime provider session failed to start. Check the gateway logs.",
       recoverable: true,
     });
   });
 
   it("reports provider errors before readiness as session start failures", async () => {
     const server = await startServer({
-      config: testConfig({ server: { providerReadyTimeoutMs: 1_000 } }),
+      config: testConfig({ server: { providerReadyTimeoutMs: 20 } }),
       hermes: fakeHermes(),
       liveModel: new PreReadyErrorAdapter(),
       logger: fakeLogger(),
@@ -284,20 +496,23 @@ describe("live gateway WebSocket", () => {
     openSockets.push(socket);
 
     await waitForOpen(socket);
+    const closed = waitForClose(socket);
     send(socket, { type: "session.start" });
 
     await expect(waitForMessage(socket, "session.error")).resolves.toMatchObject({
       code: "session_start_failed",
-      message: "Provider errored before ready",
-      recoverable: true,
+      message: "Realtime provider session failed to start. Check the gateway logs.",
+      recoverable: false,
     });
+    await expect(closed).resolves.toMatchObject({ code: 1011 });
   });
 
-  it("reports provider close before readiness as a session start failure", async () => {
+  it("rejects an oversized provider event before readiness without retaining it", async () => {
+    const liveModel = new OversizedPreReadyEventAdapter();
     const server = await startServer({
       config: testConfig({ server: { providerReadyTimeoutMs: 1_000 } }),
       hermes: fakeHermes(),
-      liveModel: new PreReadyCloseAdapter(),
+      liveModel,
       logger: fakeLogger(),
     });
     openServers.push(server);
@@ -309,9 +524,58 @@ describe("live gateway WebSocket", () => {
 
     await expect(waitForMessage(socket, "session.error")).resolves.toMatchObject({
       code: "session_start_failed",
-      message: "Realtime provider session closed before ready.",
+      message: "Realtime provider exceeded the safe pre-ready event queue limit.",
       recoverable: true,
     });
+    await vi.waitFor(() => expect(liveModel.session.close).toHaveBeenCalledTimes(1));
+  });
+
+  it("does not send session.ready when a provider opens after a latched startup error", async () => {
+    const liveModel = new ErrorThenOpenAdapter();
+    const server = await startServer({
+      config: testConfig({ server: { providerReadyTimeoutMs: 1_000 } }),
+      hermes: fakeHermes(),
+      liveModel,
+      logger: fakeLogger(),
+    });
+    openServers.push(server);
+    const socket = new WebSocket(toWebSocketUrl(server.url), { headers: { origin: server.url } });
+    openSockets.push(socket);
+    const observed: any[] = [];
+
+    await waitForOpen(socket);
+    socket.on("message", (raw) => observed.push(JSON.parse(raw.toString("utf8"))));
+    send(socket, { type: "session.start" });
+
+    await expect(waitForMessage(socket, "session.error")).resolves.toMatchObject({
+      code: "session_start_failed",
+      message: "Realtime provider session failed to start. Check the gateway logs.",
+    });
+    await vi.waitFor(() => expect(liveModel.session.close).toHaveBeenCalledTimes(1));
+    expect(observed.some((message) => message.type === "session.ready")).toBe(false);
+  });
+
+  it("reports provider close before readiness as a session start failure", async () => {
+    const server = await startServer({
+      config: testConfig({ server: { providerReadyTimeoutMs: 20 } }),
+      hermes: fakeHermes(),
+      liveModel: new PreReadyCloseAdapter(),
+      logger: fakeLogger(),
+    });
+    openServers.push(server);
+    const socket = new WebSocket(toWebSocketUrl(server.url), { headers: { origin: server.url } });
+    openSockets.push(socket);
+
+    await waitForOpen(socket);
+    const closed = waitForClose(socket);
+    send(socket, { type: "session.start" });
+
+    await expect(waitForMessage(socket, "session.error")).resolves.toMatchObject({
+      code: "session_start_failed",
+      message: "Realtime provider session closed before ready.",
+      recoverable: false,
+    });
+    await expect(closed).resolves.toMatchObject({ code: 1011 });
   });
 
   it("waits to announce ready until the provider session is assigned", async () => {
@@ -376,6 +640,82 @@ describe("live gateway WebSocket", () => {
     });
   });
 
+  it("bounds provider cleanup when a never-ready session ignores close", async () => {
+    const liveModel = new NeverOpenHungCloseAdapter();
+    const server = await startServer({
+      config: testConfig({ server: { providerReadyTimeoutMs: 20 } }),
+      hermes: fakeHermes(),
+      liveModel,
+      logger: fakeLogger(),
+    });
+    openServers.push(server);
+    const socket = new WebSocket(toWebSocketUrl(server.url), { headers: { origin: server.url } });
+    openSockets.push(socket);
+
+    await waitForOpen(socket);
+    const closed = waitForClose(socket);
+    send(socket, { type: "session.start", id: "hung_startup_close" });
+
+    await expect(waitForMessage(socket, "session.error")).resolves.toMatchObject({
+      code: "session_start_failed",
+      requestId: "hung_startup_close",
+      recoverable: false,
+    });
+    await expect(closed).resolves.toMatchObject({ code: 1011, reason: "session shutdown unconfirmed" });
+    expect(liveModel.session.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits for a pending provider connection and closes its late session before a clean client close", async () => {
+    const liveModel = new PendingConnectAdapter();
+    const server = await startServer({
+      config: testConfig({ server: { providerReadyTimeoutMs: 1_000 } }),
+      hermes: fakeHermes(),
+      liveModel,
+      logger: fakeLogger(),
+    });
+    openServers.push(server);
+    const socket = new WebSocket(toWebSocketUrl(server.url), { headers: { origin: server.url } });
+    openSockets.push(socket);
+
+    await waitForOpen(socket);
+    send(socket, { type: "session.start" });
+    await liveModel.connectEntered.promise;
+    const closed = waitForClose(socket);
+    send(socket, { type: "session.close", id: "close_pending_connect" });
+    liveModel.releaseConnect.resolve();
+
+    await expect(closed).resolves.toMatchObject({ code: 1000 });
+    expect(liveModel.session.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes abnormally when a pending provider connection misses the cleanup deadline", async () => {
+    const liveModel = new PendingConnectAdapter();
+    const server = await startServer({
+      config: testConfig({ server: { providerReadyTimeoutMs: 20 } }),
+      hermes: fakeHermes(),
+      liveModel,
+      logger: fakeLogger(),
+    });
+    openServers.push(server);
+    const socket = new WebSocket(toWebSocketUrl(server.url), { headers: { origin: server.url } });
+    openSockets.push(socket);
+
+    await waitForOpen(socket);
+    send(socket, { type: "session.start" });
+    await liveModel.connectEntered.promise;
+    const failed = waitForMessage(socket, "session.error");
+    const closed = waitForClose(socket);
+    send(socket, { type: "session.close", id: "close_stuck_connect" });
+
+    await expect(failed).resolves.toMatchObject({
+      code: "session_shutdown_unconfirmed",
+      requestId: "close_stuck_connect",
+      recoverable: false,
+    });
+    await expect(closed).resolves.toMatchObject({ code: 1011, reason: "session shutdown unconfirmed" });
+    expect(liveModel.session.close).not.toHaveBeenCalled();
+  });
+
   it("reconstructs completed output from Hermes message deltas", async () => {
     const hermes = fakeHermes({
       streamEvents: async function* () {
@@ -418,6 +758,7 @@ describe("live gateway WebSocket", () => {
           description: "This command changes a remote repository.",
           pattern_key: "git_push",
           choices: ["once", "session", "always", "deny"],
+          allow_permanent: true,
         };
         await approvalSubmitted.promise;
         yield { event: "run.completed", output: "Approved." };
@@ -444,7 +785,6 @@ describe("live gateway WebSocket", () => {
     const approval = await waitForMessage(socket, "approval.request");
     expect(approval).toMatchObject({
       approval: {
-        approvalId: "approval_1",
         command: "git push origin feature",
         description: "This command changes a remote repository.",
         patternKey: "git_push",
@@ -452,13 +792,16 @@ describe("live gateway WebSocket", () => {
         allowPermanent: true,
       },
     });
+    expect(approval.approval.approvalId).toMatch(/^approval_[a-f0-9]{32}$/);
     const approvalResponded = waitForMessage(socket, "approval.responded");
     const completed = waitForMessage(socket, "run.completed");
-    send(socket, { type: "approval.respond", runId: "run_ws", choice: "once" });
+    sendApprovalResponse(socket, approval, "once", "approval_response_1");
 
     await expect(approvalResponded).resolves.toMatchObject({
       type: "approval.responded",
+      requestId: "approval_response_1",
       runId: "run_ws",
+      approvalId: approval.approval.approvalId,
       choice: "once",
       resolved: 1,
     });
@@ -467,6 +810,53 @@ describe("live gateway WebSocket", () => {
       signal: expect.any(AbortSignal),
       sessionKey: defaultSessionKey,
     });
+  });
+
+  it("ignores a resolved approval when Hermes redelivers the same source id", async () => {
+    const submitted = deferred<void>();
+    const hermes = fakeHermes({
+      streamEvents: async function* () {
+        const approval = {
+          event: "approval.request",
+          run_id: "run_ws",
+          approval_id: "approval_redelivered",
+          command: "deploy staging",
+          choices: ["once", "deny"],
+        };
+        yield approval;
+        await submitted.promise;
+        yield approval;
+        yield { event: "run.completed", output: "Approved once." };
+      },
+      submitApproval: vi.fn(async () => {
+        submitted.resolve();
+        return { resolved: 1 };
+      }),
+    });
+    const server = await startServer({
+      config: testConfig(),
+      hermes,
+      liveModel: new MockLiveAdapter(),
+      logger: fakeLogger(),
+    });
+    openServers.push(server);
+    const socket = new WebSocket(toWebSocketUrl(server.url), { headers: { origin: server.url } });
+    openSockets.push(socket);
+    const observedAfterFirst: any[] = [];
+
+    await waitForOpen(socket);
+    send(socket, { type: "session.start" });
+    await waitForMessage(socket, "session.ready");
+    send(socket, { type: "text.input", text: "Deploy once" });
+    const approval = await waitForMessage(socket, "approval.request");
+    socket.on("message", (raw) => observedAfterFirst.push(JSON.parse(raw.toString("utf8"))));
+    const completed = waitForMessage(socket, "run.completed");
+    sendApprovalResponse(socket, approval, "once", "approval_redelivery_response");
+
+    await waitForMessage(socket, "approval.responded");
+    await completed;
+    expect(observedAfterFirst.filter((message) => message.type === "approval.request")).toHaveLength(0);
+    expect(hermes.submitApproval).toHaveBeenCalledTimes(1);
   });
 
   it("rejects approval responses for runs outside the active voice session", async () => {
@@ -494,9 +884,9 @@ describe("live gateway WebSocket", () => {
     send(socket, { type: "text.input", text: "Delete the stale build" });
     const opaqueApproval = await waitForMessage(socket, "approval.request");
     expect(opaqueApproval).toMatchObject({
-      approval: { approvalId: "approval_1", choices: ["once", "deny"], allowPermanent: false },
+      approval: { choices: ["deny"], allowPermanent: false },
     });
-    send(socket, { type: "approval.respond", runId: "other_run", choice: "once" });
+    sendApprovalResponse(socket, { ...opaqueApproval, runId: "other_run" }, "deny", "approval_wrong_run");
 
     await expect(waitForMessage(socket, "session.error")).resolves.toMatchObject({
       code: "client_message_failed",
@@ -543,16 +933,97 @@ describe("live gateway WebSocket", () => {
     await waitForMessage(socket, "session.ready");
     send(socket, { type: "text.input", text: "Deploy" });
 
-    await expect(waitForMessage(socket, "approval.request")).resolves.toMatchObject({
+    const approval = await waitForMessage(socket, "approval.request");
+    expect(approval).toMatchObject({
       approval: {
         command: "deploy production",
-        choices: ["once", "session", "deny"],
+        choices: ["once", "deny"],
         allowPermanent: false,
       },
     });
 
-    send(socket, { type: "approval.respond", runId: "run_ws", choice: "deny" });
-    approvalSubmitted.resolve();
+    sendApprovalResponse(socket, approval, "deny", "approval_no_pattern");
+  });
+
+  it.each([
+    [
+      "a control-bearing command",
+      { command: "deploy\u202e production", description: "Deploy production.", pattern_key: "deploy", choices: ["once", "always", "deny"] },
+      ["deny"],
+    ],
+    [
+      "an overlong command",
+      { command: "x".repeat(4_001), description: "Run the command.", pattern_key: "command", choices: ["once", "always", "deny"] },
+      ["deny"],
+    ],
+    [
+      "a visually blank command",
+      { command: "\u0300\u0301", pattern_key: "command", choices: ["once", "always", "deny"] },
+      ["deny"],
+    ],
+    [
+      "explicitly empty choices",
+      { command: "deploy production", choices: [] },
+      ["deny"],
+    ],
+    [
+      "malformed choices",
+      { command: "deploy production", choices: ["once", "invalid"] },
+      ["deny"],
+    ],
+    [
+      "a transformed permission pattern",
+      { command: "deploy production", pattern_key: "deploy\u202ehidden", choices: ["once", "session", "always", "deny"] },
+      ["once", "deny"],
+    ],
+    [
+      "more permission patterns than the UI can show",
+      { command: "deploy production", pattern_keys: Array.from({ length: 33 }, (_, index) => `deploy_${index}`), choices: ["once", "session", "always", "deny"] },
+      ["once", "deny"],
+    ],
+  ])("never broadens approval from %s", async (_label, approvalEvent, expectedChoices) => {
+    const approvalSubmitted = deferred<void>();
+    const hermes = fakeHermes({
+      streamEvents: async function* () {
+        yield {
+          event: "approval.request",
+          run_id: "run_ws",
+          approval_id: "approval_projection",
+          ...approvalEvent,
+        };
+        await approvalSubmitted.promise;
+        yield { event: "run.completed", output: "Denied safely." };
+      },
+      submitApproval: vi.fn(async () => {
+        approvalSubmitted.resolve();
+        return { resolved: 1 };
+      }),
+    });
+    const server = await startServer({
+      config: testConfig(),
+      hermes,
+      liveModel: new MockLiveAdapter(),
+      logger: fakeLogger(),
+    });
+    openServers.push(server);
+    const socket = new WebSocket(toWebSocketUrl(server.url), { headers: { origin: server.url } });
+    openSockets.push(socket);
+
+    await waitForOpen(socket);
+    send(socket, { type: "session.start" });
+    await waitForMessage(socket, "session.ready");
+    send(socket, { type: "text.input", text: "Check approval projection" });
+    const approval = await waitForMessage(socket, "approval.request");
+
+    expect(approval.approval.choices).toEqual(expectedChoices);
+    expect(approval.approval.allowPermanent).toBe(false);
+    expect(approval.approval).not.toHaveProperty("patternKey");
+    expect(approval.approval).not.toHaveProperty("patternKeys");
+
+    const completed = waitForMessage(socket, "run.completed");
+    sendApprovalResponse(socket, approval, "deny", `deny_projection_${String(_label).replaceAll(" ", "_")}`);
+    await waitForMessage(socket, "approval.responded");
+    await completed;
   });
 
   it.each([
@@ -598,23 +1069,22 @@ describe("live gateway WebSocket", () => {
 
     const approval = await waitForMessage(socket, "approval.request");
     expect(approval.approval).toMatchObject({
-      approvalId: "approval_uninspectable",
       choices: ["once", "deny"],
       allowPermanent: false,
     });
+    expect(approval.approval.approvalId).toMatch(/^approval_[a-f0-9]{32}$/);
     expect(approval.approval).not.toHaveProperty("patternKey");
 
     const responded = waitForMessage(socket, "approval.responded");
     const completed = waitForMessage(socket, "run.completed");
-    send(socket, { type: "approval.respond", runId: "run_ws", choice: "deny" });
+    sendApprovalResponse(socket, approval, "deny", `deny_${_label}`);
     await responded;
     await completed;
   });
 
-  it("validates human approval responses against the sanitized FIFO queue", async () => {
+  it("correlates and deduplicates approval responses without advancing the FIFO queue", async () => {
     const releaseSecondApproval = deferred<void>();
     const finishRun = deferred<void>();
-    let onceResponses = 0;
     const hermes = fakeHermes({
       streamEvents: async function* () {
         yield {
@@ -623,8 +1093,7 @@ describe("live gateway WebSocket", () => {
           approval_id: "approval_1",
           command: "deploy staging",
           description: "Deploy the current revision.",
-          choices: ["once", "always"],
-          allow_permanent: true,
+          choices: ["once", "deny"],
         };
         await releaseSecondApproval.promise;
         yield {
@@ -633,20 +1102,14 @@ describe("live gateway WebSocket", () => {
           approval_id: "approval_2",
           command: "remember deployment approval",
           description: "Allow this action for the current session.",
+          pattern_key: "deploy_session",
           choices: ["session", "deny"],
         };
         await finishRun.promise;
         yield { event: "run.completed", output: "Approved in order." };
       },
       submitApproval: vi.fn(async (_runId: string, choice: ApprovalChoice) => {
-        if (choice === "deny") {
-          return { resolved: 0 };
-        }
-        if (choice === "once") {
-          onceResponses += 1;
-          return { resolved: onceResponses === 1 ? 0 : 1 };
-        }
-        finishRun.resolve();
+        if (choice === "session") finishRun.resolve();
         return { resolved: 1 };
       }),
     });
@@ -665,67 +1128,260 @@ describe("live gateway WebSocket", () => {
     await waitForMessage(socket, "session.ready");
     send(socket, { type: "text.input", text: "Deploy safely" });
 
-    await expect(waitForMessage(socket, "approval.request")).resolves.toMatchObject({
+    const first = await waitForMessage(socket, "approval.request");
+    expect(first).toMatchObject({
       approval: {
-        approvalId: "approval_1",
+        command: "deploy staging",
+        description: "Deploy the current revision.",
         choices: ["once", "deny"],
         allowPermanent: false,
       },
     });
     releaseSecondApproval.resolve();
-    await expect(waitForMessage(socket, "approval.request")).resolves.toMatchObject({
-      approval: { approvalId: "approval_2", choices: ["session", "deny"] },
+    const second = await waitForMessage(socket, "approval.request");
+    expect(second).toMatchObject({
+      approval: { patternKey: "deploy_session", choices: ["session", "deny"] },
     });
 
-    send(socket, { type: "approval.respond", runId: "run_ws", choice: "always" });
+    sendApprovalResponse(socket, first, "always", "invalid_always");
     await expect(waitForMessage(socket, "session.error")).resolves.toMatchObject({
       code: "client_message_failed",
       message: "Permanent approval requires an inspectable permission pattern.",
     });
-    send(socket, { type: "approval.respond", runId: "run_ws", choice: "session" });
+    sendApprovalResponse(socket, first, "session", "invalid_session");
     await expect(waitForMessage(socket, "session.error")).resolves.toMatchObject({
       code: "client_message_failed",
       message: "Approval choice session was not offered for the pending request.",
     });
-    send(socket, { type: "approval.respond", runId: "run_ws", choice: "once", resolveAll: true });
+    sendApprovalResponse(socket, first, "once", "invalid_bulk", { resolveAll: true });
     await expect(waitForMessage(socket, "session.error")).resolves.toMatchObject({
       code: "client_message_failed",
       message: "Bulk approval resolution is not supported; answer each approval in FIFO order.",
     });
+    sendApprovalResponse(socket, second, "session", "stale_out_of_order");
+    await expect(waitForMessage(socket, "session.error")).resolves.toMatchObject({
+      message: "Approval response does not match the oldest pending request.",
+    });
     expect(hermes.submitApproval).not.toHaveBeenCalled();
 
-    send(socket, { type: "approval.respond", runId: "run_ws", choice: "deny" });
-    await expect(waitForMessage(socket, "approval.responded")).resolves.toMatchObject({ choice: "deny", resolved: 0 });
-    send(socket, { type: "approval.respond", runId: "run_ws", choice: "once" });
-    await expect(waitForMessage(socket, "approval.responded")).resolves.toMatchObject({ choice: "once", resolved: 0 });
-    send(socket, { type: "approval.respond", runId: "run_ws", choice: "session" });
-    await expect(waitForMessage(socket, "session.error")).resolves.toMatchObject({
-      message: "Approval choice session was not offered for the pending request.",
+    const firstResponse = waitForMessage(socket, "approval.responded");
+    sendApprovalResponse(socket, first, "once", "approve_first");
+    await expect(firstResponse).resolves.toMatchObject({
+      requestId: "approve_first",
+      approvalId: first.approval.approvalId,
+      choice: "once",
+      resolved: 1,
     });
+    expect(hermes.submitApproval).toHaveBeenCalledTimes(1);
 
-    send(socket, { type: "approval.respond", runId: "run_ws", choice: "once" });
-    await expect(waitForMessage(socket, "approval.responded")).resolves.toMatchObject({ choice: "once", resolved: 1 });
+    const duplicateResponse = waitForMessage(socket, "approval.responded");
+    sendApprovalResponse(socket, first, "once", "approve_first");
+    await expect(duplicateResponse).resolves.toMatchObject({ requestId: "approve_first", resolved: 1 });
+    expect(hermes.submitApproval).toHaveBeenCalledTimes(1);
+
+    sendApprovalResponse(socket, first, "once", "stale_first_new_request");
+    await expect(waitForMessage(socket, "session.error")).resolves.toMatchObject({
+      message: "Approval response does not match the oldest pending request.",
+    });
+    expect(hermes.submitApproval).toHaveBeenCalledTimes(1);
+
     const completed = waitForMessage(socket, "run.completed");
-    send(socket, { type: "approval.respond", runId: "run_ws", choice: "session" });
-    await expect(waitForMessage(socket, "approval.responded")).resolves.toMatchObject({ choice: "session", resolved: 1 });
+    sendApprovalResponse(socket, second, "session", "approve_second");
+    await expect(waitForMessage(socket, "approval.responded")).resolves.toMatchObject({
+      requestId: "approve_second",
+      approvalId: second.approval.approvalId,
+      choice: "session",
+      resolved: 1,
+    });
     await expect(completed).resolves.toMatchObject({ output: "Approved in order." });
 
-    expect(hermes.submitApproval).toHaveBeenNthCalledWith(1, "run_ws", "deny", {
+    const postRunDuplicate = waitForMessage(socket, "approval.responded");
+    sendApprovalResponse(socket, second, "session", "approve_second");
+    await expect(postRunDuplicate).resolves.toMatchObject({
+      requestId: "approve_second",
+      approvalId: second.approval.approvalId,
+      resolved: 1,
+    });
+    expect(hermes.submitApproval).toHaveBeenCalledTimes(2);
+
+    expect(hermes.submitApproval).toHaveBeenNthCalledWith(1, "run_ws", "once", {
       signal: expect.any(AbortSignal),
       sessionKey: defaultSessionKey,
     });
-    expect(hermes.submitApproval).toHaveBeenNthCalledWith(2, "run_ws", "once", {
+    expect(hermes.submitApproval).toHaveBeenNthCalledWith(2, "run_ws", "session", {
       signal: expect.any(AbortSignal),
       sessionKey: defaultSessionKey,
     });
-    expect(hermes.submitApproval).toHaveBeenNthCalledWith(3, "run_ws", "once", {
+  });
+
+  it("closes when Hermes mutates a reused approval id during submission", async () => {
+    const submitEntered = deferred<void>();
+    const releaseSubmit = deferred<void>();
+    const hermes = fakeHermes({
+      streamEvents: async function* () {
+        yield {
+          event: "approval.request",
+          run_id: "run_ws",
+          approval_id: "approval_reused",
+          command: "deploy staging",
+          choices: ["once", "deny"],
+        };
+        await submitEntered.promise;
+        yield {
+          event: "approval.request",
+          run_id: "run_ws",
+          approval_id: "approval_reused",
+          command: "deploy production",
+          choices: ["once", "deny"],
+        };
+        await new Promise(() => undefined);
+      },
+      submitApproval: vi.fn(async () => {
+        submitEntered.resolve();
+        await releaseSubmit.promise;
+        return { resolved: 1 };
+      }),
+      stopRun: vi.fn(async () => ({ status: "stopping" })),
+    });
+    const server = await startServer({
+      config: testConfig(),
+      hermes,
+      liveModel: new MockLiveAdapter(),
+      logger: fakeLogger(),
+    });
+    openServers.push(server);
+    const socket = new WebSocket(toWebSocketUrl(server.url), { headers: { origin: server.url } });
+    openSockets.push(socket);
+
+    await waitForOpen(socket);
+    send(socket, { type: "session.start" });
+    await waitForMessage(socket, "session.ready");
+    send(socket, { type: "text.input", text: "Deploy safely" });
+    const approval = await waitForMessage(socket, "approval.request");
+    const failed = waitForMessage(socket, "session.error");
+    const closed = waitForClose(socket);
+    sendApprovalResponse(socket, approval, "once", "approval_mutation");
+
+    await submitEntered.promise;
+    await expect(failed).resolves.toMatchObject({
+      code: "hermes_run_outcome_indeterminate",
+      recoverable: false,
+    });
+    await expect(closed).resolves.toMatchObject({ code: 1011 });
+    releaseSubmit.resolve();
+    expect(hermes.submitApproval).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops the run and closes when an approval submission outcome is indeterminate", async () => {
+    const streamAborted = deferred<void>();
+    const hermes = fakeHermes({
+      streamEvents: async function* (_runId: string, options?: { signal?: AbortSignal }) {
+        yield {
+          event: "approval.request",
+          run_id: "run_ws",
+          approval_id: "approval_indeterminate",
+          command: "deploy production",
+          choices: ["once", "deny"],
+        };
+        await new Promise<void>((_resolve, reject) => {
+          options?.signal?.addEventListener("abort", () => {
+            streamAborted.resolve();
+            reject(new DOMException("aborted", "AbortError"));
+          }, { once: true });
+        });
+        yield { event: "run.completed", output: "unreachable" };
+      },
+      submitApproval: vi.fn(async () => {
+        throw new Error("connection reset after POST");
+      }),
+      stopRun: vi.fn(async () => ({ status: "stopping" })),
+    });
+    const server = await startServer({
+      config: testConfig(),
+      hermes,
+      liveModel: new MockLiveAdapter(),
+      logger: fakeLogger(),
+    });
+    openServers.push(server);
+    const socket = new WebSocket(toWebSocketUrl(server.url), { headers: { origin: server.url } });
+    openSockets.push(socket);
+
+    await waitForOpen(socket);
+    send(socket, { type: "session.start" });
+    await waitForMessage(socket, "session.ready");
+    send(socket, { type: "text.input", text: "Deploy safely" });
+    const approval = await waitForMessage(socket, "approval.request");
+    const failed = waitForMessage(socket, "session.error");
+    const closed = waitForClose(socket);
+    sendApprovalResponse(socket, approval, "deny", "indeterminate_approval");
+
+    await expect(failed).resolves.toMatchObject({
+      code: "approval_outcome_indeterminate",
+      requestId: "indeterminate_approval",
+      recoverable: false,
+    });
+    await streamAborted.promise;
+    await expect(closed).resolves.toMatchObject({ code: 1011 });
+    expect(hermes.submitApproval).toHaveBeenCalledTimes(1);
+    expect(hermes.stopRun).toHaveBeenCalledWith("run_ws", {
       signal: expect.any(AbortSignal),
       sessionKey: defaultSessionKey,
     });
-    expect(hermes.submitApproval).toHaveBeenNthCalledWith(4, "run_ws", "session", {
-      signal: expect.any(AbortSignal),
-      sessionKey: defaultSessionKey,
+  });
+
+  it.each([
+    ["is not an object", null],
+    ["contains conflicting run aliases", { resolved: 1, run_id: "run_ws", runId: "run_other", choice: "deny" }],
+    ["names another run", { resolved: 1, run_id: "run_other", choice: "deny" }],
+    ["echoes another choice", { resolved: 1, run_id: "run_ws", choice: "once" }],
+    ["does not resolve exactly one request", { resolved: 0, run_id: "run_ws", choice: "deny" }],
+  ])("fails closed when the approval response %s", async (_label, result) => {
+    const streamAborted = deferred<void>();
+    const hermes = fakeHermes({
+      streamEvents: async function* (_runId: string, options?: { signal?: AbortSignal }) {
+        yield {
+          event: "approval.request",
+          run_id: "run_ws",
+          approval_id: "approval_bad_result",
+          command: "deploy production",
+          choices: ["once", "deny"],
+        };
+        await new Promise<void>((_resolve, reject) => {
+          options?.signal?.addEventListener("abort", () => {
+            streamAborted.resolve();
+            reject(new DOMException("aborted", "AbortError"));
+          }, { once: true });
+        });
+      },
+      submitApproval: vi.fn(async () => result),
     });
+    const server = await startServer({
+      config: testConfig(),
+      hermes,
+      liveModel: new MockLiveAdapter(),
+      logger: fakeLogger(),
+    });
+    openServers.push(server);
+    const socket = new WebSocket(toWebSocketUrl(server.url), { headers: { origin: server.url } });
+    openSockets.push(socket);
+
+    await waitForOpen(socket);
+    send(socket, { type: "session.start" });
+    await waitForMessage(socket, "session.ready");
+    send(socket, { type: "text.input", text: "Deploy safely" });
+    const approval = await waitForMessage(socket, "approval.request");
+    const failed = waitForMessage(socket, "session.error");
+    const closed = waitForClose(socket);
+    sendApprovalResponse(socket, approval, "deny", "bad_approval_result");
+
+    await expect(failed).resolves.toMatchObject({
+      code: "approval_outcome_indeterminate",
+      requestId: "bad_approval_result",
+      recoverable: false,
+    });
+    await streamAborted.promise;
+    await expect(closed).resolves.toMatchObject({ code: 1011 });
+    expect(hermes.submitApproval).toHaveBeenCalledTimes(1);
   });
 
   it("clears pending approvals as soon as a run stop is accepted", async () => {
@@ -757,14 +1413,14 @@ describe("live gateway WebSocket", () => {
     send(socket, { type: "session.start" });
     await waitForMessage(socket, "session.ready");
     send(socket, { type: "text.input", text: "Run a long command" });
-    await waitForMessage(socket, "approval.request");
+    const approval = await waitForMessage(socket, "approval.request");
 
     send(socket, { type: "run.stop", runId: "run_ws", reason: "user cancelled" });
-    await expect(waitForMessage(socket, "run.stopped")).resolves.toMatchObject({ status: "stopping" });
-    send(socket, { type: "approval.respond", runId: "run_ws", choice: "once" });
+    await expect(waitForMessage(socket, "run.stopping")).resolves.toMatchObject({ status: "stopping" });
+    sendApprovalResponse(socket, approval, "once", "approval_after_stop");
     await expect(waitForMessage(socket, "session.error")).resolves.toMatchObject({
       code: "client_message_failed",
-      message: "No pending approval is available for the active Hermes run.",
+      message: "The Hermes run is stopping and no longer accepts approval responses.",
     });
     expect(hermes.submitApproval).not.toHaveBeenCalled();
 
@@ -845,11 +1501,304 @@ describe("live gateway WebSocket", () => {
     const started = await waitForMessage(socket, "run.started");
     send(socket, { type: "run.stop", runId: started.runId, reason: "test" });
 
-    await expect(waitForMessage(socket, "run.stopped")).resolves.toMatchObject({ runId: "run_ws", status: "stopping" });
+    await expect(waitForMessage(socket, "run.stopping")).resolves.toMatchObject({ runId: "run_ws", status: "stopping" });
     expect(hermes.stopRun).toHaveBeenCalledWith("run_ws", {
       signal: expect.any(AbortSignal),
       sessionKey: defaultSessionKey,
     });
+  });
+
+  it("fails closed when Hermes returns conflicting stop response run aliases", async () => {
+    const stopRun = vi.fn()
+      .mockResolvedValueOnce({ run_id: "run_ws", runId: "run_other", status: "stopping" })
+      .mockResolvedValue({ run_id: "run_ws", status: "stopping" });
+    const hermes = fakeHermes({
+      streamEvents: async function* (_runId: string, options?: { signal?: AbortSignal }) {
+        await new Promise<void>((_resolve, reject) => {
+          options?.signal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("aborted", "AbortError")),
+            { once: true },
+          );
+        });
+      },
+      stopRun,
+    });
+    const server = await startServer({
+      config: testConfig(),
+      hermes,
+      liveModel: new MockLiveAdapter(),
+      logger: fakeLogger(),
+    });
+    openServers.push(server);
+    const socket = new WebSocket(toWebSocketUrl(server.url), { headers: { origin: server.url } });
+    openSockets.push(socket);
+
+    await waitForOpen(socket);
+    send(socket, { type: "session.start" });
+    await waitForMessage(socket, "session.ready");
+    send(socket, { type: "text.input", text: "Run until stopped" });
+    const started = await waitForMessage(socket, "run.started");
+    const failed = waitForMessage(socket, "session.error");
+    const closed = waitForClose(socket);
+    send(socket, { type: "run.stop", runId: started.runId });
+
+    await expect(failed).resolves.toMatchObject({
+      code: "hermes_run_outcome_indeterminate",
+      recoverable: false,
+    });
+    await expect(closed).resolves.toMatchObject({ code: 1011 });
+    expect(stopRun).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not emit run.stopping after a terminal event wins the stop race", async () => {
+    const stopEntered = deferred<void>();
+    const releaseStopResponse = deferred<void>();
+    const releaseTerminal = deferred<void>();
+    const hermes = fakeHermes({
+      streamEvents: async function* () {
+        await releaseTerminal.promise;
+        yield { event: "run.cancelled" };
+      },
+      stopRun: vi.fn(async () => {
+        stopEntered.resolve();
+        await releaseStopResponse.promise;
+        return { status: "stopping" };
+      }),
+    });
+    const server = await startServer({
+      config: testConfig(),
+      hermes,
+      liveModel: new MockLiveAdapter(),
+      logger: fakeLogger(),
+    });
+    openServers.push(server);
+    const socket = new WebSocket(toWebSocketUrl(server.url), { headers: { origin: server.url } });
+    openSockets.push(socket);
+    const observed: any[] = [];
+
+    await waitForOpen(socket);
+    send(socket, { type: "session.start" });
+    await waitForMessage(socket, "session.ready");
+    socket.on("message", (raw) => observed.push(JSON.parse(raw.toString("utf8"))));
+    send(socket, { type: "text.input", text: "Run something long" });
+    const started = await waitForMessage(socket, "run.started");
+    send(socket, { type: "run.stop", runId: started.runId, reason: "race test" });
+    await stopEntered.promise;
+
+    releaseTerminal.resolve();
+    await waitForMessage(socket, "run.stopped");
+    releaseStopResponse.resolve();
+    await vi.waitFor(() => expect(hermes.stopRun).toHaveBeenCalledTimes(1));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(observed.filter((message) => message.type === "run.stopping")).toHaveLength(0);
+  });
+
+  it("coalesces concurrent stop controls into one Hermes request and one notification", async () => {
+    const releaseRun = deferred<void>();
+    const stopEntered = deferred<void>();
+    const releaseStop = deferred<void>();
+    const hermes = fakeHermes({
+      streamEvents: async function* () {
+        await releaseRun.promise;
+        yield { event: "run.cancelled" };
+      },
+      stopRun: vi.fn(async () => {
+        stopEntered.resolve();
+        await releaseStop.promise;
+        return { status: "stopping" };
+      }),
+    });
+    const server = await startServer({
+      config: testConfig(),
+      hermes,
+      liveModel: new MockLiveAdapter(),
+      logger: fakeLogger(),
+    });
+    openServers.push(server);
+    const socket = new WebSocket(toWebSocketUrl(server.url), { headers: { origin: server.url } });
+    openSockets.push(socket);
+    const observed: any[] = [];
+
+    await waitForOpen(socket);
+    send(socket, { type: "session.start" });
+    await waitForMessage(socket, "session.ready");
+    socket.on("message", (raw) => observed.push(JSON.parse(raw.toString("utf8"))));
+    send(socket, { type: "text.input", text: "Run something long" });
+    const started = await waitForMessage(socket, "run.started");
+    send(socket, { type: "run.stop", id: "stop_1", runId: started.runId, reason: "first" });
+    send(socket, { type: "run.stop", id: "stop_2", runId: started.runId, reason: "second" });
+    await stopEntered.promise;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(hermes.stopRun).toHaveBeenCalledTimes(1);
+
+    releaseStop.resolve();
+    await waitForMessage(socket, "run.stopping");
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(observed.filter((message) => message.type === "run.stopping")).toHaveLength(1);
+    releaseRun.resolve();
+    await waitForMessage(socket, "run.stopped");
+  });
+
+  it("contains one indeterminate outcome when concurrent stop controls share a rejection", async () => {
+    const stopEntered = deferred<void>();
+    const releaseInitialStop = deferred<void>();
+    let stopCalls = 0;
+    const hermes = fakeHermes({
+      streamEvents: async function* (_runId: string, options?: { signal?: AbortSignal }) {
+        await new Promise<void>((_resolve, reject) => {
+          options?.signal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("aborted", "AbortError")),
+            { once: true },
+          );
+        });
+      },
+      stopRun: vi.fn(async () => {
+        stopCalls += 1;
+        if (stopCalls === 1) {
+          stopEntered.resolve();
+          await releaseInitialStop.promise;
+          throw new Error("initial stop transport failed");
+        }
+        return { status: "stopping" };
+      }),
+    });
+    const server = await startServer({
+      config: testConfig(),
+      hermes,
+      liveModel: new MockLiveAdapter(),
+      logger: fakeLogger(),
+    });
+    openServers.push(server);
+    const socket = new WebSocket(toWebSocketUrl(server.url), { headers: { origin: server.url } });
+    openSockets.push(socket);
+    const observed: any[] = [];
+
+    await waitForOpen(socket);
+    send(socket, { type: "session.start" });
+    await waitForMessage(socket, "session.ready");
+    socket.on("message", (raw) => observed.push(JSON.parse(raw.toString("utf8"))));
+    send(socket, { type: "text.input", text: "Run something long" });
+    const started = await waitForMessage(socket, "run.started");
+    const closed = waitForClose(socket);
+    send(socket, { type: "run.stop", id: "failing_stop_1", runId: started.runId });
+    send(socket, { type: "run.stop", id: "failing_stop_2", runId: started.runId });
+    await stopEntered.promise;
+    releaseInitialStop.resolve();
+
+    await expect(closed).resolves.toMatchObject({ code: 1011 });
+    expect(hermes.stopRun).toHaveBeenCalledTimes(2);
+    expect(observed.filter(
+      (message) => message.type === "session.error" && message.code === "hermes_run_outcome_indeterminate",
+    )).toHaveLength(1);
+  });
+
+  it("starts the authoritative Hermes stop even when provider cancellation hangs", async () => {
+    const releaseRun = deferred<void>();
+    const liveModel = new HungCancelToolAdapter();
+    const hermes = fakeHermes({
+      streamEvents: async function* () {
+        await releaseRun.promise;
+        yield { event: "run.cancelled" };
+      },
+      stopRun: vi.fn(async () => ({ status: "stopping" })),
+    });
+    const server = await startServer({
+      config: testConfig(),
+      hermes,
+      liveModel,
+      logger: fakeLogger(),
+    });
+    openServers.push(server);
+    const socket = new WebSocket(toWebSocketUrl(server.url), { headers: { origin: server.url } });
+    openSockets.push(socket);
+
+    await waitForOpen(socket);
+    send(socket, { type: "session.start" });
+    await waitForMessage(socket, "session.ready");
+    send(socket, { type: "text.input", text: "Run until stopped" });
+    const started = await waitForMessage(socket, "run.started");
+    send(socket, { type: "run.stop", runId: started.runId, reason: "stop now" });
+
+    await liveModel.cancelEntered.promise;
+    await expect(waitForMessage(socket, "run.stopping")).resolves.toMatchObject({ runId: "run_ws" });
+    expect(hermes.stopRun).toHaveBeenCalledTimes(1);
+    releaseRun.resolve();
+    await waitForMessage(socket, "run.stopped");
+  });
+
+  it("rejects approvals and suppresses new approval events after stop intent", async () => {
+    const releaseLateApproval = deferred<void>();
+    const stopEntered = deferred<void>();
+    const releaseStop = deferred<void>();
+    const finishRun = deferred<void>();
+    const hermes = fakeHermes({
+      streamEvents: async function* () {
+        yield {
+          event: "approval.request",
+          run_id: "run_ws",
+          approval_id: "approval_before_stop",
+          command: "deploy staging",
+          choices: ["once", "deny"],
+        };
+        await releaseLateApproval.promise;
+        yield {
+          event: "approval.request",
+          run_id: "run_ws",
+          approval_id: "approval_after_stop",
+          command: "deploy production",
+          choices: ["once", "deny"],
+        };
+        await finishRun.promise;
+        yield { event: "run.cancelled" };
+      },
+      stopRun: vi.fn(async () => {
+        stopEntered.resolve();
+        await releaseStop.promise;
+        return { status: "stopping" };
+      }),
+    });
+    const server = await startServer({
+      config: testConfig(),
+      hermes,
+      liveModel: new MockLiveAdapter(),
+      logger: fakeLogger(),
+    });
+    openServers.push(server);
+    const socket = new WebSocket(toWebSocketUrl(server.url), { headers: { origin: server.url } });
+    openSockets.push(socket);
+    const observed: any[] = [];
+
+    await waitForOpen(socket);
+    send(socket, { type: "session.start" });
+    await waitForMessage(socket, "session.ready");
+    send(socket, { type: "text.input", text: "Deploy carefully" });
+    const approval = await waitForMessage(socket, "approval.request");
+    socket.on("message", (raw) => observed.push(JSON.parse(raw.toString("utf8"))));
+    send(socket, { type: "run.stop", runId: approval.runId, reason: "changed my mind" });
+    try {
+      await stopEntered.promise;
+      const rejected = waitForMessage(socket, "session.error");
+      sendApprovalResponse(socket, approval, "once", "approval_after_stop_intent");
+      releaseLateApproval.resolve();
+
+      await expect(rejected).resolves.toMatchObject({
+        message: "The Hermes run is stopping and no longer accepts approval responses.",
+      });
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      expect(observed.filter((message) => message.type === "approval.request")).toHaveLength(0);
+      expect(hermes.submitApproval).not.toHaveBeenCalled();
+      releaseStop.resolve();
+      await waitForMessage(socket, "run.stopping");
+      finishRun.resolve();
+      await waitForMessage(socket, "run.stopped");
+    } finally {
+      releaseLateApproval.resolve();
+      releaseStop.resolve();
+      finishRun.resolve();
+    }
   });
 
   it("rejects client stop requests for runs outside the active voice session", async () => {
@@ -938,13 +1887,15 @@ describe("live gateway WebSocket", () => {
     await waitForOpen(socket);
     send(socket, { type: "session.start" });
     await waitForMessage(socket, "session.ready");
+    const closed = waitForClose(socket);
     liveModel.emitToolCall({ name: "start_hermes_run", args: { message: "side effect without call id" } });
 
     await expect(waitForMessage(socket, "session.error")).resolves.toMatchObject({
       code: "tool_call_failed",
-      message: "Realtime tool call start_hermes_run did not include an id.",
-      recoverable: true,
+      message: "Realtime provider emitted a tool call without a bounded id.",
+      recoverable: false,
     });
+    await expect(closed).resolves.toMatchObject({ code: 1011 });
     expect(hermes.startRun).not.toHaveBeenCalled();
   });
 
@@ -952,6 +1903,13 @@ describe("live gateway WebSocket", () => {
     const releaseRun = deferred<void>();
     const liveModel = new ManualToolAdapter();
     const hermes = fakeHermes({
+      getRun: vi.fn(async () => ({
+        run_id: "run_ws",
+        status: "running",
+        input: "private user request",
+        output: "private run output",
+        tool_metadata: { transcript: "x".repeat(300_000) },
+      })),
       streamEvents: async function* () {
         await releaseRun.promise;
         yield { event: "run.completed", output: "Finished." };
@@ -975,16 +1933,114 @@ describe("live gateway WebSocket", () => {
     const response = liveModel.nextToolResponse();
     liveModel.emitToolCall({ id: "status_active", name: "get_hermes_run_status", args: { run_id: "run_ws" } });
 
-    await expect(response).resolves.toMatchObject({
+    const toolResponse = await response;
+    expect(toolResponse).toMatchObject({
       call: { id: "status_active", name: "get_hermes_run_status" },
       response: { ok: true, status: { run_id: "run_ws", status: "running" } },
     });
+    expect(JSON.stringify(toolResponse)).not.toContain("private");
     expect(hermes.getRun).toHaveBeenCalledWith("run_ws", {
       signal: expect.any(AbortSignal),
       sessionKey: defaultSessionKey,
     });
     releaseRun.resolve();
     await waitForMessage(socket, "run.completed");
+  });
+
+  it("rejects a provider status response correlated to another Hermes run", async () => {
+    const releaseRun = deferred<void>();
+    const liveModel = new ManualToolAdapter();
+    const hermes = fakeHermes({
+      getRun: vi.fn(async () => ({ run_id: "run_other", runId: "run_ws", status: "running" })),
+      streamEvents: async function* () {
+        await releaseRun.promise;
+        yield { event: "run.completed", output: "Finished." };
+      },
+    });
+    const server = await startServer({
+      config: testConfig(),
+      hermes,
+      liveModel,
+      logger: fakeLogger(),
+    });
+    openServers.push(server);
+    const socket = new WebSocket(toWebSocketUrl(server.url), { headers: { origin: server.url } });
+    openSockets.push(socket);
+
+    await waitForOpen(socket);
+    send(socket, { type: "session.start" });
+    await waitForMessage(socket, "session.ready");
+    send(socket, { type: "text.input", text: "Run something long" });
+    await waitForMessage(socket, "run.started");
+    const response = liveModel.nextToolResponse();
+    liveModel.emitToolCall({ id: "status_misrouted", name: "get_hermes_run_status", args: { run_id: "run_ws" } });
+
+    await expect(response).resolves.toMatchObject({
+      call: { id: "status_misrouted" },
+      response: { ok: false, error: "Hermes run status could not be read. Check the gateway logs." },
+    });
+    releaseRun.resolve();
+    await waitForMessage(socket, "run.completed");
+  });
+
+  it("replays exact provider tool-call ids without repeating Hermes side effects", async () => {
+    const liveModel = new ManualToolAdapter();
+    const hermes = fakeHermes();
+    const server = await startServer({
+      config: testConfig(),
+      hermes,
+      liveModel,
+      logger: fakeLogger(),
+    });
+    openServers.push(server);
+    const socket = new WebSocket(toWebSocketUrl(server.url), { headers: { origin: server.url } });
+    openSockets.push(socket);
+
+    await waitForOpen(socket);
+    send(socket, { type: "session.start" });
+    await waitForMessage(socket, "session.ready");
+    send(socket, { type: "text.input", text: "Run exactly once" });
+    await expect(liveModel.nextToolResponse()).resolves.toMatchObject({ response: { ok: true, run_id: "run_ws" } });
+    expect(hermes.startRun).toHaveBeenCalledTimes(1);
+
+    liveModel.emitToolCall({
+      id: "manual_start",
+      name: "start_hermes_run",
+      args: { message: "Run exactly once" },
+    });
+    await expect(liveModel.nextToolResponse()).resolves.toMatchObject({ response: { ok: true, run_id: "run_ws" } });
+    expect(hermes.startRun).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes on conflicting provider tool-call id reuse", async () => {
+    const liveModel = new ManualToolAdapter();
+    const hermes = fakeHermes();
+    const server = await startServer({
+      config: testConfig(),
+      hermes,
+      liveModel,
+      logger: fakeLogger(),
+    });
+    openServers.push(server);
+    const socket = new WebSocket(toWebSocketUrl(server.url), { headers: { origin: server.url } });
+    openSockets.push(socket);
+
+    await waitForOpen(socket);
+    send(socket, { type: "session.start" });
+    await waitForMessage(socket, "session.ready");
+    send(socket, { type: "text.input", text: "Original task" });
+    await liveModel.nextToolResponse();
+    const failed = waitForMessage(socket, "session.error");
+    const closed = waitForClose(socket);
+    liveModel.emitToolCall({
+      id: "manual_start",
+      name: "start_hermes_run",
+      args: { message: "Different task" },
+    });
+
+    await expect(failed).resolves.toMatchObject({ code: "realtime_tool_call_conflict", recoverable: false });
+    await expect(closed).resolves.toMatchObject({ code: 1011 });
+    expect(hermes.startRun).toHaveBeenCalledTimes(1);
   });
 
   it("routes realtime response cancellation to the provider session", async () => {
@@ -1041,6 +2097,301 @@ describe("live gateway WebSocket", () => {
     });
   });
 
+  it("fails closed when a Hermes event is correlated to another run", async () => {
+    const hermes = fakeHermes({
+      streamEvents: async function* () {
+        yield {
+          event: "approval.request",
+          run_id: "run_other",
+          approval_id: "misrouted_approval",
+          command: "deploy production",
+          choices: ["once", "deny"],
+        };
+      },
+      stopRun: vi.fn(async () => ({ status: "stopping" })),
+    });
+    const server = await startServer({
+      config: testConfig(),
+      hermes,
+      liveModel: new MockLiveAdapter(),
+      logger: fakeLogger(),
+    });
+    openServers.push(server);
+    const socket = new WebSocket(toWebSocketUrl(server.url), { headers: { origin: server.url } });
+    openSockets.push(socket);
+    const observed: any[] = [];
+
+    await waitForOpen(socket);
+    send(socket, { type: "session.start" });
+    await waitForMessage(socket, "session.ready");
+    socket.on("message", (raw) => observed.push(JSON.parse(raw.toString("utf8"))));
+    const closed = waitForClose(socket);
+    send(socket, { type: "text.input", text: "Run until correlation fails" });
+
+    await expect(waitForMessage(socket, "session.error")).resolves.toMatchObject({
+      code: "hermes_run_outcome_indeterminate",
+      recoverable: false,
+    });
+    await expect(closed).resolves.toMatchObject({ code: 1011 });
+    expect(observed.filter((message) => message.type === "approval.request")).toHaveLength(0);
+    expect(hermes.stopRun).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["ends early", "throws"])("stops and closes when the Hermes event stream %s", async (mode) => {
+    const hermes = fakeHermes({
+      streamEvents: async function* () {
+        yield { event: "message.delta", delta: "partial" };
+        if (mode === "throws") throw new Error("SSE connection lost");
+      },
+      stopRun: vi.fn(async () => ({ status: "stopping" })),
+    });
+    const server = await startServer({
+      config: testConfig(),
+      hermes,
+      liveModel: new MockLiveAdapter(),
+      logger: fakeLogger(),
+    });
+    openServers.push(server);
+    const socket = new WebSocket(toWebSocketUrl(server.url), { headers: { origin: server.url } });
+    openSockets.push(socket);
+
+    await waitForOpen(socket);
+    send(socket, { type: "session.start" });
+    await waitForMessage(socket, "session.ready");
+    const started = waitForMessage(socket, "run.started");
+    const failed = waitForMessage(socket, "session.error");
+    const closed = waitForClose(socket);
+    send(socket, { type: "text.input", text: "Run until the stream breaks" });
+
+    await expect(started).resolves.toMatchObject({ runId: "run_ws" });
+    await expect(failed).resolves.toMatchObject({
+      code: "hermes_run_outcome_indeterminate",
+      recoverable: false,
+    });
+    await expect(closed).resolves.toMatchObject({ code: 1011 });
+    expect(hermes.stopRun).toHaveBeenCalledWith("run_ws", {
+      signal: expect.any(AbortSignal),
+      sessionKey: defaultSessionKey,
+    });
+  });
+
+  it("fails closed when Hermes does not confirm whether a run-start POST mutated state", async () => {
+    const hermes = fakeHermes({
+      startRun: vi.fn(async () => {
+        throw new Error("connection reset after mutating POST");
+      }),
+    });
+    const server = await startServer({
+      config: testConfig(),
+      hermes,
+      liveModel: new MockLiveAdapter(),
+      logger: fakeLogger(),
+    });
+    openServers.push(server);
+    const socket = new WebSocket(toWebSocketUrl(server.url), { headers: { origin: server.url } });
+    openSockets.push(socket);
+
+    await waitForOpen(socket);
+    send(socket, { type: "session.start" });
+    await waitForMessage(socket, "session.ready");
+    const failed = waitForMessage(socket, "session.error");
+    const closed = waitForClose(socket);
+    send(socket, { type: "text.input", text: "Start exactly one task" });
+
+    await expect(failed).resolves.toMatchObject({
+      code: "hermes_run_start_outcome_indeterminate",
+      recoverable: false,
+    });
+    await expect(closed).resolves.toMatchObject({ code: 1011 });
+    expect(hermes.startRun).toHaveBeenCalledTimes(1);
+    expect(hermes.stopRun).not.toHaveBeenCalled();
+  });
+
+  it("stops a Hermes run whose start response arrives while the session is closing", async () => {
+    const startCalled = deferred<void>();
+    const startResult = deferred<{ runId: string; status: string }>();
+    const stopped = deferred<void>();
+    const hermes = fakeHermes({
+      startRun: vi.fn(async () => {
+        startCalled.resolve();
+        return await startResult.promise;
+      }),
+      stopRun: vi.fn(async (runId: string, options?: { signal?: AbortSignal; sessionKey?: string }) => {
+        expect(runId).toBe("run_late");
+        expect(options?.signal?.aborted).toBe(false);
+        expect(options?.sessionKey).toBe(defaultSessionKey);
+        stopped.resolve();
+        return { status: "stopping" };
+      }),
+    });
+    const server = await startServer({
+      config: testConfig(),
+      hermes,
+      liveModel: new MockLiveAdapter(),
+      logger: fakeLogger(),
+    });
+    openServers.push(server);
+    const socket = new WebSocket(toWebSocketUrl(server.url), { headers: { origin: server.url } });
+    openSockets.push(socket);
+
+    await waitForOpen(socket);
+    send(socket, { type: "session.start" });
+    await waitForMessage(socket, "session.ready");
+    send(socket, { type: "text.input", text: "Start, then disconnect" });
+    await startCalled.promise;
+    const closing = server.close();
+    startResult.resolve({ runId: "run_late", status: "started" });
+
+    await stopped.promise;
+    await closing;
+    expect(hermes.stopRun).toHaveBeenCalledTimes(1);
+    openServers.splice(openServers.indexOf(server), 1);
+  });
+
+  it("closes abnormally when a pending Hermes start rejects without yielding a run id", async () => {
+    const startCalled = deferred<void>();
+    const startResult = deferred<{ runId: string; status: string }>();
+    const hermes = fakeHermes({
+      startRun: vi.fn(async () => {
+        startCalled.resolve();
+        return await startResult.promise;
+      }),
+    });
+    const server = await startServer({
+      config: testConfig(),
+      hermes,
+      liveModel: new MockLiveAdapter(),
+      logger: fakeLogger(),
+    });
+    openServers.push(server);
+    const socket = new WebSocket(toWebSocketUrl(server.url), { headers: { origin: server.url } });
+    openSockets.push(socket);
+
+    await waitForOpen(socket);
+    send(socket, { type: "session.start" });
+    await waitForMessage(socket, "session.ready");
+    send(socket, { type: "text.input", text: "Start, then close ambiguously" });
+    await startCalled.promise;
+    const observed: any[] = [];
+    socket.on("message", (raw) => observed.push(JSON.parse(raw.toString("utf8"))));
+    const closed = waitForClose(socket);
+    send(socket, { type: "session.close", id: "close_during_start" });
+    startResult.reject(new Error("connection reset after mutating POST"));
+
+    await expect(closed).resolves.toMatchObject({ code: 1011 });
+    expect(observed).toContainEqual(expect.objectContaining({
+      type: "session.error",
+      code: "session_shutdown_unconfirmed",
+      recoverable: false,
+    }));
+    expect(hermes.stopRun).not.toHaveBeenCalled();
+  });
+
+  it("closes abnormally when session close interrupts an in-flight approval mutation", async () => {
+    const submitEntered = deferred<void>();
+    const hermes = fakeHermes({
+      streamEvents: async function* (_runId: string, options?: { signal?: AbortSignal }) {
+        yield {
+          event: "approval.request",
+          run_id: "run_ws",
+          approval_id: "approval_close_race",
+          command: "deploy production",
+          choices: ["once", "deny"],
+        };
+        await new Promise<void>((_resolve, reject) => {
+          options?.signal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("aborted", "AbortError")),
+            { once: true },
+          );
+        });
+      },
+      submitApproval: vi.fn(async () => {
+        submitEntered.resolve();
+        return await new Promise<never>(() => undefined);
+      }),
+      stopRun: vi.fn(async () => ({ status: "stopping" })),
+    });
+    const server = await startServer({
+      config: testConfig(),
+      hermes,
+      liveModel: new MockLiveAdapter(),
+      logger: fakeLogger(),
+    });
+    openServers.push(server);
+    const socket = new WebSocket(toWebSocketUrl(server.url), { headers: { origin: server.url } });
+    openSockets.push(socket);
+
+    await waitForOpen(socket);
+    send(socket, { type: "session.start" });
+    await waitForMessage(socket, "session.ready");
+    send(socket, { type: "text.input", text: "Deploy safely" });
+    const approval = await waitForMessage(socket, "approval.request");
+    sendApprovalResponse(socket, approval, "deny", "approval_before_close");
+    await submitEntered.promise;
+    const observed: any[] = [];
+    socket.on("message", (raw) => observed.push(JSON.parse(raw.toString("utf8"))));
+    const closed = waitForClose(socket);
+    send(socket, { type: "session.close", id: "close_during_approval" });
+
+    await expect(closed).resolves.toMatchObject({ code: 1011 });
+    expect(observed).toContainEqual(expect.objectContaining({
+      type: "session.error",
+      code: "session_shutdown_unconfirmed",
+      requestId: "close_during_approval",
+      recoverable: false,
+    }));
+    expect(hermes.stopRun).toHaveBeenCalledTimes(1);
+  });
+
+  it("makes concurrent close calls wait for the same in-flight Hermes stop", async () => {
+    const stopEntered = deferred<void>();
+    const releaseStop = deferred<void>();
+    const hermes = fakeHermes({
+      streamEvents: async function* (_runId: string, options?: { signal?: AbortSignal }) {
+        await new Promise<void>((_resolve, reject) => {
+          options?.signal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("aborted", "AbortError")),
+            { once: true },
+          );
+        });
+        yield { event: "run.completed", output: "unreachable" };
+      },
+      stopRun: vi.fn(async () => {
+        stopEntered.resolve();
+        await releaseStop.promise;
+        return { status: "stopping" };
+      }),
+    });
+    const server = await startServer({
+      config: testConfig(),
+      hermes,
+      liveModel: new MockLiveAdapter(),
+      logger: fakeLogger(),
+    });
+    openServers.push(server);
+    const socket = new WebSocket(toWebSocketUrl(server.url), { headers: { origin: server.url } });
+    openSockets.push(socket);
+
+    await waitForOpen(socket);
+    send(socket, { type: "session.start" });
+    await waitForMessage(socket, "session.ready");
+    send(socket, { type: "text.input", text: "Run while closing twice" });
+    await waitForMessage(socket, "run.started");
+    socket.close(1000, "first close");
+    await stopEntered.promise;
+
+    let serverCloseFinished = false;
+    const secondClose = server.close().then(() => { serverCloseFinished = true; });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(serverCloseFinished).toBe(false);
+    releaseStop.resolve();
+    await secondClose;
+    expect(hermes.stopRun).toHaveBeenCalledTimes(1);
+    openServers.splice(openServers.indexOf(server), 1);
+  });
+
   it("closes the client session when the realtime provider closes unexpectedly", async () => {
     const providerClosed = deferred<void>();
     const server = await startServer({
@@ -1066,7 +2417,52 @@ describe("live gateway WebSocket", () => {
     await expect(closed).resolves.toMatchObject({ code: 1011 });
   });
 
-  it("requests Hermes stop before aborting the run event stream on socket close", async () => {
+  it("reports unconfirmed Hermes cleanup when an automatic fatal close cannot stop the owned run", async () => {
+    const providerClosed = deferred<void>();
+    const hermes = fakeHermes({
+      streamEvents: async function* (_runId: string, options?: { signal?: AbortSignal }) {
+        await new Promise<void>((_resolve, reject) => {
+          options?.signal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("aborted", "AbortError")),
+            { once: true },
+          );
+        });
+      },
+      stopRun: vi.fn(async () => {
+        throw new Error("Hermes stop endpoint unavailable");
+      }),
+    });
+    const server = await startServer({
+      config: testConfig(),
+      hermes,
+      liveModel: new ProviderCloseAdapter(providerClosed),
+      logger: fakeLogger(),
+    });
+    openServers.push(server);
+    const socket = new WebSocket(toWebSocketUrl(server.url), { headers: { origin: server.url } });
+    openSockets.push(socket);
+    const observed: any[] = [];
+
+    await waitForOpen(socket);
+    send(socket, { type: "session.start" });
+    await waitForMessage(socket, "session.ready");
+    send(socket, { type: "text.input", text: "Start owned work" });
+    await waitForMessage(socket, "run.started");
+    socket.on("message", (raw) => observed.push(JSON.parse(raw.toString("utf8"))));
+    const closed = waitForClose(socket);
+    providerClosed.resolve();
+
+    await expect(closed).resolves.toMatchObject({ code: 1011, reason: "session shutdown unconfirmed" });
+    expect(observed).toContainEqual(expect.objectContaining({
+      type: "session.error",
+      code: "session_shutdown_unconfirmed",
+      recoverable: false,
+    }));
+    expect(hermes.stopRun).toHaveBeenCalledTimes(1);
+  });
+
+  it("aborts the run event stream before issuing a separately bounded Hermes stop on close", async () => {
     const eventStreamAttached = deferred<void>();
     const stopped = deferred<void>();
     let eventStreamSignal: AbortSignal | undefined;
@@ -1079,8 +2475,10 @@ describe("live gateway WebSocket", () => {
         await stopped.promise;
         yield { event: "run.cancelled" };
       },
-      stopRun: vi.fn(async () => {
-        expect(eventStreamSignal?.aborted).toBe(false);
+      stopRun: vi.fn(async (_runId: string, options?: { signal?: AbortSignal; sessionKey?: string }) => {
+        expect(eventStreamSignal?.aborted).toBe(true);
+        expect(options?.signal?.aborted).toBe(false);
+        expect(options?.signal).not.toBe(eventStreamSignal);
         stopped.resolve();
         return { status: "stopping" };
       }),
@@ -1108,6 +2506,47 @@ describe("live gateway WebSocket", () => {
       signal: expect.any(AbortSignal),
       sessionKey: defaultSessionKey,
     });
+  });
+
+  it("hard-times out close-time Hermes stop even when the port ignores abort", async () => {
+    const hermes = fakeHermes({
+      streamEvents: async function* (_runId: string, options?: { signal?: AbortSignal }) {
+        await new Promise<void>((_resolve, reject) => {
+          options?.signal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("aborted", "AbortError")),
+            { once: true },
+          );
+        });
+      },
+      stopRun: vi.fn(async () => await new Promise<never>(() => undefined)),
+    });
+    const server = await startServer({
+      config: testConfig({ hermes: { timeoutMs: 20 } }),
+      hermes,
+      liveModel: new MockLiveAdapter(),
+      logger: fakeLogger(),
+    });
+    openServers.push(server);
+    const socket = new WebSocket(toWebSocketUrl(server.url), { headers: { origin: server.url } });
+    openSockets.push(socket);
+
+    await waitForOpen(socket);
+    send(socket, { type: "session.start" });
+    await waitForMessage(socket, "session.ready");
+    send(socket, { type: "text.input", text: "Keep running until close" });
+    await waitForMessage(socket, "run.started");
+    const failed = waitForMessage(socket, "session.error");
+    const closed = waitForClose(socket);
+    send(socket, { type: "session.close", id: "close_hung_stop" });
+
+    await expect(failed).resolves.toMatchObject({
+      code: "session_shutdown_unconfirmed",
+      requestId: "close_hung_stop",
+      recoverable: false,
+    });
+    await expect(closed).resolves.toMatchObject({ code: 1011, reason: "session shutdown unconfirmed" });
+    expect(hermes.stopRun).toHaveBeenCalledTimes(1);
   });
 
   it("treats a client-close event-stream abort as cancellation instead of a run failure", async () => {
@@ -1370,6 +2809,140 @@ describe("live gateway WebSocket", () => {
     });
   });
 
+  it("closes an authenticated client that outruns the bounded inbound queue", async () => {
+    const audioEntered = deferred<void>();
+    const releaseAudio = deferred<void>();
+    const server = await startServer({
+      config: testConfig(),
+      hermes: fakeHermes(),
+      liveModel: new SlowAudioAdapter(audioEntered, releaseAudio.promise),
+      logger: fakeLogger(),
+    });
+    openServers.push(server);
+    const socket = new WebSocket(toWebSocketUrl(server.url), { headers: { origin: server.url } });
+    openSockets.push(socket);
+
+    await waitForOpen(socket);
+    send(socket, { type: "session.start" });
+    await waitForMessage(socket, "session.ready");
+    const frame = { type: "audio.input", data: Buffer.from([0, 0]).toString("base64"), mimeType: "audio/pcm;rate=24000" };
+    send(socket, frame);
+    await audioEntered.promise;
+    const failed = waitForMessage(socket, "session.error");
+    const closed = waitForClose(socket);
+    for (let index = 0; index < 300; index += 1) send(socket, frame);
+
+    await expect(failed).resolves.toMatchObject({
+      code: "client_input_backpressure",
+      recoverable: false,
+    });
+    await expect(closed).resolves.toMatchObject({ code: 1009, reason: "client input backpressure" });
+    releaseAudio.resolve();
+  });
+
+  it("closes clients that exceed the invalid-message budget", async () => {
+    const server = await startServer({
+      config: testConfig(),
+      hermes: fakeHermes(),
+      liveModel: new MockLiveAdapter(),
+      logger: fakeLogger(),
+    });
+    openServers.push(server);
+    const socket = new WebSocket(toWebSocketUrl(server.url), { headers: { origin: server.url } });
+    openSockets.push(socket);
+
+    await waitForOpen(socket);
+    send(socket, { type: "session.start" });
+    await waitForMessage(socket, "session.ready");
+    const closed = waitForClose(socket);
+    for (let index = 0; index < 16; index += 1) socket.send("{");
+
+    await expect(closed).resolves.toMatchObject({ code: 1008, reason: "too many invalid client messages" });
+  });
+
+  it("preempts a stalled audio send with realtime response cancellation", async () => {
+    const audioEntered = deferred<void>();
+    const releaseAudio = deferred<void>();
+    const server = await startServer({
+      config: testConfig(),
+      hermes: fakeHermes(),
+      liveModel: new SlowAudioAdapter(audioEntered, releaseAudio.promise),
+      logger: fakeLogger(),
+    });
+    openServers.push(server);
+    const socket = new WebSocket(toWebSocketUrl(server.url), { headers: { origin: server.url } });
+    openSockets.push(socket);
+
+    await waitForOpen(socket);
+    send(socket, { type: "session.start" });
+    await waitForMessage(socket, "session.ready");
+    send(socket, {
+      type: "audio.input",
+      data: Buffer.from([0, 0]).toString("base64"),
+      mimeType: "audio/pcm;rate=24000",
+    });
+    await audioEntered.promise;
+    send(socket, { type: "response.cancel", id: "cancel_while_audio_stalled", reason: "barge-in" });
+
+    await expect(waitForMessage(socket, "log")).resolves.toMatchObject({
+      level: "debug",
+      message: "No active realtime response to cancel",
+    });
+    releaseAudio.resolve();
+  });
+
+  it("preempts stalled audio to deliver a correlated approval response", async () => {
+    const audioEntered = deferred<void>();
+    const releaseAudio = deferred<void>();
+    const approvalSubmitted = deferred<void>();
+    const hermes = fakeHermes({
+      streamEvents: async function* () {
+        yield {
+          event: "approval.request",
+          run_id: "run_ws",
+          approval_id: "approval_during_audio",
+          command: "deploy staging",
+          choices: ["once", "deny"],
+        };
+        await approvalSubmitted.promise;
+        yield { event: "run.completed", output: "Approved while audio was stalled." };
+      },
+      submitApproval: vi.fn(async () => {
+        approvalSubmitted.resolve();
+        return { run_id: "run_ws", choice: "once", resolved: 1 };
+      }),
+    });
+    const server = await startServer({
+      config: testConfig(),
+      hermes,
+      liveModel: new SlowAudioAdapter(audioEntered, releaseAudio.promise),
+      logger: fakeLogger(),
+    });
+    openServers.push(server);
+    const socket = new WebSocket(toWebSocketUrl(server.url), { headers: { origin: server.url } });
+    openSockets.push(socket);
+
+    await waitForOpen(socket);
+    send(socket, { type: "session.start" });
+    await waitForMessage(socket, "session.ready");
+    send(socket, { type: "text.input", text: "Deploy safely" });
+    const approval = await waitForMessage(socket, "approval.request");
+    send(socket, {
+      type: "audio.input",
+      data: Buffer.from([0, 0]).toString("base64"),
+      mimeType: "audio/pcm;rate=24000",
+    });
+    await audioEntered.promise;
+    const responded = waitForMessage(socket, "approval.responded");
+    const completed = waitForMessage(socket, "run.completed");
+    sendApprovalResponse(socket, approval, "once", "approval_preempts_audio");
+
+    await responded;
+    await completed;
+    expect(hermes.submitApproval).toHaveBeenCalledTimes(1);
+    releaseAudio.resolve();
+  });
+
   it("rejects oversized text input before forwarding to the provider", async () => {
     const server = await startServer({
       config: testConfig({ server: { maxTextChars: 4 } }),
@@ -1467,6 +3040,8 @@ describe("live gateway WebSocket", () => {
 function fakeHermes(
   options: {
     assertRunsSupported?: ReturnType<typeof vi.fn>;
+    startRun?: ReturnType<typeof vi.fn>;
+    getRun?: ReturnType<typeof vi.fn>;
     streamEvents?: (
       runId: string,
       options?: { signal?: AbortSignal; sessionKey?: string },
@@ -1493,8 +3068,8 @@ function fakeHermes(
           run_approval_response: true,
         },
       })),
-    startRun: vi.fn(async () => ({ runId: "run_ws", status: "started" })),
-    getRun: vi.fn(async () => ({ run_id: "run_ws", status: "running" })),
+    startRun: options.startRun ?? vi.fn(async () => ({ runId: "run_ws", status: "started" })),
+    getRun: options.getRun ?? vi.fn(async () => ({ run_id: "run_ws", status: "running" })),
     streamRunEvents:
       options.streamEvents ??
       (async function* () {
@@ -1519,7 +3094,31 @@ function fakeHermes(
 }
 
 function send(socket: WebSocket, value: unknown): void {
-  socket.send(JSON.stringify(value));
+  const message = value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+  socket.send(JSON.stringify(
+    message?.type === "session.start" && message.protocolVersion === undefined
+      ? { ...message, protocolVersion: 2 }
+      : value,
+  ));
+}
+
+function sendApprovalResponse(
+  socket: WebSocket,
+  request: { runId: string; approval: { approvalId: string } },
+  choice: ApprovalChoice,
+  id: string,
+  extra: Record<string, unknown> = {},
+): void {
+  send(socket, {
+    type: "approval.respond",
+    id,
+    runId: request.runId,
+    approvalId: request.approval.approvalId,
+    choice,
+    ...extra,
+  });
 }
 
 async function waitForOpen(socket: WebSocket): Promise<void> {
@@ -1594,7 +3193,10 @@ function toWebSocketUrl(url: string): string {
   return parsed.toString();
 }
 
-function testConfig(overrides: { server?: Partial<AppConfig["server"]> } = {}): AppConfig {
+function testConfig(overrides: {
+  server?: Partial<AppConfig["server"]>;
+  hermes?: Partial<AppConfig["hermes"]>;
+} = {}): AppConfig {
   return {
     server: {
       host: "127.0.0.1",
@@ -1612,7 +3214,12 @@ function testConfig(overrides: { server?: Partial<AppConfig["server"]> } = {}): 
       ...overrides.server,
       allowUnauthenticated: overrides.server?.allowUnauthenticated ?? false,
     },
-    hermes: { baseUrl: "http://127.0.0.1:8642", model: "hermes-agent", timeoutMs: 30_000 },
+    hermes: {
+      baseUrl: "http://127.0.0.1:8642",
+      model: "hermes-agent",
+      timeoutMs: 30_000,
+      ...overrides.hermes,
+    },
     realtime: { provider: "mock", model: "mock-live" },
     gemini: { model: "gemini-3.1-flash-live-preview", enterprise: false, location: "us-central1" },
     openai: {
@@ -1694,6 +3301,56 @@ class TranscriptMetadataAdapter implements LiveModelAdapter {
   }
 }
 
+class SlowAudioAdapter implements LiveModelAdapter {
+  constructor(
+    private readonly entered: ReturnType<typeof deferred<void>>,
+    private readonly release: Promise<void>,
+  ) {}
+
+  async connect(params: LiveModelConnectParams): Promise<LiveModelSession> {
+    queueMicrotask(() => params.callbacks.onOpen?.());
+    return new SlowAudioSession(this.entered, this.release, params.callbacks);
+  }
+}
+
+class SlowAudioSession implements LiveModelSession {
+  constructor(
+    private readonly entered: ReturnType<typeof deferred<void>>,
+    private readonly release: Promise<void>,
+    private readonly callbacks: LiveModelCallbacks,
+  ) {}
+
+  async sendRealtimeAudio(_audio: LiveModelAudio): Promise<void> {
+    this.entered.resolve();
+    await this.release;
+  }
+
+  async sendText(text: string): Promise<void> {
+    this.callbacks.onEvent({
+      type: "tool_call",
+      call: { id: "slow_audio_start", name: "start_hermes_run", args: { message: text } },
+    });
+  }
+  async sendAudioStreamEnd(): Promise<void> {}
+  async cancelResponse(): Promise<boolean> { return false; }
+  async sendToolResponse(_call: LiveToolCall, _response: Record<string, unknown>): Promise<void> {}
+  async close(): Promise<void> {}
+}
+
+class ManualProviderEventAdapter implements LiveModelAdapter {
+  private callbacks?: LiveModelCallbacks;
+
+  async connect(params: LiveModelConnectParams): Promise<LiveModelSession> {
+    this.callbacks = params.callbacks;
+    queueMicrotask(() => params.callbacks.onOpen?.());
+    return new CloseTrackingSession();
+  }
+
+  emit(event: Parameters<LiveModelCallbacks["onEvent"]>[0]): void {
+    this.callbacks?.onEvent(event);
+  }
+}
+
 class FailingConnectAdapter implements LiveModelAdapter {
   async connect(_params: LiveModelConnectParams): Promise<LiveModelSession> {
     throw new Error("Provider did not connect");
@@ -1705,6 +3362,25 @@ class PreReadyErrorAdapter implements LiveModelAdapter {
     params.callbacks.onError?.(new Error("Provider errored before ready"));
     await new Promise(() => undefined);
     return new CloseTrackingSession();
+  }
+}
+
+class OversizedPreReadyEventAdapter implements LiveModelAdapter {
+  readonly session = new CloseTrackingSession();
+
+  async connect(params: LiveModelConnectParams): Promise<LiveModelSession> {
+    params.callbacks.onEvent({ type: "text", text: "x".repeat(8 * 1024 * 1024) });
+    return this.session;
+  }
+}
+
+class ErrorThenOpenAdapter implements LiveModelAdapter {
+  readonly session = new CloseTrackingSession();
+
+  async connect(params: LiveModelConnectParams): Promise<LiveModelSession> {
+    params.callbacks.onError?.(new Error("provider startup secret"));
+    params.callbacks.onOpen?.();
+    return this.session;
   }
 }
 
@@ -1720,6 +3396,26 @@ class NeverOpenAdapter implements LiveModelAdapter {
   readonly session = new CloseTrackingSession();
 
   async connect(_params: LiveModelConnectParams): Promise<LiveModelSession> {
+    return this.session;
+  }
+}
+
+class NeverOpenHungCloseAdapter implements LiveModelAdapter {
+  readonly session = new HungCloseSession();
+
+  async connect(_params: LiveModelConnectParams): Promise<LiveModelSession> {
+    return this.session;
+  }
+}
+
+class PendingConnectAdapter implements LiveModelAdapter {
+  readonly connectEntered = deferred<void>();
+  readonly releaseConnect = deferred<void>();
+  readonly session = new CloseTrackingSession();
+
+  async connect(_params: LiveModelConnectParams): Promise<LiveModelSession> {
+    this.connectEntered.resolve();
+    await this.releaseConnect.promise;
     return this.session;
   }
 }
@@ -1765,6 +3461,10 @@ class CloseTrackingSession implements LiveModelSession {
   async sendToolResponse(_call: LiveToolCall, _response: Record<string, unknown>): Promise<void> {}
 }
 
+class HungCloseSession extends CloseTrackingSession {
+  override readonly close = vi.fn(async () => await new Promise<never>(() => undefined));
+}
+
 class OversizedToolCallAdapter implements LiveModelAdapter {
   async connect(params: LiveModelConnectParams): Promise<LiveModelSession> {
     queueMicrotask(() => params.callbacks.onOpen?.());
@@ -1807,7 +3507,11 @@ class ManualToolAdapter implements LiveModelAdapter {
   }
 
   emitToolCall(call: LiveToolCall): void {
-    this.callbacks?.onEvent({ type: "tool_call", call });
+    this.emitEvent({ type: "tool_call", call });
+  }
+
+  emitEvent(event: LiveModelEvent): void {
+    this.callbacks?.onEvent(event);
   }
 
   nextToolResponse(): Promise<{ call: LiveToolCall; response: Record<string, unknown> }> {
@@ -1877,6 +3581,46 @@ class CancelTrackingSession implements LiveModelSession {
   async sendToolResponse(_call: LiveToolCall, _response: Record<string, unknown>): Promise<void> {}
 
   async close(): Promise<void> {}
+}
+
+class HungCancelToolAdapter implements LiveModelAdapter {
+  readonly cancelEntered = deferred<void>();
+  private readonly releaseCancel = deferred<boolean>();
+
+  async connect(params: LiveModelConnectParams): Promise<LiveModelSession> {
+    queueMicrotask(() => params.callbacks.onOpen?.());
+    return new HungCancelToolSession(params.callbacks, this.cancelEntered, this.releaseCancel);
+  }
+}
+
+class HungCancelToolSession implements LiveModelSession {
+  constructor(
+    private readonly callbacks: LiveModelCallbacks,
+    private readonly cancelEntered: ReturnType<typeof deferred<void>>,
+    private readonly releaseCancel: ReturnType<typeof deferred<boolean>>,
+  ) {}
+
+  async sendRealtimeAudio(_audio: LiveModelAudio): Promise<void> {}
+
+  async sendText(text: string): Promise<void> {
+    this.callbacks.onEvent({
+      type: "tool_call",
+      call: { id: "hung_cancel_start", name: "start_hermes_run", args: { message: text } },
+    });
+  }
+
+  async sendAudioStreamEnd(): Promise<void> {}
+
+  async cancelResponse(): Promise<boolean> {
+    this.cancelEntered.resolve();
+    return await this.releaseCancel.promise;
+  }
+
+  async sendToolResponse(_call: LiveToolCall, _response: Record<string, unknown>): Promise<void> {}
+
+  async close(): Promise<void> {
+    this.releaseCancel.resolve(false);
+  }
 }
 
 class SpeechStartedAdapter implements LiveModelAdapter {

--- a/test/openai-realtime.test.ts
+++ b/test/openai-realtime.test.ts
@@ -1,6 +1,6 @@
 import { once } from "node:events";
 import { WebSocketServer } from "ws";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   buildOpenAIConversationItemTruncate,
   buildOpenAIRealtimeAudioAppend,
@@ -18,7 +18,7 @@ describe("OpenAI Realtime adapter helpers", () => {
       type: "audio",
       audio: { data: "abc", mimeType: "audio/pcm;rate=24000", itemId: "item_1", contentIndex: 0 },
     });
-    expect(audioEvents.at(-1)).toMatchObject({ type: "raw" });
+    expect(audioEvents).toHaveLength(1);
     expect(normalizeOpenAIRealtimeEvent({ type: "response.audio.delta", delta: "legacy-audio" })).toContainEqual({
       type: "audio",
       audio: { data: "legacy-audio", mimeType: "audio/pcm;rate=24000" },
@@ -45,6 +45,25 @@ describe("OpenAI Realtime adapter helpers", () => {
       type: "tool_call",
       call: { id: "call_1", name: "start_hermes_run", args: { message: "hello" } },
     });
+  });
+
+  it("orders function calls before a terminal response from the same provider event", () => {
+    const events = normalizeOpenAIRealtimeEvent({
+      type: "response.done",
+      response: {
+        id: "resp_tool",
+        status: "completed",
+        output: [{
+          type: "function_call",
+          call_id: "call_combined",
+          name: "start_hermes_run",
+          arguments: '{"message":"inspect"}',
+        }],
+      },
+    });
+
+    expect(events.map((event) => event.type)).toEqual(["tool_call", "response"]);
+    expect(events[1]).toMatchObject({ type: "response", status: "completed", responseId: "resp_tool" });
   });
 
   it("normalizes speech-start events for VAD interruption handling", () => {
@@ -169,6 +188,511 @@ describe("OpenAI Realtime adapter helpers", () => {
       await closeServer(server);
     }
   });
+
+  it("rejects malformed JSON before session readiness without leaking the provider socket", async () => {
+    const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    await once(server, "listening");
+    const port = portOf(server);
+    const closed = deferred<{ code: number; reason: string }>();
+    server.once("connection", (socket) => {
+      socket.once("message", () => socket.send("not-json"));
+      socket.once("close", (code, reason) => {
+        closed.resolve({ code, reason: reason.toString("utf8") });
+      });
+    });
+    const adapter = new OpenAIRealtimeAdapter(testOpenAIConfig({
+      apiKey: "test-key",
+      baseUrl: `ws://127.0.0.1:${port}/v1/realtime`,
+    }));
+
+    try {
+      await expect(adapter.connect(testConnectParams())).rejects.toThrow("not valid JSON");
+      await expect(withTimeout(closed.promise, 1_000, "Malformed startup socket did not close."))
+        .resolves.toMatchObject({ code: 1011 });
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it("defers a fast tool follow-up until the response that requested the tool is terminal", async () => {
+    const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    await once(server, "listening");
+    const port = portOf(server);
+    const clientMessages: any[] = [];
+    const toolResponseFinished = deferred<void>();
+    const toolOutputReceived = deferred<void>();
+    const secondResponseCreate = deferred<void>();
+    let upstream: import("ws").WebSocket | undefined;
+
+    server.once("connection", (socket) => {
+      upstream = socket;
+      socket.on("message", (raw) => {
+        const message = JSON.parse(raw.toString("utf8"));
+        clientMessages.push(message);
+        if (message.type === "session.update") {
+          socket.send(JSON.stringify({ type: "session.updated" }));
+          return;
+        }
+        if (message.type === "response.create") {
+          const responseCreateCount = clientMessages.filter((entry) => entry.type === "response.create").length;
+          if (responseCreateCount === 1) {
+            socket.send(JSON.stringify({ type: "response.created", response: { status: "in_progress" } }));
+            socket.send(JSON.stringify({
+              type: "response.function_call_arguments.done",
+              call_id: "call_1",
+              name: "get_hermes_run_status",
+              arguments: '{"run_id":"run_1"}',
+            }));
+          } else if (responseCreateCount === 2) {
+            secondResponseCreate.resolve();
+          }
+          return;
+        }
+        if (message.type === "conversation.item.create" && message.item?.type === "function_call_output") {
+          toolOutputReceived.resolve();
+        }
+      });
+    });
+
+    const adapter = new OpenAIRealtimeAdapter(testOpenAIConfig({
+      apiKey: "test-key",
+      baseUrl: `ws://127.0.0.1:${port}/v1/realtime`,
+    }));
+    let session: Awaited<ReturnType<OpenAIRealtimeAdapter["connect"]>> | undefined;
+
+    try {
+      session = await adapter.connect({
+        sessionId: "live_openai_tool_serialization",
+        systemInstruction: "test",
+        callbacks: {
+          onEvent: (event) => {
+            if (event.type !== "tool_call") return;
+            void session?.sendToolResponse(event.call, { ok: true, status: "running" }).then(
+              () => toolResponseFinished.resolve(),
+              (error) => toolResponseFinished.reject(error),
+            );
+          },
+        },
+      });
+
+      await session.sendText("check the run");
+      await withTimeout(toolResponseFinished.promise, 1_000, "Tool response was not sent.");
+      await withTimeout(toolOutputReceived.promise, 1_000, "Tool output did not reach OpenAI.");
+      expect(clientMessages.filter((entry) => entry.type === "response.create")).toHaveLength(1);
+
+      upstream?.send(JSON.stringify({
+        type: "response.done",
+        response: {
+          status: "completed",
+          output: [{
+            type: "function_call",
+            call_id: "call_1",
+            name: "get_hermes_run_status",
+            arguments: '{"run_id":"run_1"}',
+          }],
+        },
+      }));
+      await withTimeout(secondResponseCreate.promise, 1_000, "Deferred response.create was not sent.");
+
+      const toolOutputIndex = clientMessages.findIndex(
+        (entry) => entry.type === "conversation.item.create" && entry.item?.type === "function_call_output",
+      );
+      const secondResponseIndex = clientMessages.map((entry) => entry.type).lastIndexOf("response.create");
+      expect(toolOutputIndex).toBeGreaterThanOrEqual(0);
+      expect(secondResponseIndex).toBeGreaterThan(toolOutputIndex);
+      expect(clientMessages.filter((entry) => entry.type === "response.create")).toHaveLength(2);
+    } finally {
+      await session?.close();
+      await closeServer(server);
+    }
+  });
+
+  it("sends a same-event tool result before releasing a queued response", async () => {
+    const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    await once(server, "listening");
+    const port = portOf(server);
+    const clientMessages: any[] = [];
+    const responseStarted = deferred<void>();
+    const toolOutputReceived = deferred<void>();
+    const secondResponseCreate = deferred<void>();
+    let upstream: import("ws").WebSocket | undefined;
+
+    server.once("connection", (socket) => {
+      upstream = socket;
+      socket.on("message", (raw) => {
+        const message = JSON.parse(raw.toString("utf8"));
+        clientMessages.push(message);
+        if (message.type === "session.update") {
+          socket.send(JSON.stringify({ type: "session.updated" }));
+        } else if (message.type === "response.create") {
+          const count = clientMessages.filter((entry) => entry.type === "response.create").length;
+          if (count === 1) {
+            socket.send(JSON.stringify({
+              type: "response.created",
+              response: { id: "resp_tool", status: "in_progress" },
+            }));
+            responseStarted.resolve();
+          } else if (count === 2) {
+            secondResponseCreate.resolve();
+          }
+        } else if (
+          message.type === "conversation.item.create" &&
+          message.item?.type === "function_call_output"
+        ) {
+          toolOutputReceived.resolve();
+        }
+      });
+    });
+
+    const adapter = new OpenAIRealtimeAdapter(testOpenAIConfig({
+      apiKey: "test-key",
+      baseUrl: `ws://127.0.0.1:${port}/v1/realtime`,
+    }));
+    let session: Awaited<ReturnType<OpenAIRealtimeAdapter["connect"]>> | undefined;
+
+    try {
+      session = await adapter.connect({
+        sessionId: "live_openai_same_event_tool_serialization",
+        systemInstruction: "test",
+        callbacks: {
+          onEvent: (event) => {
+            if (event.type !== "tool_call") return;
+            void session?.sendToolResponse(event.call, { ok: true, status: "running" });
+          },
+        },
+      });
+      await session.sendText("first question");
+      await withTimeout(responseStarted.promise, 1_000, "OpenAI response did not start.");
+      await session.sendText("queued question");
+
+      upstream?.send(JSON.stringify({
+        type: "response.done",
+        response: {
+          id: "resp_tool",
+          status: "completed",
+          output: [{
+            type: "function_call",
+            call_id: "call_same_event",
+            name: "get_hermes_run_status",
+            arguments: '{"run_id":"run_1"}',
+          }],
+        },
+      }));
+
+      await withTimeout(toolOutputReceived.promise, 1_000, "Tool output did not reach OpenAI.");
+      await withTimeout(secondResponseCreate.promise, 1_000, "Queued response was not released after the tool output.");
+      const toolOutputIndex = clientMessages.findIndex(
+        (entry) => entry.type === "conversation.item.create" && entry.item?.type === "function_call_output",
+      );
+      const secondResponseIndex = clientMessages.map((entry) => entry.type).lastIndexOf("response.create");
+      expect(secondResponseIndex).toBeGreaterThan(toolOutputIndex);
+      expect(clientMessages.filter((entry) => entry.type === "response.create")).toHaveLength(2);
+    } finally {
+      await session?.close();
+      await closeServer(server);
+    }
+  });
+
+  it("waits for cancellation acknowledgement before creating a queued text response", async () => {
+    const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    await once(server, "listening");
+    const port = portOf(server);
+    const clientMessages: any[] = [];
+    const responseStarted = deferred<void>();
+    const cancelReceived = deferred<void>();
+    const queuedTextReceived = deferred<void>();
+    const secondResponseCreate = deferred<void>();
+    let upstream: import("ws").WebSocket | undefined;
+
+    server.once("connection", (socket) => {
+      upstream = socket;
+      socket.on("message", (raw) => {
+        const message = JSON.parse(raw.toString("utf8"));
+        clientMessages.push(message);
+        if (message.type === "session.update") {
+          socket.send(JSON.stringify({ type: "session.updated" }));
+          return;
+        }
+        if (message.type === "response.create") {
+          const responseCreateCount = clientMessages.filter((entry) => entry.type === "response.create").length;
+          if (responseCreateCount === 1) {
+            socket.send(JSON.stringify({
+              type: "response.created",
+              response: { id: "resp_1", status: "in_progress" },
+            }));
+          } else if (responseCreateCount === 2) {
+            secondResponseCreate.resolve();
+          }
+          return;
+        }
+        if (message.type === "response.cancel") cancelReceived.resolve();
+        if (
+          message.type === "conversation.item.create" &&
+          message.item?.content?.[0]?.text === "next question"
+        ) {
+          queuedTextReceived.resolve();
+        }
+      });
+    });
+
+    const adapter = new OpenAIRealtimeAdapter(testOpenAIConfig({
+      apiKey: "test-key",
+      baseUrl: `ws://127.0.0.1:${port}/v1/realtime`,
+    }));
+    let session: Awaited<ReturnType<OpenAIRealtimeAdapter["connect"]>> | undefined;
+
+    try {
+      session = await adapter.connect({
+        sessionId: "live_openai_cancel_serialization",
+        systemInstruction: "test",
+        callbacks: {
+          onEvent: (event) => {
+            if (event.type === "response" && event.status === "started") responseStarted.resolve();
+          },
+        },
+      });
+
+      await session.sendText("first question");
+      await withTimeout(responseStarted.promise, 1_000, "OpenAI response did not start.");
+      await expect(session.cancelResponse("interrupted")).resolves.toBe(true);
+      await session.sendText("next question");
+      await withTimeout(cancelReceived.promise, 1_000, "OpenAI did not receive response.cancel.");
+      await withTimeout(queuedTextReceived.promise, 1_000, "Queued text did not reach OpenAI.");
+      expect(clientMessages.filter((entry) => entry.type === "response.create")).toHaveLength(1);
+
+      upstream?.send(JSON.stringify({
+        type: "response.done",
+        response: { id: "resp_1", status: "cancelled" },
+      }));
+      await withTimeout(secondResponseCreate.promise, 1_000, "Queued text response was not created after cancellation.");
+
+      const cancelIndex = clientMessages.findIndex((entry) => entry.type === "response.cancel");
+      const secondResponseIndex = clientMessages.map((entry) => entry.type).lastIndexOf("response.create");
+      expect(cancelIndex).toBeGreaterThanOrEqual(0);
+      expect(secondResponseIndex).toBeGreaterThan(cancelIndex);
+      expect(clientMessages.filter((entry) => entry.type === "response.create")).toHaveLength(2);
+    } finally {
+      await session?.close();
+      await closeServer(server);
+    }
+  });
+
+  it("fails closed when OpenAI does not acknowledge response cancellation", async () => {
+    const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    await once(server, "listening");
+    const port = portOf(server);
+    const clientMessages: any[] = [];
+    const responseStarted = deferred<void>();
+    const adapterError = deferred<unknown>();
+    const providerClosed = deferred<{ code: number; reason: string }>();
+
+    server.once("connection", (socket) => {
+      socket.on("message", (raw) => {
+        const message = JSON.parse(raw.toString("utf8"));
+        clientMessages.push(message);
+        if (message.type === "session.update") {
+          socket.send(JSON.stringify({ type: "session.updated" }));
+        } else if (message.type === "response.create") {
+          socket.send(JSON.stringify({
+            type: "response.created",
+            response: { id: "resp_timeout", status: "in_progress" },
+          }));
+        }
+      });
+      socket.once("close", (code, reason) => {
+        providerClosed.resolve({ code, reason: reason.toString("utf8") });
+      });
+    });
+
+    const adapter = new OpenAIRealtimeAdapter(testOpenAIConfig({
+      apiKey: "test-key",
+      baseUrl: `ws://127.0.0.1:${port}/v1/realtime`,
+    }));
+    let session: Awaited<ReturnType<OpenAIRealtimeAdapter["connect"]>> | undefined;
+
+    try {
+      session = await adapter.connect({
+        sessionId: "live_openai_cancel_timeout",
+        systemInstruction: "test",
+        callbacks: {
+          onEvent: (event) => {
+            if (event.type === "response" && event.status === "started") responseStarted.resolve();
+          },
+          onError: (error) => adapterError.resolve(error),
+        },
+      });
+
+      await session.sendText("first question");
+      await withTimeout(responseStarted.promise, 1_000, "OpenAI response did not start.");
+      vi.useFakeTimers();
+      try {
+        await expect(session.cancelResponse("interrupted")).resolves.toBe(true);
+        await session.sendText("must stay queued");
+        await vi.advanceTimersByTimeAsync(2_000);
+      } finally {
+        vi.useRealTimers();
+      }
+
+      await expect(withTimeout(adapterError.promise, 1_000, "Cancel timeout did not report an adapter error."))
+        .resolves.toMatchObject({ message: "OpenAI Realtime did not confirm response cancellation within 2000ms." });
+      await expect(withTimeout(providerClosed.promise, 1_000, "Cancel timeout did not close the provider socket."))
+        .resolves.toEqual({ code: 1011, reason: "OpenAI Realtime cancel timeout" });
+      expect(clientMessages.filter((entry) => entry.type === "response.create")).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+      await session?.close();
+      await closeServer(server);
+    }
+  });
+
+  it("fails closed on a post-ready provider error instead of wedging response state", async () => {
+    const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    await once(server, "listening");
+    const port = portOf(server);
+    const adapterError = deferred<unknown>();
+    const providerClosed = deferred<{ code: number; reason: string }>();
+    let responseCreates = 0;
+
+    server.once("connection", (socket) => {
+      socket.on("message", (raw) => {
+        const message = JSON.parse(raw.toString("utf8"));
+        if (message.type === "session.update") {
+          socket.send(JSON.stringify({ type: "session.updated" }));
+        } else if (message.type === "response.create") {
+          responseCreates += 1;
+          socket.send(JSON.stringify({ type: "response.created", response: { status: "in_progress" } }));
+          socket.send(JSON.stringify({ type: "error", error: { message: "provider rejected response" } }));
+        }
+      });
+      socket.once("close", (code, reason) => {
+        providerClosed.resolve({ code, reason: reason.toString("utf8") });
+      });
+    });
+
+    const adapter = new OpenAIRealtimeAdapter(testOpenAIConfig({
+      apiKey: "test-key",
+      baseUrl: `ws://127.0.0.1:${port}/v1/realtime`,
+    }));
+    let session: Awaited<ReturnType<OpenAIRealtimeAdapter["connect"]>> | undefined;
+
+    try {
+      session = await adapter.connect({
+        sessionId: "live_openai_provider_error",
+        systemInstruction: "test",
+        callbacks: {
+          onEvent: () => undefined,
+          onError: (error) => adapterError.resolve(error),
+        },
+      });
+      await session.sendText("trigger provider error");
+
+      await expect(withTimeout(adapterError.promise, 1_000, "Provider error was not reported."))
+        .resolves.toMatchObject({ message: "provider rejected response" });
+      await expect(withTimeout(providerClosed.promise, 1_000, "Provider error did not close the socket."))
+        .resolves.toEqual({ code: 1011, reason: "OpenAI Realtime provider error" });
+      expect(responseCreates).toBe(1);
+    } finally {
+      await session?.close();
+      await closeServer(server);
+    }
+  });
+
+  it("fails closed on malformed post-ready provider JSON", async () => {
+    const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    await once(server, "listening");
+    const port = portOf(server);
+    const adapterError = deferred<unknown>();
+    const providerClosed = deferred<{ code: number; reason: string }>();
+
+    server.once("connection", (socket) => {
+      socket.on("message", (raw) => {
+        const message = JSON.parse(raw.toString("utf8"));
+        if (message.type === "session.update") {
+          socket.send(JSON.stringify({ type: "session.updated" }));
+          queueMicrotask(() => socket.send("not-json"));
+        }
+      });
+      socket.once("close", (code, reason) => {
+        providerClosed.resolve({ code, reason: reason.toString("utf8") });
+      });
+    });
+
+    const adapter = new OpenAIRealtimeAdapter(testOpenAIConfig({
+      apiKey: "test-key",
+      baseUrl: `ws://127.0.0.1:${port}/v1/realtime`,
+    }));
+    let session: Awaited<ReturnType<OpenAIRealtimeAdapter["connect"]>> | undefined;
+
+    try {
+      session = await adapter.connect({
+        sessionId: "live_openai_malformed_event",
+        systemInstruction: "test",
+        callbacks: {
+          onEvent: () => undefined,
+          onError: (error) => adapterError.resolve(error),
+        },
+      });
+      await expect(withTimeout(adapterError.promise, 1_000, "Malformed provider event was not reported."))
+        .resolves.toMatchObject({ message: "OpenAI Realtime event was not valid JSON." });
+      await expect(withTimeout(providerClosed.promise, 1_000, "Malformed provider event did not close the socket."))
+        .resolves.toEqual({ code: 1011, reason: "OpenAI Realtime provider error" });
+    } finally {
+      await session?.close();
+      await closeServer(server);
+    }
+  });
+
+  it("fails closed instead of issuing a response before multiple tool outputs", async () => {
+    const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    await once(server, "listening");
+    const port = portOf(server);
+    const adapterError = deferred<unknown>();
+    const providerClosed = deferred<{ code: number; reason: string }>();
+    const onEvent = vi.fn();
+
+    server.once("connection", (socket) => {
+      socket.on("message", (raw) => {
+        const message = JSON.parse(raw.toString("utf8"));
+        if (message.type === "session.update") {
+          socket.send(JSON.stringify({ type: "session.updated" }));
+          queueMicrotask(() => socket.send(JSON.stringify({
+            type: "response.done",
+            response: {
+              status: "completed",
+              output: [
+                { type: "function_call", call_id: "call_1", name: "get_hermes_run_status", arguments: '{}' },
+                { type: "function_call", call_id: "call_2", name: "stop_hermes_run", arguments: '{}' },
+              ],
+            },
+          })));
+        }
+      });
+      socket.once("close", (code, reason) => {
+        providerClosed.resolve({ code, reason: reason.toString("utf8") });
+      });
+    });
+
+    const adapter = new OpenAIRealtimeAdapter(testOpenAIConfig({
+      apiKey: "test-key",
+      baseUrl: `ws://127.0.0.1:${port}/v1/realtime`,
+    }));
+    let session: Awaited<ReturnType<OpenAIRealtimeAdapter["connect"]>> | undefined;
+    try {
+      session = await adapter.connect({
+        sessionId: "live_openai_multiple_tools",
+        systemInstruction: "test",
+        callbacks: { onEvent, onError: (error) => adapterError.resolve(error) },
+      });
+      await expect(withTimeout(adapterError.promise, 1_000, "Multiple tool calls were not rejected."))
+        .resolves.toMatchObject({ message: expect.stringContaining("multiple tool calls") });
+      await expect(withTimeout(providerClosed.promise, 1_000, "Multiple tool calls did not close the provider socket."))
+        .resolves.toEqual({ code: 1011, reason: "OpenAI Realtime provider error" });
+      expect(onEvent).not.toHaveBeenCalled();
+    } finally {
+      await session?.close();
+      await closeServer(server);
+    }
+  });
 });
 
 function testOpenAIConfig(
@@ -222,4 +746,14 @@ async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: s
       clearTimeout(timeout);
     }
   }
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve(value: T): void; reject(error: unknown): void } {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
 }

--- a/test/protocol.test.ts
+++ b/test/protocol.test.ts
@@ -3,9 +3,9 @@ import { HERMES_LIVE_TOOL_DECLARATIONS, OPENAI_HERMES_LIVE_TOOLS, parseClientMes
 
 describe("protocol", () => {
   it("validates known client messages", () => {
-    expect(parseClientMessage({ type: "session.start", protocolVersion: 1, profileId: "default" })).toMatchObject({
+    expect(parseClientMessage({ type: "session.start", protocolVersion: 2, profileId: "default" })).toMatchObject({
       type: "session.start",
-      protocolVersion: 1,
+      protocolVersion: 2,
     });
     expect(parseClientMessage({ type: "text.input", text: "hello" }).type).toBe("text.input");
     expect(parseClientMessage({ type: "response.cancel", reason: "user interrupted" }).type).toBe("response.cancel");
@@ -29,13 +29,25 @@ describe("protocol", () => {
       type: "response.cancel",
       truncate: { itemId: "item_1", contentIndex: 0, audioEndMs: 0 },
     });
-    expect(parseClientMessage({ type: "approval.respond", runId: "run_1", choice: "once" }).type).toBe("approval.respond");
+    expect(parseClientMessage({
+      type: "approval.respond",
+      id: "approval_response_1",
+      runId: "run_1",
+      approvalId: "approval_1",
+      choice: "once",
+    }).type).toBe("approval.respond");
   });
 
   it("rejects invalid client messages", () => {
     expect(() => parseClientMessage({ type: "session.start", protocolVersion: 0 })).toThrow();
     expect(() => parseClientMessage({ type: "text.input", text: "" })).toThrow();
     expect(() => parseClientMessage({ type: "approval.respond", runId: "run_1", choice: "forever" })).toThrow();
+    expect(() => parseClientMessage({
+      type: "approval.respond",
+      id: "approval_response_1",
+      runId: "run_1",
+      choice: "once",
+    })).toThrow();
   });
 
   it("bounds client-controlled metadata fields", () => {
@@ -44,7 +56,13 @@ describe("protocol", () => {
 
     expect(() => parseClientMessage({ type: "session.start", profileId: tooLongMetadata })).toThrow();
     expect(() => parseClientMessage({ type: "audio.input", data: "AA==", mimeType: "x".repeat(129) })).toThrow();
-    expect(() => parseClientMessage({ type: "approval.respond", runId: tooLongMetadata, choice: "once" })).toThrow();
+    expect(() => parseClientMessage({
+      type: "approval.respond",
+      id: "approval_response_1",
+      runId: tooLongMetadata,
+      approvalId: "approval_1",
+      choice: "once",
+    })).toThrow();
     expect(() => parseClientMessage({ type: "run.stop", reason: tooLongReason })).toThrow();
     expect(() =>
       parseClientMessage({ type: "response.cancel", truncate: { itemId: "item_1", audioEndMs: Number.POSITIVE_INFINITY } }),
@@ -55,10 +73,10 @@ describe("protocol", () => {
   });
 
   it("serializes server messages as JSON", () => {
-    expect(JSON.parse(serverMessage({ type: "run.stopped", runId: "run_1", status: "stopping" }))).toEqual({
+    expect(JSON.parse(serverMessage({ type: "run.stopped", runId: "run_1", status: "cancelled" }))).toEqual({
       type: "run.stopped",
       runId: "run_1",
-      status: "stopping",
+      status: "cancelled",
     });
   });
 

--- a/test/server-http.test.ts
+++ b/test/server-http.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createConnection } from "node:net";
 import type { AppConfig } from "../src/config.js";
 import type { HermesRunsPort } from "../src/application/live-gateway/ports/hermes-runs.port.js";
 import type { Logger } from "../src/logger.js";
@@ -27,7 +28,7 @@ describe("HTTP server", () => {
     });
     await expect(fetch(`${server.url}/v1/capabilities`).then((res) => res.json())).resolves.toMatchObject({
       object: "hermes_live.capabilities",
-      protocolVersion: 1,
+      protocolVersion: 2,
       realtime: {
         provider: "openai",
         model: "gpt-realtime-2.1",
@@ -271,6 +272,32 @@ describe("HTTP server", () => {
     });
   });
 
+  it("rejects malformed WebSocket upgrades without taking down the HTTP server", async () => {
+    const server = await startServer({
+      config: testConfig(),
+      hermes: fakeHermes(),
+      liveModel: new MockLiveAdapter(),
+      logger: fakeLogger(),
+    });
+    openServers.push(server);
+
+    const malformedTarget = await rawHttpRequest(
+      server.url,
+      "GET //[ HTTP/1.1\r\nHost: localhost\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n\r\n",
+    );
+    const malformedHost = await rawHttpRequest(
+      server.url,
+      "GET /v1/live HTTP/1.1\r\nHost: [\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n\r\n",
+    );
+
+    expect(malformedTarget).toMatch(/^HTTP\/1\.1 400 Bad Request\r\n/);
+    expect(malformedHost).toMatch(/^HTTP\/1\.1 400 Bad Request\r\n/);
+    await expect(fetch(`${server.url}/health`).then((res) => res.json())).resolves.toMatchObject({
+      status: "ok",
+      service: "hermes-live",
+    });
+  });
+
   it("rejects startup when the listen port is already in use", async () => {
     const server = await startServer({
       config: testConfig(),
@@ -345,6 +372,20 @@ function fakeHermes(): HermesRunsPort {
       },
     })),
   } as unknown as HermesRunsPort;
+}
+
+function rawHttpRequest(serverUrl: string, request: string): Promise<string> {
+  const url = new URL(serverUrl);
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    const socket = createConnection({ host: url.hostname, port: Number(url.port) });
+    socket.setTimeout(2_000);
+    socket.on("connect", () => socket.write(request));
+    socket.on("data", (chunk: Buffer) => chunks.push(chunk));
+    socket.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    socket.on("error", reject);
+    socket.on("timeout", () => socket.destroy(new Error("Timed out waiting for the raw HTTP response.")));
+  });
 }
 
 function testConfig(

--- a/test/sse.test.ts
+++ b/test/sse.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseSseEventBlock, parseSseStream } from "../src/adapters/outbound/hermes/sse.js";
+import { MAX_SSE_EVENT_BYTES, parseSseEventBlock, parseSseStream } from "../src/adapters/outbound/hermes/sse.js";
 
 describe("SSE parsing", () => {
   it("parses JSON data blocks", () => {
@@ -42,5 +42,43 @@ describe("SSE parsing", () => {
     }
 
     expect(events).toEqual([{ event: "a" }, { event: "b" }]);
+  });
+
+  it("rejects an oversized unterminated event before buffering more data", async () => {
+    let cancelled = false;
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(`data: ${"x".repeat(MAX_SSE_EVENT_BYTES + 1)}`));
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+
+    const consume = async () => {
+      for await (const _event of parseSseStream(stream)) {
+        // No complete event should be emitted.
+      }
+    };
+    await expect(consume()).rejects.toThrow(`${MAX_SSE_EVENT_BYTES}-byte safety limit`);
+    expect(cancelled).toBe(true);
+  });
+
+  it("cancels the source when a consumer returns before natural EOF", async () => {
+    let cancelled = false;
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('data: {"event":"run.completed"}\n\n'));
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+
+    for await (const _event of parseSseStream(stream)) {
+      break;
+    }
+
+    expect(cancelled).toBe(true);
   });
 });

--- a/test/terminal-client.test.ts
+++ b/test/terminal-client.test.ts
@@ -67,6 +67,8 @@ describe("TerminalGatewaySession", () => {
               },
             }),
           );
+        } else if (message.type === "session.close") {
+          socket.close(1000, "session closed");
         }
       });
     });
@@ -152,19 +154,35 @@ describe("TerminalGatewaySession", () => {
     await waitForMessage(received, "approval.respond");
     expect(received.find((message) => message.type === "approval.respond")).toMatchObject({
       runId: "run_terminal",
+      approvalId: "approval_terminal_1",
       choice: "always",
     });
 
-    peer?.send(JSON.stringify({ type: "approval.responded", runId: "run_terminal", choice: "always", resolved: 1 }));
+    peer?.send(JSON.stringify({
+      type: "approval.responded",
+      requestId: "terminal_approval_1",
+      runId: "run_terminal",
+      approvalId: "approval_terminal_1",
+      choice: "always",
+      resolved: 1,
+    }));
     await vi.waitFor(() => expect(session.snapshot.pendingApproval?.command).toBe("npm publish"));
     expect(lines).toContain("[approval] Command: npm publish");
     session.execute("/approve deny");
     await waitForMessageCount(received, "approval.respond", 2);
     expect(received.filter((message) => message.type === "approval.respond").at(-1)).toMatchObject({
       runId: "run_terminal",
+      approvalId: "approval_terminal_2",
       choice: "deny",
     });
-    peer?.send(JSON.stringify({ type: "approval.responded", runId: "run_terminal", choice: "deny", resolved: 1 }));
+    peer?.send(JSON.stringify({
+      type: "approval.responded",
+      requestId: "terminal_approval_2",
+      runId: "run_terminal",
+      approvalId: "approval_terminal_2",
+      choice: "deny",
+      resolved: 1,
+    }));
     await vi.waitFor(() => expect(session.snapshot.pendingApprovals).toEqual([]));
     peer?.send(JSON.stringify({
       type: "approval.request",
@@ -182,7 +200,41 @@ describe("TerminalGatewaySession", () => {
     expect(lines).toContain("[approval] Hermes did not provide an inspectable permission pattern; permanent approval is unavailable.");
     session.execute("/approve deny");
     await waitForMessageCount(received, "approval.respond", 3);
-    peer?.send(JSON.stringify({ type: "approval.responded", runId: "run_terminal", choice: "deny", resolved: 1 }));
+    peer?.send(JSON.stringify({
+      type: "approval.responded",
+      requestId: "terminal_approval_3",
+      runId: "run_terminal",
+      approvalId: "approval_terminal_3",
+      choice: "deny",
+      resolved: 1,
+    }));
+    await vi.waitFor(() => expect(session.snapshot.pendingApprovals).toEqual([]));
+    peer?.send(JSON.stringify({
+      type: "approval.request",
+      runId: "run_terminal",
+      event: { event: "approval.request", approval_id: "approval_terminal_4" },
+      approval: {
+        approvalId: "approval_terminal_4",
+        command: "deploy\nproduction",
+        patternKey: "terminal:deploy",
+        choices: ["once", "session", "deny"],
+        allowPermanent: true,
+      },
+    }));
+    await vi.waitFor(() => expect(session.snapshot.pendingApproval?.choices).toEqual(["deny"]));
+    expect(session.snapshot.pendingApproval?.patternKeys).toEqual([]);
+    session.execute("/approve once");
+    expect(lines).toContain("[approval] once is not allowed for this request. Choose: deny.");
+    session.execute("/approve deny");
+    await waitForMessageCount(received, "approval.respond", 4);
+    peer?.send(JSON.stringify({
+      type: "approval.responded",
+      requestId: "terminal_approval_4",
+      runId: "run_terminal",
+      approvalId: "approval_terminal_4",
+      choice: "deny",
+      resolved: 1,
+    }));
     await vi.waitFor(() => expect(session.snapshot.pendingApprovals).toEqual([]));
     session.execute("/interrupt");
     await waitForMessage(received, "response.cancel");
@@ -236,17 +288,22 @@ describe("TerminalGatewaySession", () => {
     let peer: WebSocket | undefined;
     server.on("connection", (socket) => {
       peer = socket;
-      socket.once("message", () => {
-        socket.send(
-          JSON.stringify({
-            type: "session.ready",
-            protocolVersion: HERMES_LIVE_PROTOCOL_VERSION,
-            sessionId: "audio_only",
-            model: "mock-live",
-            hermes: {},
-            realtime: { provider: "mock", model: "mock-live" },
-          }),
-        );
+      socket.on("message", (raw) => {
+        const message = JSON.parse(raw.toString("utf8")) as Record<string, unknown>;
+        if (message.type === "session.start") {
+          socket.send(
+            JSON.stringify({
+              type: "session.ready",
+              protocolVersion: HERMES_LIVE_PROTOCOL_VERSION,
+              sessionId: "audio_only",
+              model: "mock-live",
+              hermes: {},
+              realtime: { provider: "mock", model: "mock-live" },
+            }),
+          );
+        } else if (message.type === "session.close") {
+          socket.close(1000, "session closed");
+        }
       });
     });
 

--- a/test/web-demo.test.ts
+++ b/test/web-demo.test.ts
@@ -35,7 +35,19 @@ describe("web demo behavior", () => {
     expect(harness.client.stopRun).toHaveBeenCalledWith("demo user stopped Hermes task");
   });
 
-  it("limits opaque approvals to once or deny", async () => {
+  it("shows disconnect failures instead of leaving an unhandled rejection", async () => {
+    const harness = loadWebDemo();
+    await harness.api.connect();
+    harness.client.disconnectError = new Error("Verify the active Hermes task");
+
+    harness.elements.connect.click();
+    await vi.waitFor(() => expect(harness.elements.status.textContent).toBe("Error"));
+
+    expect(harness.elements.log.entries.at(-1)?.strong.textContent).toBe("error");
+    expect(harness.elements.log.entries.at(-1)?.pre.textContent).toBe("Verify the active Hermes task");
+  });
+
+  it("limits opaque approvals to deny", async () => {
     const harness = loadWebDemo();
     await harness.api.connect();
 
@@ -45,7 +57,7 @@ describe("web demo behavior", () => {
       event: { event: "approval.request", approval_id: "approval_1" },
     });
 
-    expect(harness.elements.log.buttonLabels.at(-1)).toEqual(["once", "deny"]);
+    expect(harness.elements.log.buttonLabels.at(-1)).toEqual(["deny"]);
   });
 
   it("requires an inspectable pattern before offering permanent approval", async () => {
@@ -56,6 +68,7 @@ describe("web demo behavior", () => {
       type: "approval.request",
       runId: "run_1",
       approval: {
+        approvalId: "approval_1",
         command: "npm publish",
         patternKey: "\u001b[31m\u202e",
         choices: ["once", "always", "deny"],
@@ -104,15 +117,42 @@ describe("web demo behavior", () => {
     expect(harness.client.respondToApproval).not.toHaveBeenCalled();
     expect(always?.textContent).toBe("confirm always");
     always?.click();
-    expect(harness.client.respondToApproval).toHaveBeenCalledWith("always", "run_1");
+    expect(harness.client.respondToApproval).toHaveBeenCalledWith("always", "run_1", { approvalId: "approval_1" });
 
     harness.api.handleMessage({
       type: "approval.responded",
+      requestId: "response_1",
       runId: "run_1",
+      approvalId: "approval_1",
       choice: "always",
       resolved: 1,
     });
     expect(second.every((button) => !button.disabled)).toBe(true);
+  });
+
+  it("keeps an approval actionable when sending the response fails", async () => {
+    const harness = loadWebDemo();
+    await harness.api.connect();
+    harness.client.respondToApproval.mockImplementationOnce(() => {
+      throw new Error("Gateway connection closed");
+    });
+
+    harness.api.handleMessage({
+      type: "approval.request",
+      runId: "run_1",
+      approval: {
+        approvalId: "approval_retry",
+        command: "npm test",
+        choices: ["once", "deny"],
+        allowPermanent: false,
+      },
+    });
+    const buttons = harness.elements.log.entries.at(-1)?.buttons ?? [];
+    buttons.find((button) => button.textContent === "once")?.click();
+
+    expect(harness.elements.status.textContent).toBe("Error");
+    expect(buttons.every((button) => !button.disabled)).toBe(true);
+    expect(harness.elements.log.entries.at(-1)?.pre.textContent).toBe("Gateway connection closed");
   });
 });
 
@@ -190,6 +230,7 @@ class FakeHermesLiveClient {
   connected = false;
   state = "idle";
   activeRunId = "";
+  disconnectError?: Error;
   stopRun = vi.fn();
   respondToApproval = vi.fn();
   sendText = vi.fn();
@@ -211,6 +252,7 @@ class FakeHermesLiveClient {
   }
 
   async disconnect(): Promise<void> {
+    if (this.disconnectError) throw this.disconnectError;
     this.connected = false;
     this.state = "closed";
   }

--- a/test/websocket-client-connection.test.ts
+++ b/test/websocket-client-connection.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+import type WebSocket from "ws";
+import {
+  MAX_CLIENT_BUFFERED_BYTES,
+  WebSocketClientConnection,
+} from "../src/adapters/inbound/http/websocket-client-connection.js";
+
+describe("WebSocketClientConnection", () => {
+  it("sends while the payload fits within the outbound buffer cap", () => {
+    const socket = fakeSocket({ bufferedAmount: MAX_CLIENT_BUFFERED_BYTES - 5 });
+    const connection = new WebSocketClientConnection(socket as unknown as WebSocket);
+
+    connection.sendText("hello");
+
+    expect(socket.send).toHaveBeenCalledOnce();
+    expect(socket.send).toHaveBeenCalledWith("hello");
+    expect(socket.terminate).not.toHaveBeenCalled();
+  });
+
+  it("terminates a slow client before queuing data beyond the outbound buffer cap", () => {
+    const socket = fakeSocket({ bufferedAmount: MAX_CLIENT_BUFFERED_BYTES - 4 });
+    const connection = new WebSocketClientConnection(socket as unknown as WebSocket);
+
+    connection.sendText("hello");
+
+    expect(socket.send).not.toHaveBeenCalled();
+    expect(socket.terminate).toHaveBeenCalledOnce();
+  });
+
+  it("measures UTF-8 bytes rather than JavaScript string length", () => {
+    const socket = fakeSocket({ bufferedAmount: MAX_CLIENT_BUFFERED_BYTES - 3 });
+    const connection = new WebSocketClientConnection(socket as unknown as WebSocket);
+
+    connection.sendText("🙂");
+
+    expect(socket.send).not.toHaveBeenCalled();
+    expect(socket.terminate).toHaveBeenCalledOnce();
+  });
+
+  it("terminates the socket if send races with a close", () => {
+    const socket = fakeSocket();
+    socket.send.mockImplementationOnce(() => {
+      throw new Error("WebSocket is not open");
+    });
+    const connection = new WebSocketClientConnection(socket as unknown as WebSocket);
+
+    expect(() => connection.sendText("hello")).not.toThrow();
+    expect(socket.terminate).toHaveBeenCalledOnce();
+  });
+
+  it("does not send or terminate a socket that is already closing", () => {
+    const socket = fakeSocket({ readyState: 2 });
+    const connection = new WebSocketClientConnection(socket as unknown as WebSocket);
+
+    connection.sendText("hello");
+
+    expect(socket.send).not.toHaveBeenCalled();
+    expect(socket.terminate).not.toHaveBeenCalled();
+  });
+});
+
+function fakeSocket({
+  bufferedAmount = 0,
+  readyState = 1,
+}: {
+  bufferedAmount?: number;
+  readyState?: number;
+} = {}) {
+  return {
+    OPEN: 1,
+    CONNECTING: 0,
+    bufferedAmount,
+    readyState,
+    send: vi.fn(),
+    terminate: vi.fn(),
+  };
+}


### PR DESCRIPTION
## What changed

- moves the live wire contract to protocol v2 with exact approval and stop lifecycle correlation
- bounds provider, Hermes, WebSocket, audio, transcript, tool, and client queues
- contains ambiguous run starts, approvals, stops, stream endings, and shutdown outcomes
- makes Dashboard, browser, demo, and terminal clients wait for confirmed cleanup
- documents Dashboard, terminal, and community UI integration as distinct first-class surfaces

## Why

v0.3.0 adds richer clients and long-lived sessions. The gateway therefore needs explicit limits, idempotency, correlation, and fail-closed cleanup so retries, disconnects, provider races, and malformed upstream data cannot repeat side effects or mislead users about active Hermes work.

## User impact

- Dashboard/browser users get safer approvals, truthful stop states, interruption, and confirmed disconnect behavior.
- Terminal users retain persistent text control for SSH/headless operation.
- Community UIs get a documented dependency-free browser client and secure relay pattern.
- Protocol v1 clients must upgrade to protocol v2; the endpoint remains `/v1/live`.

## Validation

- `npm run verify`
- 294 tests across 20 files
- Dashboard asset parity and plugin proxy smoke
- Hermes plugin, browser client, terminal, gateway, provider CLI, and package-install smokes
- `npm audit --audit-level=low` (0 vulnerabilities)
- deterministic Docker and real-provider verification will be repeated from exact protected `main` before tagging v0.3.0
