### PR TITLE
fix: close final v0.3 browser and publish gates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
-          cache: npm
+          package-manager-cache: false
       - name: Verify tag matches package version
         run: |
           package_version="$(node -p 'require("./package.json").version')"
@@ -50,9 +50,29 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org
-          cache: npm
+          package-manager-cache: false
+      - name: Install trusted-publishing npm CLI
+        run: npm install --global npm@11.18.0
+      - name: Verify trusted-publishing runtime
+        run: |
+          npm_version="$(npm --version)"
+          test "$(node -p 'process.versions.node.split(".")[0]')" = "24"
+          test "$npm_version" = "11.18.0"
+          node -e '
+            const actual = process.argv[1].split(".").map(Number);
+            const minimum = [11, 5, 1];
+            let comparison = 0;
+            for (let index = 0; index < minimum.length; index += 1) {
+              if (actual[index] === minimum[index]) continue;
+              comparison = actual[index] > minimum[index] ? 1 : -1;
+              break;
+            }
+            if (comparison < 0) {
+              throw new Error("npm " + process.argv[1] + " is older than the trusted-publishing minimum 11.5.1");
+            }
+          ' "$npm_version"
       - name: Verify tag matches package version
         run: |
           package_version="$(node -p 'require("./package.json").version')"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Add an authenticated same-origin Dashboard HTTP/WebSocket proxy that delegates to Hermes' own Dashboard authentication and origin checks while keeping the upstream gateway URL and bearer out of browser code.
 - Publish a dependency-free `hermes-live-voice/browser` client and microphone worklet with strict protocol/lifecycle validation, bounded input and playback queues, request IDs, state subscriptions, and host-provided authenticated WebSocket URLs.
 - Normalize client close frames to browser-legal codes and bounded UTF-8 reasons, recover from missing close events, suppress late audio after interruption until the next response begins, and replace stale connected notices when a gateway connection drops.
+- Reserve browser playback capacity before awaiting autoplay permission, time-bound suspended-context resume, expose a user-gesture `primePlayback()` API, and make audio disposal independent of a stalled playback chain.
+- Clear stale demo approvals on fatal disconnects and run npm trusted publishing on an explicitly verified Node 24/npm 11 OIDC runtime.
 - Move the negotiated wire contract to protocol v2, a breaking client handshake that removes raw provider envelopes, adds `run.stopping`, and requires exact approval identity and choice correlation while retaining `/v1/live` as the endpoint path.
 - Enable Gemini Live input/output audio transcription, preserve speaker/final metadata, avoid duplicate transcript events, and emit a normalized response-start lifecycle before assistant output.
 - Preserve concurrent approvals in a capacity-bounded FIFO across the browser client, Dashboard, demo, persistent terminal, and one-shot CLI; only the queue head is actionable and only the exact confirmed entry is removed.

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ HERMES_LIVE_AUTH_TOKEN=your-gateway-token \
 node dist/cli.js terminal
 ```
 
-The console keeps one realtime session open, shows provider transcripts and Hermes task progress, surfaces approvals, and provides separate `/interrupt` (stop the provider response) and `/stop` (stop Hermes work) controls. Use `/help` for the full command list. It intentionally does not capture or play audio; use the Hermes Dashboard or browser UI for remote gateway audio.
+The console keeps one realtime session open, shows provider transcripts and Hermes task progress, surfaces approvals, and provides separate `/interrupt` (request provider-response cancellation) and `/stop` (stop Hermes work) controls. Provider cancellation is best effort; Gemini accepts the request without a dedicated upstream cancellation acknowledgement. Use `/help` for the full command list. It intentionally does not capture or play audio; use the Hermes Dashboard or browser UI for remote gateway audio.
 
 For scripts and CI, the existing one-shot command remains available:
 
@@ -359,11 +359,12 @@ client.on("approval.request", showApproval);
 client.on("run.completed", ({ output }) => showResult(output));
 client.on("audio.output", (message) => void audio.play(message).catch(showError));
 client.on("input.speech_started", () => audio.interrupt("provider detected user speech"));
+await audio.primePlayback(); // Invoke synchronously from a click or tap handler.
 await client.connect();
 await audio.startMicrophone();
 ```
 
-The gateway serves the canonical worklet at `/mic-worklet.js`; package consumers can also resolve the `hermes-live-voice/browser/mic-worklet.js` export into their own static assets. The client validates lifecycle messages, returns request IDs, bounds microphone and playback buffering, and exposes `subscribe()`/`getSnapshot()` for React or other state-driven UIs.
+The gateway serves the canonical worklet at `/mic-worklet.js`; package consumers can also resolve the `hermes-live-voice/browser/mic-worklet.js` export into their own static assets. Call `primePlayback()` directly from a user gesture before other asynchronous work so browser autoplay policy can unlock the output context. The client validates lifecycle messages, returns request IDs, reserves playback capacity before awaiting that context, bounds microphone and playback buffering, and exposes `subscribe()`/`getSnapshot()` for React or other state-driven UIs.
 
 `webSocketUrlProvider` lets a host return a same-origin authenticated proxy URL or a host-issued short-lived ticket. The Hermes Live gateway does not mint per-user tickets itself. Do not embed an installation-wide `HERMES_LIVE_AUTH_TOKEN` in a public web app; the Dashboard integration keeps it server-side through its authenticated plugin proxy.
 

--- a/apps/web-demo/app.js
+++ b/apps/web-demo/app.js
@@ -14,6 +14,7 @@ const logEl = document.querySelector("#log");
 
 let client;
 let audio;
+let connectPending = false;
 const approvalQueue = [];
 
 setInteractive(false);
@@ -24,7 +25,7 @@ connectButton.addEventListener("click", () => {
     void client.disconnect().catch(showError);
     return;
   }
-  if (client?.state === "connecting") return;
+  if (connectPending || client?.state === "connecting") return;
   void connect().catch(showError);
 });
 
@@ -33,6 +34,7 @@ form.addEventListener("submit", (event) => {
   const text = textInput.value.trim();
   if (!text) return;
   try {
+    void audio.primePlayback().catch(showError);
     audio.interrupt("new text input");
     client.sendText(text);
     addLog("you", text);
@@ -63,18 +65,27 @@ stopButton.addEventListener("click", () => {
 });
 
 async function connect() {
-  await disposeSession();
-  client = new HermesLiveClient({
+  connectPending = true;
+  const disposing = disposeSession();
+  const nextClient = new HermesLiveClient({
     url: gatewayInput.value,
     token: tokenInput.value,
     profileId: "demo",
     userLabel: "web-demo",
   });
-  audio = new HermesLiveAudio(client, { workletUrl: "/mic-worklet.js" });
-  bindSession(client, audio);
+  const nextAudio = new HermesLiveAudio(nextClient, { workletUrl: "/mic-worklet.js" });
+  client = nextClient;
+  audio = nextAudio;
+  bindSession(nextClient, nextAudio);
   connectButton.textContent = "Disconnect";
   setInteractive(false);
-  await client.connect();
+  void nextAudio.primePlayback().catch(showError);
+  try {
+    await disposing;
+    await nextClient.connect();
+  } finally {
+    connectPending = false;
+  }
 }
 
 function bindSession(nextClient, nextAudio) {
@@ -96,6 +107,7 @@ function bindSession(nextClient, nextAudio) {
   });
   nextClient.on("close", () => {
     if (nextClient !== client) return;
+    resetApprovalQueue();
     setStatus("Disconnected");
     setInteractive(false);
     connectButton.textContent = "Connect";
@@ -140,7 +152,10 @@ function handleMessage(message) {
   } else if (message.type === "run.failed" || message.type === "session.error") {
     setStatus(message.type === "run.failed" ? "Run failed" : "Error");
     audio.clearPlayback();
-    if (message.type === "session.error" && !message.recoverable) setInteractive(false);
+    if (message.type === "session.error" && !message.recoverable) {
+      resetApprovalQueue();
+      setInteractive(false);
+    }
     addLog("error", JSON.stringify(message, null, 2));
   } else if (message.type === "run.stopping") {
     addLog("run", `stop requested for ${message.runId}: ${message.status}`);
@@ -167,6 +182,7 @@ async function toggleMicrophone() {
   if (audio.microphoneActive) {
     await audio.stopMicrophone();
   } else {
+    await audio.primePlayback();
     await audio.startMicrophone();
   }
 }

--- a/clients/browser/hermes-live-client.d.ts
+++ b/clients/browser/hermes-live-client.d.ts
@@ -164,6 +164,8 @@ export interface HermesLiveAudioOptions {
   workletUrl?: string;
   sampleRate?: number;
   maxQueuedAudioMs?: number;
+  maxQueuedAudioFrames?: number;
+  playbackResumeTimeoutMs?: number;
   mediaDevices?: Pick<MediaDevices, "getUserMedia">;
   audioContextFactory?: (options: AudioContextOptions) => AudioContext;
   audioWorkletNodeFactory?: (
@@ -186,6 +188,7 @@ export class HermesLiveAudio {
   readonly microphoneActive: boolean;
   readonly microphoneState: "idle" | "starting" | "active" | "stopping" | "disposed";
   on<K extends keyof HermesLiveAudioEventMap>(type: K, listener: (event: HermesLiveAudioEventMap[K]) => void): () => void;
+  primePlayback(): Promise<void>;
   startMicrophone(): Promise<void>;
   stopMicrophone(options?: { endTurn?: boolean }): Promise<void>;
   play(message: Extract<HermesLiveServerMessage, { type: "audio.output" }>): Promise<boolean>;

--- a/clients/browser/hermes-live-client.js
+++ b/clients/browser/hermes-live-client.js
@@ -3,7 +3,11 @@ const DEFAULT_DISCONNECT_TIMEOUT_MS = 12_000;
 const DEFAULT_MAX_BUFFERED_AMOUNT_BYTES = 1_000_000;
 const DEFAULT_MAX_INBOUND_MESSAGE_BYTES = 8_000_000;
 const DEFAULT_MAX_QUEUED_AUDIO_MS = 5_000;
+const DEFAULT_MAX_QUEUED_AUDIO_FRAMES = 256;
+const DEFAULT_PLAYBACK_RESUME_TIMEOUT_MS = 2_000;
 const DEFAULT_SAMPLE_RATE = 24_000;
+const MIN_PCM_SAMPLE_RATE = 8_000;
+const MAX_PCM_SAMPLE_RATE = 192_000;
 const MAX_PENDING_APPROVALS = 128;
 const OPEN = 1;
 export const HERMES_LIVE_PROTOCOL_VERSION = 2;
@@ -594,6 +598,14 @@ export class HermesLiveAudio {
     this.workletUrl = options.workletUrl ?? "/mic-worklet.js";
     this.sampleRate = positiveInteger(options.sampleRate, DEFAULT_SAMPLE_RATE);
     this.maxQueuedAudioMs = positiveInteger(options.maxQueuedAudioMs, DEFAULT_MAX_QUEUED_AUDIO_MS);
+    this.maxQueuedAudioFrames = positiveInteger(
+      options.maxQueuedAudioFrames,
+      DEFAULT_MAX_QUEUED_AUDIO_FRAMES,
+    );
+    this.playbackResumeTimeoutMs = positiveInteger(
+      options.playbackResumeTimeoutMs,
+      DEFAULT_PLAYBACK_RESUME_TIMEOUT_MS,
+    );
     this.mediaDevices = options.mediaDevices ?? globalThis.navigator?.mediaDevices;
     this.audioContextFactory = options.audioContextFactory ?? ((config) => new AudioContext(config));
     this.audioWorkletNodeFactory = options.audioWorkletNodeFactory ??
@@ -614,8 +626,14 @@ export class HermesLiveAudio {
     this.playbackSources = new Set();
     this.playbackItems = new Map();
     this.playbackChain = Promise.resolve();
+    this.pendingPlaybackMs = 0;
+    this.pendingPlaybackFrames = 0;
     this.playbackGeneration = 0;
+    this.playbackEpoch = createPlaybackEpoch();
     this.playbackSuppressed = false;
+    this.playbackResumeContext = undefined;
+    this.playbackResumePromise = undefined;
+    this.cancelPlaybackResume = undefined;
     this.unsubscribeClose = client.on?.("close", () => void this.dispose());
     this.unsubscribeResponseStarted = client.on?.("response.started", () => {
       this.playbackSuppressed = false;
@@ -630,6 +648,15 @@ export class HermesLiveAudio {
 
   get microphoneActive() {
     return this.microphoneState === "active";
+  }
+
+  async primePlayback() {
+    if (this.disposed) throw new Error("Hermes Live audio has been disposed.");
+    const context = this.ensurePlaybackContext();
+    if (context.state !== "running") await this.resumePlaybackContext(context);
+    if (context.state !== "running") {
+      throw new Error("Browser audio playback is unavailable. Allow audio, then try again from a user gesture.");
+    }
   }
 
   async startMicrophone() {
@@ -762,51 +789,92 @@ export class HermesLiveAudio {
   }
 
   play(message) {
-    if (this.playbackSuppressed) return Promise.resolve(false);
-    const generation = this.playbackGeneration;
-    const operation = this.playbackChain.then(() => this.schedulePlayback(message, generation));
-    this.playbackChain = operation.catch(() => undefined);
-    return operation;
-  }
-
-  async schedulePlayback(message, generation) {
-    if (this.disposed || this.playbackSuppressed || generation !== this.playbackGeneration) return false;
-    if (message?.type !== "audio.output") {
-      throw new TypeError("HermesLiveAudio.play expects an audio.output message.");
+    if (this.disposed || this.playbackSuppressed) return Promise.resolve(false);
+    let frame;
+    try {
+      frame = preparePlaybackFrame(message, this.decodeBase64);
+    } catch (error) {
+      return Promise.reject(error);
     }
-    const rate = parsePcmRate(message.mimeType);
-    const samples = decodePcm16(message.data, this.decodeBase64);
-    const durationMs = (samples.length / rate) * 1_000;
 
-    if (!this.playbackContext || this.playbackContext.state === "closed") {
-      this.playbackContext = this.audioContextFactory({});
-      this.playbackCursor = 0;
-    }
-    if (this.playbackContext.state === "suspended") await this.playbackContext.resume();
-    if (this.disposed || this.playbackSuppressed || generation !== this.playbackGeneration) return false;
-
-    const context = this.playbackContext;
-    const queuedMs = this.calculateQueuedPlaybackMs(context.currentTime);
-    if (queuedMs + durationMs > this.maxQueuedAudioMs) {
+    const scheduledMs = this.playbackContext && this.playbackContext.state !== "closed"
+      ? this.calculateQueuedPlaybackMs(this.playbackContext.currentTime)
+      : 0;
+    const queuedMs = scheduledMs + this.pendingPlaybackMs;
+    const queuedFrames = this.playbackSources.size + this.pendingPlaybackFrames;
+    if (
+      queuedFrames >= this.maxQueuedAudioFrames ||
+      queuedMs + frame.durationMs > this.maxQueuedAudioMs
+    ) {
       this.emitter.emit("audio.dropped", {
         direction: "output",
         reason: "playback_backpressure",
         queuedMs,
-        droppedMs: durationMs,
+        droppedMs: frame.durationMs,
+      });
+      return Promise.resolve(false);
+    }
+
+    const generation = this.playbackGeneration;
+    const epoch = this.playbackEpoch;
+    this.pendingPlaybackMs += frame.durationMs;
+    this.pendingPlaybackFrames += 1;
+    const operation = this.playbackChain.then(async () => {
+      try {
+        return await this.schedulePlayback(frame, generation, epoch);
+      } finally {
+        this.pendingPlaybackMs = Math.max(0, this.pendingPlaybackMs - frame.durationMs);
+        this.pendingPlaybackFrames = Math.max(0, this.pendingPlaybackFrames - 1);
+      }
+    });
+    this.playbackChain = operation.catch(() => undefined);
+    return operation;
+  }
+
+  async schedulePlayback(frame, generation, epoch) {
+    if (
+      this.disposed ||
+      this.playbackSuppressed ||
+      generation !== this.playbackGeneration ||
+      epoch !== this.playbackEpoch
+    ) return false;
+
+    const context = this.ensurePlaybackContext();
+    if (context.state !== "running") {
+      const resumed = await Promise.race([
+        this.resumePlaybackContext(context).then(() => true),
+        epoch.invalidated.then(() => false),
+      ]);
+      if (!resumed) return false;
+    }
+    if (
+      this.disposed ||
+      this.playbackSuppressed ||
+      generation !== this.playbackGeneration ||
+      epoch !== this.playbackEpoch
+    ) return false;
+
+    const queuedMs = this.calculateQueuedPlaybackMs(context.currentTime);
+    if (queuedMs + frame.durationMs > this.maxQueuedAudioMs) {
+      this.emitter.emit("audio.dropped", {
+        direction: "output",
+        reason: "playback_backpressure",
+        queuedMs,
+        droppedMs: frame.durationMs,
       });
       return false;
     }
 
-    const buffer = context.createBuffer(1, samples.length, rate);
-    buffer.copyToChannel(samples, 0);
+    const buffer = context.createBuffer(1, frame.samples.length, frame.rate);
+    buffer.copyToChannel(frame.samples, 0);
     const source = context.createBufferSource();
     source.buffer = buffer;
     source.connect(context.destination);
     const startAt = Math.max(context.currentTime + 0.02, this.playbackCursor || 0);
-    const contentIndex = Number.isInteger(message.contentIndex) ? message.contentIndex : 0;
-    const itemKey = message.itemId ? `${message.itemId}:${contentIndex}` : "";
+    const contentIndex = frame.contentIndex;
+    const itemKey = frame.itemId ? `${frame.itemId}:${contentIndex}` : "";
     if (itemKey && !this.playbackItems.has(itemKey)) {
-      this.playbackItems.set(itemKey, { itemId: message.itemId, contentIndex, playedMs: 0 });
+      this.playbackItems.set(itemKey, { itemId: frame.itemId, contentIndex, playedMs: 0 });
       trimOldestMapEntries(this.playbackItems, 32);
     }
     const record = {
@@ -849,6 +917,8 @@ export class HermesLiveAudio {
   }
 
   clearPlayback() {
+    this.playbackEpoch.invalidate();
+    this.playbackEpoch = createPlaybackEpoch();
     ++this.playbackGeneration;
     const records = [...this.playbackSources].sort((left, right) => left.startAt - right.startAt);
     const now = this.playbackContext?.currentTime ?? 0;
@@ -894,11 +964,70 @@ export class HermesLiveAudio {
     if (item) item.playedMs += Math.max(0, playedMs);
   }
 
+  ensurePlaybackContext() {
+    if (!this.playbackContext || this.playbackContext.state === "closed") {
+      this.playbackContext = this.audioContextFactory({});
+      this.playbackCursor = 0;
+    }
+    return this.playbackContext;
+  }
+
+  resumePlaybackContext(context) {
+    if (context.state === "running") return Promise.resolve();
+    if (context.state === "closed") {
+      return Promise.reject(new Error("Browser audio playback context is closed."));
+    }
+    if (this.playbackResumeContext === context && this.playbackResumePromise) {
+      return this.playbackResumePromise;
+    }
+
+    let cancel;
+    const operation = new Promise((resolve, reject) => {
+      let settled = false;
+      const finish = (error) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        if (error) reject(error);
+        else resolve();
+      };
+      const timeout = setTimeout(
+        () => finish(new Error(
+          "Browser audio playback did not start in time. Allow audio, then retry from a user gesture.",
+        )),
+        this.playbackResumeTimeoutMs,
+      );
+      cancel = () => finish(abortError());
+      try {
+        Promise.resolve(context.resume()).then(() => finish(), (error) => finish(toError(error)));
+      } catch (error) {
+        finish(toError(error));
+      }
+    }).finally(() => {
+      if (this.playbackResumePromise === operation) {
+        this.playbackResumeContext = undefined;
+        this.playbackResumePromise = undefined;
+        this.cancelPlaybackResume = undefined;
+      }
+    });
+    this.playbackResumeContext = context;
+    this.playbackResumePromise = operation;
+    this.cancelPlaybackResume = cancel;
+    return operation;
+  }
+
   async closePlaybackContext() {
     this.clearPlayback();
+    this.cancelPlaybackResume?.();
     const context = this.playbackContext;
     this.playbackContext = undefined;
-    if (context && context.state !== "closed") await context.close();
+    if (context && context.state !== "closed") {
+      await playbackDeadline(
+        Promise.resolve().then(() => context.close()),
+        this.playbackResumeTimeoutMs,
+        "Browser audio playback context did not close in time.",
+      ).catch(() => undefined);
+    }
   }
 
   assertCaptureGeneration(generation) {
@@ -916,7 +1045,6 @@ export class HermesLiveAudio {
     this.disposed = true;
     await this.stopMicrophone({ endTurn: false });
     this.clearPlayback();
-    await this.playbackChain.catch(() => undefined);
     await this.closePlaybackContext();
     this.unsubscribeClose?.();
     this.unsubscribeResponseStarted?.();
@@ -1222,8 +1350,14 @@ function parsePcmRate(mimeType) {
   if (normalized.split(";")[0]?.trim().toLowerCase() !== "audio/pcm") {
     throw new Error(`Hermes Live browser audio supports PCM16 output, not ${normalized || "an unknown format"}.`);
   }
-  const match = /(?:^|;)\s*rate=(\d+)(?:;|$)/i.exec(normalized);
-  return positiveInteger(match?.[1], DEFAULT_SAMPLE_RATE);
+  const matches = [...normalized.matchAll(/(?:^|;)\s*rate=(\d+)(?=;|$)/gi)];
+  const rate = matches.length === 1 ? Number(matches[0]?.[1]) : Number.NaN;
+  if (!Number.isInteger(rate) || rate < MIN_PCM_SAMPLE_RATE || rate > MAX_PCM_SAMPLE_RATE) {
+    throw new Error(
+      `Hermes Live PCM16 output requires exactly one rate between ${MIN_PCM_SAMPLE_RATE} and ${MAX_PCM_SAMPLE_RATE} Hz.`,
+    );
+  }
+  return rate;
 }
 
 function isPcmMimeType(mimeType) {
@@ -1240,6 +1374,48 @@ function decodePcm16(data, decodeBase64) {
     samples[index] = view.getInt16(index * 2, true) / 32768;
   }
   return samples;
+}
+
+function preparePlaybackFrame(message, decodeBase64) {
+  if (message?.type !== "audio.output" || typeof message.data !== "string") {
+    throw new TypeError("HermesLiveAudio.play expects an audio.output message.");
+  }
+  const rate = parsePcmRate(message.mimeType);
+  const samples = decodePcm16(message.data, decodeBase64);
+  if (samples.length === 0) throw new Error("Hermes Live returned an empty PCM16 audio frame.");
+  return {
+    rate,
+    samples,
+    durationMs: (samples.length / rate) * 1_000,
+    itemId: typeof message.itemId === "string" ? message.itemId : "",
+    contentIndex: Number.isInteger(message.contentIndex) ? message.contentIndex : 0,
+  };
+}
+
+function createPlaybackEpoch() {
+  let invalidate;
+  const invalidated = new Promise((resolve) => {
+    invalidate = resolve;
+  });
+  return { invalidated, invalidate };
+}
+
+function playbackDeadline(promise, timeoutMs, message) {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const finish = (error, value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      if (error) reject(error);
+      else resolve(value);
+    };
+    const timeout = setTimeout(() => finish(new Error(message)), timeoutMs);
+    Promise.resolve(promise).then(
+      (value) => finish(undefined, value),
+      (error) => finish(toError(error)),
+    );
+  });
 }
 
 async function cleanupCapture({ stream, context, source, node }) {

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -33,7 +33,7 @@ The release workflow reruns verification, audits dependencies, packs the npm tar
 
 ## npm publication
 
-The workflow contains an optional npm trusted-publishing job. It runs only when the repository variable `PUBLISH_NPM` is set to `true` and the npm package has a trusted publisher configured for this GitHub repository and workflow.
+The workflow contains an optional npm trusted-publishing job. It runs only when the repository variable `PUBLISH_NPM` is set to `true` and the npm package has a trusted publisher configured for this GitHub repository and workflow. That job deliberately uses Node 24, installs the pinned npm 11 CLI, and asserts npm's current minimum OIDC runtime before publishing.
 
 Before enabling it:
 

--- a/docs/ui-integration.md
+++ b/docs/ui-integration.md
@@ -82,6 +82,7 @@ client.on("approval.request", renderApproval);
 client.on("audio.output", (message) => void audio.play(message).catch(renderError));
 client.on("input.speech_started", () => audio.interrupt("provider detected user speech"));
 
+await audio.primePlayback(); // Run directly inside the initiating click or tap handler.
 await client.connect();
 ```
 
@@ -140,9 +141,9 @@ client.respondToApproval(choice, request.runId, {
 
 - Microphone capture requires `localhost` or another secure context.
 - Copy `hermes-live-voice/browser/mic-worklet.js` into a same-origin static asset path.
-- Start `AudioContext` and microphone capture from a user gesture.
+- Call `audio.primePlayback()` synchronously from a click or tap before awaiting network work; start microphone capture from a user gesture as well.
 - Respect `session.ready.realtime.audio`; mock mode and some future providers may disable input or output.
-- Bound queued playback and clear it immediately on interruption or disconnect.
+- Bound queued playback before waiting for autoplay permission and clear it immediately on interruption or disconnect.
 - Await `client.disconnect()`. A clean resolution means the gateway confirmed session cleanup; rejection or `session_shutdown_unconfirmed` means the user must verify any active task in Hermes.
 - Test keyboard focus, screen-reader labels, reduced motion, narrow layouts, and permission denial.
 

--- a/plugins/hermes-live/dashboard/dist/hermes-live-client.js
+++ b/plugins/hermes-live/dashboard/dist/hermes-live-client.js
@@ -3,7 +3,11 @@ const DEFAULT_DISCONNECT_TIMEOUT_MS = 12_000;
 const DEFAULT_MAX_BUFFERED_AMOUNT_BYTES = 1_000_000;
 const DEFAULT_MAX_INBOUND_MESSAGE_BYTES = 8_000_000;
 const DEFAULT_MAX_QUEUED_AUDIO_MS = 5_000;
+const DEFAULT_MAX_QUEUED_AUDIO_FRAMES = 256;
+const DEFAULT_PLAYBACK_RESUME_TIMEOUT_MS = 2_000;
 const DEFAULT_SAMPLE_RATE = 24_000;
+const MIN_PCM_SAMPLE_RATE = 8_000;
+const MAX_PCM_SAMPLE_RATE = 192_000;
 const MAX_PENDING_APPROVALS = 128;
 const OPEN = 1;
 export const HERMES_LIVE_PROTOCOL_VERSION = 2;
@@ -594,6 +598,14 @@ export class HermesLiveAudio {
     this.workletUrl = options.workletUrl ?? "/mic-worklet.js";
     this.sampleRate = positiveInteger(options.sampleRate, DEFAULT_SAMPLE_RATE);
     this.maxQueuedAudioMs = positiveInteger(options.maxQueuedAudioMs, DEFAULT_MAX_QUEUED_AUDIO_MS);
+    this.maxQueuedAudioFrames = positiveInteger(
+      options.maxQueuedAudioFrames,
+      DEFAULT_MAX_QUEUED_AUDIO_FRAMES,
+    );
+    this.playbackResumeTimeoutMs = positiveInteger(
+      options.playbackResumeTimeoutMs,
+      DEFAULT_PLAYBACK_RESUME_TIMEOUT_MS,
+    );
     this.mediaDevices = options.mediaDevices ?? globalThis.navigator?.mediaDevices;
     this.audioContextFactory = options.audioContextFactory ?? ((config) => new AudioContext(config));
     this.audioWorkletNodeFactory = options.audioWorkletNodeFactory ??
@@ -614,8 +626,14 @@ export class HermesLiveAudio {
     this.playbackSources = new Set();
     this.playbackItems = new Map();
     this.playbackChain = Promise.resolve();
+    this.pendingPlaybackMs = 0;
+    this.pendingPlaybackFrames = 0;
     this.playbackGeneration = 0;
+    this.playbackEpoch = createPlaybackEpoch();
     this.playbackSuppressed = false;
+    this.playbackResumeContext = undefined;
+    this.playbackResumePromise = undefined;
+    this.cancelPlaybackResume = undefined;
     this.unsubscribeClose = client.on?.("close", () => void this.dispose());
     this.unsubscribeResponseStarted = client.on?.("response.started", () => {
       this.playbackSuppressed = false;
@@ -630,6 +648,15 @@ export class HermesLiveAudio {
 
   get microphoneActive() {
     return this.microphoneState === "active";
+  }
+
+  async primePlayback() {
+    if (this.disposed) throw new Error("Hermes Live audio has been disposed.");
+    const context = this.ensurePlaybackContext();
+    if (context.state !== "running") await this.resumePlaybackContext(context);
+    if (context.state !== "running") {
+      throw new Error("Browser audio playback is unavailable. Allow audio, then try again from a user gesture.");
+    }
   }
 
   async startMicrophone() {
@@ -762,51 +789,92 @@ export class HermesLiveAudio {
   }
 
   play(message) {
-    if (this.playbackSuppressed) return Promise.resolve(false);
-    const generation = this.playbackGeneration;
-    const operation = this.playbackChain.then(() => this.schedulePlayback(message, generation));
-    this.playbackChain = operation.catch(() => undefined);
-    return operation;
-  }
-
-  async schedulePlayback(message, generation) {
-    if (this.disposed || this.playbackSuppressed || generation !== this.playbackGeneration) return false;
-    if (message?.type !== "audio.output") {
-      throw new TypeError("HermesLiveAudio.play expects an audio.output message.");
+    if (this.disposed || this.playbackSuppressed) return Promise.resolve(false);
+    let frame;
+    try {
+      frame = preparePlaybackFrame(message, this.decodeBase64);
+    } catch (error) {
+      return Promise.reject(error);
     }
-    const rate = parsePcmRate(message.mimeType);
-    const samples = decodePcm16(message.data, this.decodeBase64);
-    const durationMs = (samples.length / rate) * 1_000;
 
-    if (!this.playbackContext || this.playbackContext.state === "closed") {
-      this.playbackContext = this.audioContextFactory({});
-      this.playbackCursor = 0;
-    }
-    if (this.playbackContext.state === "suspended") await this.playbackContext.resume();
-    if (this.disposed || this.playbackSuppressed || generation !== this.playbackGeneration) return false;
-
-    const context = this.playbackContext;
-    const queuedMs = this.calculateQueuedPlaybackMs(context.currentTime);
-    if (queuedMs + durationMs > this.maxQueuedAudioMs) {
+    const scheduledMs = this.playbackContext && this.playbackContext.state !== "closed"
+      ? this.calculateQueuedPlaybackMs(this.playbackContext.currentTime)
+      : 0;
+    const queuedMs = scheduledMs + this.pendingPlaybackMs;
+    const queuedFrames = this.playbackSources.size + this.pendingPlaybackFrames;
+    if (
+      queuedFrames >= this.maxQueuedAudioFrames ||
+      queuedMs + frame.durationMs > this.maxQueuedAudioMs
+    ) {
       this.emitter.emit("audio.dropped", {
         direction: "output",
         reason: "playback_backpressure",
         queuedMs,
-        droppedMs: durationMs,
+        droppedMs: frame.durationMs,
+      });
+      return Promise.resolve(false);
+    }
+
+    const generation = this.playbackGeneration;
+    const epoch = this.playbackEpoch;
+    this.pendingPlaybackMs += frame.durationMs;
+    this.pendingPlaybackFrames += 1;
+    const operation = this.playbackChain.then(async () => {
+      try {
+        return await this.schedulePlayback(frame, generation, epoch);
+      } finally {
+        this.pendingPlaybackMs = Math.max(0, this.pendingPlaybackMs - frame.durationMs);
+        this.pendingPlaybackFrames = Math.max(0, this.pendingPlaybackFrames - 1);
+      }
+    });
+    this.playbackChain = operation.catch(() => undefined);
+    return operation;
+  }
+
+  async schedulePlayback(frame, generation, epoch) {
+    if (
+      this.disposed ||
+      this.playbackSuppressed ||
+      generation !== this.playbackGeneration ||
+      epoch !== this.playbackEpoch
+    ) return false;
+
+    const context = this.ensurePlaybackContext();
+    if (context.state !== "running") {
+      const resumed = await Promise.race([
+        this.resumePlaybackContext(context).then(() => true),
+        epoch.invalidated.then(() => false),
+      ]);
+      if (!resumed) return false;
+    }
+    if (
+      this.disposed ||
+      this.playbackSuppressed ||
+      generation !== this.playbackGeneration ||
+      epoch !== this.playbackEpoch
+    ) return false;
+
+    const queuedMs = this.calculateQueuedPlaybackMs(context.currentTime);
+    if (queuedMs + frame.durationMs > this.maxQueuedAudioMs) {
+      this.emitter.emit("audio.dropped", {
+        direction: "output",
+        reason: "playback_backpressure",
+        queuedMs,
+        droppedMs: frame.durationMs,
       });
       return false;
     }
 
-    const buffer = context.createBuffer(1, samples.length, rate);
-    buffer.copyToChannel(samples, 0);
+    const buffer = context.createBuffer(1, frame.samples.length, frame.rate);
+    buffer.copyToChannel(frame.samples, 0);
     const source = context.createBufferSource();
     source.buffer = buffer;
     source.connect(context.destination);
     const startAt = Math.max(context.currentTime + 0.02, this.playbackCursor || 0);
-    const contentIndex = Number.isInteger(message.contentIndex) ? message.contentIndex : 0;
-    const itemKey = message.itemId ? `${message.itemId}:${contentIndex}` : "";
+    const contentIndex = frame.contentIndex;
+    const itemKey = frame.itemId ? `${frame.itemId}:${contentIndex}` : "";
     if (itemKey && !this.playbackItems.has(itemKey)) {
-      this.playbackItems.set(itemKey, { itemId: message.itemId, contentIndex, playedMs: 0 });
+      this.playbackItems.set(itemKey, { itemId: frame.itemId, contentIndex, playedMs: 0 });
       trimOldestMapEntries(this.playbackItems, 32);
     }
     const record = {
@@ -849,6 +917,8 @@ export class HermesLiveAudio {
   }
 
   clearPlayback() {
+    this.playbackEpoch.invalidate();
+    this.playbackEpoch = createPlaybackEpoch();
     ++this.playbackGeneration;
     const records = [...this.playbackSources].sort((left, right) => left.startAt - right.startAt);
     const now = this.playbackContext?.currentTime ?? 0;
@@ -894,11 +964,70 @@ export class HermesLiveAudio {
     if (item) item.playedMs += Math.max(0, playedMs);
   }
 
+  ensurePlaybackContext() {
+    if (!this.playbackContext || this.playbackContext.state === "closed") {
+      this.playbackContext = this.audioContextFactory({});
+      this.playbackCursor = 0;
+    }
+    return this.playbackContext;
+  }
+
+  resumePlaybackContext(context) {
+    if (context.state === "running") return Promise.resolve();
+    if (context.state === "closed") {
+      return Promise.reject(new Error("Browser audio playback context is closed."));
+    }
+    if (this.playbackResumeContext === context && this.playbackResumePromise) {
+      return this.playbackResumePromise;
+    }
+
+    let cancel;
+    const operation = new Promise((resolve, reject) => {
+      let settled = false;
+      const finish = (error) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        if (error) reject(error);
+        else resolve();
+      };
+      const timeout = setTimeout(
+        () => finish(new Error(
+          "Browser audio playback did not start in time. Allow audio, then retry from a user gesture.",
+        )),
+        this.playbackResumeTimeoutMs,
+      );
+      cancel = () => finish(abortError());
+      try {
+        Promise.resolve(context.resume()).then(() => finish(), (error) => finish(toError(error)));
+      } catch (error) {
+        finish(toError(error));
+      }
+    }).finally(() => {
+      if (this.playbackResumePromise === operation) {
+        this.playbackResumeContext = undefined;
+        this.playbackResumePromise = undefined;
+        this.cancelPlaybackResume = undefined;
+      }
+    });
+    this.playbackResumeContext = context;
+    this.playbackResumePromise = operation;
+    this.cancelPlaybackResume = cancel;
+    return operation;
+  }
+
   async closePlaybackContext() {
     this.clearPlayback();
+    this.cancelPlaybackResume?.();
     const context = this.playbackContext;
     this.playbackContext = undefined;
-    if (context && context.state !== "closed") await context.close();
+    if (context && context.state !== "closed") {
+      await playbackDeadline(
+        Promise.resolve().then(() => context.close()),
+        this.playbackResumeTimeoutMs,
+        "Browser audio playback context did not close in time.",
+      ).catch(() => undefined);
+    }
   }
 
   assertCaptureGeneration(generation) {
@@ -916,7 +1045,6 @@ export class HermesLiveAudio {
     this.disposed = true;
     await this.stopMicrophone({ endTurn: false });
     this.clearPlayback();
-    await this.playbackChain.catch(() => undefined);
     await this.closePlaybackContext();
     this.unsubscribeClose?.();
     this.unsubscribeResponseStarted?.();
@@ -1222,8 +1350,14 @@ function parsePcmRate(mimeType) {
   if (normalized.split(";")[0]?.trim().toLowerCase() !== "audio/pcm") {
     throw new Error(`Hermes Live browser audio supports PCM16 output, not ${normalized || "an unknown format"}.`);
   }
-  const match = /(?:^|;)\s*rate=(\d+)(?:;|$)/i.exec(normalized);
-  return positiveInteger(match?.[1], DEFAULT_SAMPLE_RATE);
+  const matches = [...normalized.matchAll(/(?:^|;)\s*rate=(\d+)(?=;|$)/gi)];
+  const rate = matches.length === 1 ? Number(matches[0]?.[1]) : Number.NaN;
+  if (!Number.isInteger(rate) || rate < MIN_PCM_SAMPLE_RATE || rate > MAX_PCM_SAMPLE_RATE) {
+    throw new Error(
+      `Hermes Live PCM16 output requires exactly one rate between ${MIN_PCM_SAMPLE_RATE} and ${MAX_PCM_SAMPLE_RATE} Hz.`,
+    );
+  }
+  return rate;
 }
 
 function isPcmMimeType(mimeType) {
@@ -1240,6 +1374,48 @@ function decodePcm16(data, decodeBase64) {
     samples[index] = view.getInt16(index * 2, true) / 32768;
   }
   return samples;
+}
+
+function preparePlaybackFrame(message, decodeBase64) {
+  if (message?.type !== "audio.output" || typeof message.data !== "string") {
+    throw new TypeError("HermesLiveAudio.play expects an audio.output message.");
+  }
+  const rate = parsePcmRate(message.mimeType);
+  const samples = decodePcm16(message.data, decodeBase64);
+  if (samples.length === 0) throw new Error("Hermes Live returned an empty PCM16 audio frame.");
+  return {
+    rate,
+    samples,
+    durationMs: (samples.length / rate) * 1_000,
+    itemId: typeof message.itemId === "string" ? message.itemId : "",
+    contentIndex: Number.isInteger(message.contentIndex) ? message.contentIndex : 0,
+  };
+}
+
+function createPlaybackEpoch() {
+  let invalidate;
+  const invalidated = new Promise((resolve) => {
+    invalidate = resolve;
+  });
+  return { invalidated, invalidate };
+}
+
+function playbackDeadline(promise, timeoutMs, message) {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const finish = (error, value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      if (error) reject(error);
+      else resolve(value);
+    };
+    const timeout = setTimeout(() => finish(new Error(message)), timeoutMs);
+    Promise.resolve(promise).then(
+      (value) => finish(undefined, value),
+      (error) => finish(toError(error)),
+    );
+  });
 }
 
 async function cleanupCapture({ stream, context, source, node }) {

--- a/plugins/hermes-live/dashboard/dist/index.js
+++ b/plugins/hermes-live/dashboard/dist/index.js
@@ -496,9 +496,23 @@
         .finally(function () { setBusyAction(""); });
     }
 
+    function primePlaybackFromGesture() {
+      const createAudio = ensureAudioRef.current;
+      if (!createAudio) return null;
+      const audio = createAudio();
+      void audio.primePlayback().catch(function (error) {
+        setNotice({
+          tone: "warning",
+          text: friendlyError(error, "Browser audio is blocked. Allow playback, then try again."),
+        });
+      });
+      return audio;
+    }
+
     function connect() {
       const client = clientRef.current;
       if (!client) return;
+      primePlaybackFromGesture();
       runAction("connect", function () {
         return client.connect().then(function () {
           if (ensureAudioRef.current) ensureAudioRef.current();
@@ -533,9 +547,9 @@
     }
 
     function startMicrophone() {
-      const createAudio = ensureAudioRef.current;
-      if (!createAudio) return;
-      runAction("microphone", function () { return createAudio().startMicrophone(); });
+      const audio = primePlaybackFromGesture();
+      if (!audio) return;
+      runAction("microphone", function () { return audio.startMicrophone(); });
     }
 
     function stopMicrophone() {
@@ -574,7 +588,7 @@
       const client = clientRef.current;
       if (!text || !client) return;
       try {
-        const audio = audioRef.current;
+        const audio = primePlaybackFromGesture() || audioRef.current;
         if (audio) audio.interrupt("new Dashboard text input");
         else client.cancelResponse("new Dashboard text input");
         client.sendText(text);

--- a/test/browser-client.test.ts
+++ b/test/browser-client.test.ts
@@ -427,6 +427,75 @@ describe("HermesLiveAudio", () => {
     await audio.dispose();
   });
 
+  it("bounds pending playback before a suspended context resumes and disposes without waiting", async () => {
+    const context = new FakeAudioContext({});
+    context.state = "suspended";
+    context.resume = vi.fn(async () => await new Promise<void>(() => undefined));
+    const dropped = vi.fn();
+    const audio = createAudio({
+      audioContextFactory: () => context as unknown as AudioContext,
+      maxQueuedAudioMs: 3,
+      playbackResumeTimeoutMs: 10_000,
+    });
+    audio.on("audio.dropped", dropped);
+    const frame = pcmFrame(new Array(48).fill(0)); // 2ms at 24kHz.
+
+    const first = audio.play({ type: "audio.output", data: frame, mimeType: "audio/pcm;rate=24000" });
+    const second = audio.play({ type: "audio.output", data: frame, mimeType: "audio/pcm;rate=24000" });
+
+    await expect(second).resolves.toBe(false);
+    expect(context.resume).toHaveBeenCalledOnce();
+    expect(dropped).toHaveBeenCalledWith(expect.objectContaining({
+      reason: "playback_backpressure",
+      queuedMs: 2,
+      droppedMs: 2,
+    }));
+    await expect(audio.dispose()).resolves.toBeUndefined();
+    await expect(first).resolves.toBe(false);
+    expect(context.close).toHaveBeenCalledOnce();
+  });
+
+  it("bounds queued frame count even when frames have negligible duration", async () => {
+    const context = new FakeAudioContext({});
+    context.state = "suspended";
+    context.resume = vi.fn(async () => await new Promise<void>(() => undefined));
+    const dropped = vi.fn();
+    const audio = createAudio({
+      audioContextFactory: () => context as unknown as AudioContext,
+      maxQueuedAudioFrames: 2,
+      playbackResumeTimeoutMs: 10_000,
+    });
+    audio.on("audio.dropped", dropped);
+    const message = {
+      type: "audio.output" as const,
+      data: pcmFrame([0]),
+      mimeType: "audio/pcm;rate=192000",
+    };
+
+    const first = audio.play(message);
+    const second = audio.play(message);
+    await expect(audio.play(message)).resolves.toBe(false);
+    expect(dropped).toHaveBeenCalledWith(expect.objectContaining({ reason: "playback_backpressure" }));
+
+    await audio.dispose();
+    await expect(Promise.all([first, second])).resolves.toEqual([false, false]);
+  });
+
+  it("primes browser playback synchronously from a user gesture and bounds a stalled resume", async () => {
+    const context = new FakeAudioContext({});
+    context.state = "suspended";
+    context.resume = vi.fn(async () => await new Promise<void>(() => undefined));
+    const audio = createAudio({
+      audioContextFactory: () => context as unknown as AudioContext,
+      playbackResumeTimeoutMs: 20,
+    });
+
+    const priming = audio.primePlayback();
+    expect(context.resume).toHaveBeenCalledOnce();
+    await expect(priming).rejects.toThrow(/did not start in time/);
+    await audio.dispose();
+  });
+
   it("suppresses late audio after interruption until the next response starts", async () => {
     const client = audioClient();
     const audio = createAudio({ client });
@@ -486,6 +555,29 @@ describe("HermesLiveAudio", () => {
     await expect(
       audio.play({ type: "audio.output", data: "AA==", mimeType: "audio/pcmu;rate=8000" }),
     ).rejects.toThrow(/supports PCM16 output/);
+    await audio.dispose();
+  });
+
+  it.each([
+    "audio/pcm",
+    "audio/pcm;rate=7999",
+    "audio/pcm;rate=192001",
+    "audio/pcm;rate=24000;rate=16000",
+  ])("rejects unsafe or ambiguous PCM output rate metadata: %s", async (mimeType) => {
+    const audio = createAudio();
+
+    await expect(
+      audio.play({ type: "audio.output", data: "AAA=", mimeType }),
+    ).rejects.toThrow(/requires exactly one rate between 8000 and 192000/);
+    await audio.dispose();
+  });
+
+  it("rejects empty PCM output instead of admitting zero-duration queue entries", async () => {
+    const audio = createAudio();
+
+    await expect(
+      audio.play({ type: "audio.output", data: "", mimeType: "audio/pcm;rate=24000" }),
+    ).rejects.toThrow(/empty PCM16 audio frame/);
     await audio.dispose();
   });
 

--- a/test/dashboard-plugin.test.ts
+++ b/test/dashboard-plugin.test.ts
@@ -65,6 +65,8 @@ describe("Hermes Dashboard plugin", () => {
     expect(source).toContain('audio.interrupt("provider detected user speech")');
     expect(source).toContain('audio.interrupt("new Dashboard text input")');
     expect(source).toContain("audio.clearPlayback()");
+    expect(source).toContain("audio.primePlayback()");
+    expect(source).toContain("primePlaybackFromGesture();");
   });
 
   it("keeps queued approvals read-only and permanent approval pattern-bound", () => {

--- a/test/web-demo.test.ts
+++ b/test/web-demo.test.ts
@@ -7,6 +7,8 @@ describe("web demo behavior", () => {
     const harness = loadWebDemo();
     await harness.api.connect();
 
+    expect(harness.audio.primePlayback).toHaveBeenCalledOnce();
+
     harness.api.handleMessage({ type: "input.speech_started", provider: "openai", audioStartMs: 320 });
 
     expect(harness.audio.interrupt).toHaveBeenCalledWith("provider detected user speech");
@@ -154,6 +156,59 @@ describe("web demo behavior", () => {
     expect(buttons.every((button) => !button.disabled)).toBe(true);
     expect(harness.elements.log.entries.at(-1)?.pre.textContent).toBe("Gateway connection closed");
   });
+
+  it("invalidates queued approvals when the socket closes", async () => {
+    const harness = loadWebDemo();
+    await harness.api.connect();
+
+    harness.api.handleMessage({
+      type: "approval.request",
+      runId: "run_close",
+      approval: {
+        approvalId: "approval_close",
+        command: "npm test",
+        choices: ["once", "deny"],
+        allowPermanent: false,
+      },
+    });
+    const buttons = harness.elements.log.entries.at(-1)?.buttons ?? [];
+
+    harness.client.emit("close");
+    buttons.find((button) => button.textContent === "once")?.click();
+
+    expect(harness.elements.status.textContent).toBe("Disconnected");
+    expect(buttons.every((button) => button.disabled)).toBe(true);
+    expect(harness.client.respondToApproval).not.toHaveBeenCalled();
+  });
+
+  it("invalidates queued approvals after a fatal session error", async () => {
+    const harness = loadWebDemo();
+    await harness.api.connect();
+
+    harness.api.handleMessage({
+      type: "approval.request",
+      runId: "run_fatal",
+      approval: {
+        approvalId: "approval_fatal",
+        command: "npm publish",
+        choices: ["once", "deny"],
+        allowPermanent: false,
+      },
+    });
+    const buttons = harness.elements.log.entries.at(-1)?.buttons ?? [];
+
+    harness.api.handleMessage({
+      type: "session.error",
+      code: "session_shutdown_unconfirmed",
+      error: "Session shutdown could not be confirmed.",
+      recoverable: false,
+    });
+    buttons.find((button) => button.textContent === "once")?.click();
+
+    expect(harness.elements.status.textContent).toBe("Error");
+    expect(buttons.every((button) => button.disabled)).toBe(true);
+    expect(harness.client.respondToApproval).not.toHaveBeenCalled();
+  });
 });
 
 function loadWebDemo(): {
@@ -246,6 +301,10 @@ class FakeHermesLiveClient {
     return () => listeners.delete(listener);
   }
 
+  emit(type: string, event: unknown = {}): void {
+    for (const listener of this.listeners.get(type) ?? []) listener(event);
+  }
+
   async connect(): Promise<void> {
     this.connected = true;
     this.state = "ready";
@@ -262,6 +321,7 @@ class FakeHermesLiveAudio {
   static instances: FakeHermesLiveAudio[] = [];
   readonly listeners = new Map<string, Set<(event: any) => void>>();
   microphoneActive = false;
+  primePlayback = vi.fn(async () => undefined);
   interrupt = vi.fn();
   play = vi.fn(async () => true);
   clearPlayback = vi.fn();


### PR DESCRIPTION
## What changed

- reserve browser audio duration and frame capacity before a suspended `AudioContext` can stall playback
- time-bound playback resume, reject unsafe PCM rates and empty frames, and let disposal cancel a stuck chain
- expose `primePlayback()` and call it directly from Dashboard/demo user gestures
- clear stale demo approval controls after fatal errors and disconnects
- describe terminal response cancellation as best effort
- run optional npm trusted publishing on Node 24 with pinned npm 11.18.0 and explicit OIDC runtime assertions

## Root cause

The existing playback limit was checked only after the serialized playback chain reached `AudioContext.resume()`. Browser autoplay policy can leave that promise pending, so later full audio messages could remain retained before the limit was evaluated and disposal could wait indefinitely. Separately, npm trusted publishing now requires Node 22.14+ and npm 11.5.1+, while the optional job still selected Node 20.

## User impact

Browser playback now remains bounded even before autoplay permission is granted, cleanup completes when resume never does, and Dashboard/demo gestures proactively unlock output. The future npm publication path now meets npm's current trusted-publisher requirements without adding a long-lived token.

## Validation

- `npm run verify`
- 304 tests across 20 files
- Dashboard asset parity and Dashboard/plugin/package smokes
- `npm audit --audit-level=low` (0 vulnerabilities)
- `actionlint`
- Node 24.18.0 container with npm 11.18.0 install and version assertions
