### PR TITLE
chore(ci): update artifact actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       - run: mkdir -p release
       - run: npm pack --pack-destination release
       - run: sha256sum release/*.tgz > release/SHA256SUMS
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-package
           path: release/
@@ -54,7 +54,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-package
           path: release
@@ -79,7 +79,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-package
           path: release


### PR DESCRIPTION
## Summary

- update `actions/upload-artifact` from v4.6.2 to SHA-pinned v7.0.1
- update both `actions/download-artifact` uses from v4.3.0 to SHA-pinned v8.0.1
- remove the Node 20 action-runtime deprecation warning observed in the v0.3.1 release
- gain download-artifact v8 digest mismatch failure by default

## Verification

- actionlint v1.7.12 — clean
- exact release-tag commits verified through the GitHub API
- v0.3.1 release completed successfully before this maintenance change