### PR TITLE
fix(release): make checksum manifest portable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,8 @@ jobs:
       - run: npm audit --audit-level=moderate
       - run: mkdir -p release
       - run: npm pack --pack-destination release
-      - run: sha256sum release/*.tgz > release/SHA256SUMS
+      - run: sha256sum -- *.tgz > SHA256SUMS
+        working-directory: release
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-package
@@ -58,12 +59,14 @@ jobs:
         with:
           name: release-package
           path: release
-      - name: Verify packaged version and checksum
+      - name: Verify packaged checksum
+        run: sha256sum --check SHA256SUMS
+        working-directory: release
+      - name: Verify packaged version
         run: |
           package_file="$(find release -maxdepth 1 -type f -name '*.tgz' -print -quit)"
           test -n "$package_file"
           test "$(find release -maxdepth 1 -type f -name '*.tgz' | wc -l)" -eq 1
-          sha256sum --check release/SHA256SUMS
           package_version="$(tar -xOf "$package_file" package/package.json | node -e 'let data=""; process.stdin.on("data", (chunk) => data += chunk).on("end", () => process.stdout.write(JSON.parse(data).version))')"
           test "$GITHUB_REF_NAME" = "v$package_version"
       - run: gh release create "$GITHUB_REF_NAME" release/*.tgz release/SHA256SUMS --title "$GITHUB_REF_NAME" --generate-notes --verify-tag
@@ -108,12 +111,14 @@ jobs:
               throw new Error("npm " + process.argv[1] + " is older than the trusted-publishing minimum 11.5.1");
             }
           ' "$npm_version"
+      - name: Verify packaged checksum
+        run: sha256sum --check SHA256SUMS
+        working-directory: release
       - name: Verify tag matches package version
         run: |
           package_file="$(find release -maxdepth 1 -type f -name '*.tgz' -print -quit)"
           test -n "$package_file"
           test "$(find release -maxdepth 1 -type f -name '*.tgz' | wc -l)" -eq 1
-          sha256sum --check release/SHA256SUMS
           package_version="$(tar -xOf "$package_file" package/package.json | node -e 'let data=""; process.stdin.on("data", (chunk) => data += chunk).on("end", () => process.stdout.write(JSON.parse(data).version))')"
           test "$GITHUB_REF_NAME" = "v$package_version"
       - run: npm publish ./release/*.tgz --access public --provenance

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -29,7 +29,7 @@ git tag -a vX.Y.Z -m "vX.Y.Z"
 git push origin vX.Y.Z
 ```
 
-The release workflow reruns verification, audits dependencies, packs the npm tarball, and records its SHA-256 checksum in a read-only job. A separate job with `contents: write` downloads only those artifacts and creates the GitHub release; it never checks out or executes repository/dependency code with the write credential.
+The release workflow reruns verification, audits dependencies, packs the npm tarball, and records its SHA-256 checksum in a read-only job. The checksum manifest stores only the tarball basename so users can download both release assets into one directory and verify them directly with `sha256sum --check SHA256SUMS` (or `shasum -a 256 -c SHA256SUMS` on macOS). A separate job with `contents: write` downloads only those artifacts and creates the GitHub release; it never checks out or executes repository/dependency code with the write credential.
 
 ## npm publication
 
@@ -49,6 +49,6 @@ Do not add a long-lived npm token when trusted publishing is available.
 
 - Install the exact released package or tarball into a clean temporary directory.
 - Run `hermes-live --help`, `hermes-live plugin status`, and the mock quick start.
-- Verify the GitHub release asset and release notes.
+- Download the GitHub release tarball and `SHA256SUMS` into one directory, verify the checksum, and inspect the release notes.
 - Verify the npm package and provenance when npm publishing is enabled.
 - Update README install instructions only after the npm registry readback succeeds.


### PR DESCRIPTION
## Summary

- generate `SHA256SUMS` from inside the release directory so it records the tarball basename rather than a workflow-local `release/` path
- verify checksums from the same directory in both GitHub release and optional npm publish jobs
- document the exact Linux and macOS verification commands

## Why

The v0.3.1 digest is correct, but its original manifest recorded `release/hermes-live-voice-0.3.1.tgz`. After downloading the two public assets into one folder, the standard checksum command therefore looked for a nonexistent nested directory.

## Verification

- `npm run verify` — 21 test files and 354 tests passed; all docs/plugin/CLI/gateway/package smokes passed
- every workflow passes `actionlint` 1.7.7 and shellcheck validation
- corrected v0.3.1 manifest passes `shasum -a 256 -c SHA256SUMS` on macOS
- corrected v0.3.1 manifest passes GNU `sha256sum --check SHA256SUMS` in `node:22-slim`
- release tarball digest remains `0451b13a60b0daebb65f3ca6d0c177663f859bf6efce99cad0c301bd1d437a82`
