### PR TITLE
docs: streamline README onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <p align="center">
   The open-source realtime voice layer for <a href="https://github.com/NousResearch/hermes-agent">Hermes Agent</a>.<br>
   Gemini Live or OpenAI Realtime handles natural conversation and interruption;<br>
-  Hermes keeps the memory, tools, skills, approvals, and work.
+  Hermes keeps the memory, tools, skills, and work.
 </p>
 
 <p align="center">
@@ -25,10 +25,6 @@
 </p>
 
 <p align="center">
-  <img src="assets/dashboard-live-voice.jpg" alt="Hermes Live Voice running inside Hermes Dashboard" width="100%">
-</p>
-
-<p align="center">
   <a href="https://github.com/bielcarpi/hermes-live-voice/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/bielcarpi/hermes-live-voice/actions/workflows/ci.yml/badge.svg"></a>
   <a href="https://github.com/bielcarpi/hermes-live-voice/releases"><img alt="Release" src="https://img.shields.io/github/v/release/bielcarpi/hermes-live-voice?display_name=tag"></a>
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-16a34a"></a>
@@ -36,48 +32,30 @@
   <img alt="Status: developer preview" src="https://img.shields.io/badge/status-developer%20preview-f59e0b">
 </p>
 
+<p align="center">
+  <img src="assets/dashboard-live-voice.jpg" alt="Hermes Live Voice running inside Hermes Dashboard in deterministic mock mode" width="100%">
+  <br>
+  <sub>Hermes Dashboard integration shown in safe mock mode; Gemini and OpenAI modes support microphone input and audio playback.</sub>
+</p>
+
 ## Give Your Hermes Agent A Realtime Voice
 
 Hermes Live Voice is a Hermes plugin, a self-hosted voice gateway, and a small client protocol. It turns an existing Hermes Agent into the action-taking brain behind an interruptible speech-to-speech conversation.
 
-Ask it to inspect a repository, use memory, research something current, or run a command. The realtime model handles the speech loop; Hermes performs the tool-using work, while clients keep progress and stop controls visible. Targeted approval controls appear only when the connected Hermes version can correlate each decision safely.
-
-```txt
-You speak
-   ↓
-Gemini Live or OpenAI Realtime
-   ↓  delegates meaningful work
-Hermes Live Voice gateway
-   ↓
-Hermes Agent — memory, tools, skills, MCP, approvals
-   ↓
-The result returns to the live conversation
-```
-
-In v0.3, delegation to Hermes is synchronous from the realtime provider's perspective: conversation is fluid before and after the delegated run, but the speech model waits for that run's terminal result. The Dashboard and other clients still receive live task events and stop controls during the wait, plus targeted approvals when Hermes advertises stable approval IDs. Continuous provider-side conversation while Hermes works is a roadmap item, not a current claim.
-
-The realtime provider receives three narrow gateway tools—not unrestricted access to the Hermes toolbelt. Provider credentials, Hermes credentials, Hermes session keys, and approval decisions remain outside the provider.
+Ask it to inspect a repository, use memory, research something current, or run a command. The realtime model handles the speech loop; Hermes performs the tool-using work, while clients keep progress and stop controls visible.
 
 ### What you get
 
-- **Natural realtime conversation** — persistent speech sessions instead of record, transcribe, wait, and synthesize loops.
-- **Barge-in and cancellation** — interrupt provider speech and stop an active Hermes run.
-- **The Hermes you already configured** — keep its memory, terminal access, skills, MCP servers, approval policy, and model setup.
-- **Two live providers** — Gemini Live and OpenAI Realtime, plus a deterministic mock provider for local development.
-- **A client-ready gateway** — connect a browser, mobile app, desktop app, embedded device, or terminal client over WebSocket.
-- **Fail-closed approval compatibility** — enable human decisions only when Hermes advertises stable approval IDs; otherwise deny where possible, stop the run, and close the session instead of guessing.
-- **A first-class Hermes Dashboard integration** — install a **Live Voice** tab with transcript, task progress, interruption, run stop, and negotiated approval status.
-- **A real Hermes plugin** — install `hermes-live`, check gateway status from Hermes, and keep voice integration discoverable.
+- **Natural realtime speech** with persistent sessions, interruption, and separate controls for provider playback and Hermes work.
+- **The Hermes you already configured** with its memory, terminal access, skills, MCP servers, and model setup.
+- **A first-class Dashboard experience** with microphone and playback, transcripts, task progress, stop controls, and negotiated safety status.
+- **Browser, custom UI, and terminal surfaces** backed by one authenticated JSON/WebSocket gateway.
+- **Gemini Live and OpenAI Realtime**, plus a deterministic mock provider for setup and CI.
+- **A narrow security boundary**: the realtime model gets only three gateway tools—not Hermes credentials, session keys, or approval authority. Provider credentials stay server-side and out of client and tool payloads.
 
-> **Approval compatibility:** Hermes Agent's current Runs API, verified against the official v0.18.2 image and upstream `main` for this release, does not yet identify approval requests strongly enough to target concurrent decisions safely. Hermes Live Voice therefore attempts a deny-all, stops that run, and closes the voice session with an explicit verification warning. It never lets an uncorrelated approval run continue. Interactive controls enable automatically only when Hermes advertises `features.run_approval_response_by_id: true` and echoes the same approval identity in its response.
+Try a request that makes the agent do real work: *“Inspect this repository, run the tests, and tell me whether it is safe to release.”*
 
-## See The Difference
-
-The useful demo is not a chatbot greeting. It is a live request that makes Hermes work:
-
-> “Inspect this repository, run the tests, and tell me whether it is safe to release.”
-
-A good client can acknowledge immediately, let the user interrupt, show Hermes run progress, cancel when asked, and speak the final result. With a targeted-approval-capable Hermes release, it can also surface and correlate explicit human decisions.
+> **Approval safety:** Hermes Agent v0.18.2, tested for this release, does not expose stable approval IDs. Hermes Live Voice never guesses: it attempts denial, stops the run, and closes the voice session. Interactive decisions enable only after Hermes negotiates targeted approval identity. See the [security model](docs/security.md).
 
 ## Why Not Just Use Hermes Voice Mode?
 
@@ -95,19 +73,17 @@ Use Hermes Live Voice when the product itself needs a persistent realtime conver
 | Agent actions | Hermes | Hermes, through three gateway tools |
 | Deployment shape | Local Hermes feature | Separate self-hosted gateway and optional Hermes plugin |
 
-This project does not replace Hermes Voice Mode. It serves the integration layer that Voice Mode is not designed to be.
-
 ## Choose How You Use It
 
 | Surface | Best for | Audio |
 | --- | --- | --- |
-| **Hermes Dashboard + Live Voice plugin — recommended** | Daily use with transcript, task progress, interruption, stop, and negotiated approval status | Browser microphone and playback |
+| **Hermes Dashboard + Live Voice — recommended** | Daily use with transcript, progress, interruption, stop, and negotiated safety status | Browser microphone and playback |
 | **Bundled browser demo** | Local development and gateway troubleshooting | Browser microphone and playback |
 | **`hermes-live-voice/browser`** | Community web UIs and custom React, Vue, Svelte, vanilla, or Electron clients | Host-integrated microphone and playback |
 | **`hermes-live terminal`** | SSH, headless systems, automation, and remote text control | Text only |
 | **Hermes Ctrl+B Voice Mode** | The fastest local terminal voice experience | Hermes-managed voice |
 
-Generic chat UI compatibility is not the same as Hermes Live compatibility. A community UI needs the browser client or JSON/WebSocket protocol, microphone and playback controls, and a secure server-side authentication bridge. OpenAI-compatible chat support alone does not provide persistent realtime audio, barge-in, run events, or the negotiated approval lifecycle. See [UI integration](docs/ui-integration.md) for the exact contract.
+An OpenAI-compatible chat endpoint alone does not provide this realtime audio and run-event contract. Community UIs should follow the [UI integration guide](docs/ui-integration.md).
 
 ## Quick Start
 
@@ -130,20 +106,14 @@ npm run build
 
 ### 2. Install the Hermes plugin
 
-Current Hermes releases can install and enable the plugin directly from this repository:
+Install the plugin from the tagged checkout you just built:
 
 ```sh
-hermes plugins install bielcarpi/hermes-live-voice/plugins/hermes-live --enable
-```
-
-If you already cloned and built the gateway, the package installer provides the same plugin locally:
-
-```sh
-node dist/cli.js plugin install
+node dist/cli.js plugin install --force
 hermes plugins enable hermes-live
 ```
 
-The repository/package name is `hermes-live-voice`. The short CLI command and Hermes plugin id are `hermes-live`.
+`--force` replaces an older installed copy so the gateway and plugin stay on the same release. The repository/package name is `hermes-live-voice`; the short CLI command and plugin id are `hermes-live`. See [plugin installation](docs/plugin.md#install-in-hermes) for the one-line latest-source option and symlinked development installs.
 
 ### 3. Start safely in mock mode
 
@@ -187,19 +157,19 @@ HERMES_AGENT_API_SERVER_KEY=your-hermes-api-server-key \
 npm run dev
 ```
 
-Before calling a real-provider deployment ready, open an actual provider session:
+Before calling a real-provider deployment ready, repeat the provider selection and credential in a second shell for an actual connect/close smoke test:
 
 ```sh
-npm run check:live-provider
+HERMES_LIVE_PROVIDER=gemini GEMINI_API_KEY=your-gemini-key npm run check:live-provider
+# or
+HERMES_LIVE_PROVIDER=openai OPENAI_API_KEY=your-openai-key npm run check:live-provider
 ```
 
-Then complete the audio, interruption, approval, and negative-case checklist in [docs/live-provider-testing.md](docs/live-provider-testing.md).
+Then complete the audio and negative-case checklist in [live provider testing](docs/live-provider-testing.md).
 
 ## Use It From A Terminal
 
-Hermes already has the right local microphone experience: run `hermes` and press **Ctrl+B** for official Hermes Voice Mode. Hermes Live Voice does not duplicate that audio stack or add native microphone dependencies.
-
-For a remote gateway, automation host, or headless machine, open the persistent text-control console:
+For local terminal microphone use, run `hermes` and press **Ctrl+B**. For a remote gateway, automation host, or headless machine, use the persistent text-control console:
 
 ```sh
 HERMES_LIVE_URL=https://voice.example.com \
@@ -207,13 +177,7 @@ HERMES_LIVE_AUTH_TOKEN=your-gateway-token \
 node dist/cli.js terminal
 ```
 
-The console keeps one realtime session open, shows provider transcripts, Hermes task progress, and negotiated approval warnings or requests, and provides separate `/interrupt` (request provider-response cancellation) and `/stop` (stop Hermes work) controls. Provider cancellation is best effort; Gemini accepts the request without a dedicated upstream cancellation acknowledgement. Use `/help` for the full command list. It intentionally does not capture or play audio; use the Hermes Dashboard or browser UI for remote gateway audio.
-
-For scripts and CI, the existing one-shot command remains available:
-
-```sh
-node dist/cli.js client "What is the current status?"
-```
+The console shows transcripts and Hermes progress, with separate `/interrupt` and `/stop` controls. It is intentionally text-only; use the Dashboard or browser client for gateway audio. Scripts can use `node dist/cli.js client "What is the current status?"`. See [UI integration](docs/ui-integration.md#terminal).
 
 ## Supported Providers
 
@@ -225,14 +189,6 @@ node dist/cli.js client "What is the current status?"
 
 Model ids are configuration, not hardcoded provider forks. Override `GEMINI_MODEL` or `OPENAI_REALTIME_MODEL` when validating a compatible model.
 
-### About future `gpt-live-1` support
-
-`gpt-live-1` is not currently listed in OpenAI's public API documentation or model catalog. It cannot be selected or truthfully advertised as supported today.
-
-The project is designed to adopt new OpenAI live models without changing the Hermes boundary. If `gpt-live-1` becomes a public Realtime-compatible API model, the plan is to add captured event fixtures, tool-call coverage, interruption tests, and a real provider handshake before listing it as supported. See the [compatibility roadmap](docs/roadmap.md#provider-roadmap).
-
-Current OpenAI model guidance is tracked against the official [Realtime and audio documentation](https://developers.openai.com/api/docs/guides/realtime), not rumors or private product labels.
-
 ## How It Works
 
 ```mermaid
@@ -240,7 +196,7 @@ flowchart LR
   C["Voice client<br/>browser · mobile · desktop · device"]
   G["Hermes Live Voice<br/>auth · sessions · audio · policy"]
   R["Realtime provider<br/>Gemini Live or OpenAI Realtime"]
-  H["Hermes Agent<br/>memory · tools · skills · MCP · approvals"]
+  H["Hermes Agent<br/>memory · tools · skills · MCP"]
 
   C <-->|"JSON + PCM16 over WebSocket"| G
   G <-->|"persistent realtime session"| R
@@ -256,121 +212,43 @@ The provider can ask the gateway to:
 - `get_hermes_run_status`
 - `stop_hermes_run`
 
-It cannot call arbitrary Hermes tools or submit approvals. When Hermes supports targeted approval responses, choices come only from a connected human client and are validated against the exact correlated envelope. A legacy uncorrelated request is never offered as a human choice: the gateway attempts denial, stops the run, and closes the voice session for operator verification.
+It cannot call arbitrary Hermes tools or submit approvals. Human choices come only from an authenticated client and must match the negotiated identity; legacy uncorrelated requests trigger the fail-closed containment described above.
+
+In v0.3 the realtime provider waits for a delegated Hermes run to finish, while clients continue receiving progress and stop controls. Continuous provider-side conversation during that work remains a [roadmap](docs/roadmap.md) item.
 
 Read the [architecture](docs/architecture.md) and [client protocol](docs/client-protocol.md) for the full lifecycle.
 
 ## Configuration
 
-Copy the example and change only what you need:
+The gateway reads the process environment. npm scripts do **not** load a local `.env` automatically, so export variables or pass them inline as shown in Quick Start. Docker Compose can consume one explicitly with `--env-file`.
+
+At minimum, set `HERMES_AGENT_API_SERVER_KEY` to Hermes Agent's `API_SERVER_KEY`, then select `mock` or provide the chosen realtime-provider credential. [.env.example](.env.example) is the complete reference; [local setup](docs/local-setup.md) explains every runtime path.
+
+A network-accessible bind requires a strong `HERMES_LIVE_AUTH_TOKEN` and should use an exact `HERMES_LIVE_ALLOW_ORIGIN`. This developer preview is not a turnkey public multi-user service; review the [deployment security model](docs/security.md) before exposing it beyond localhost.
+
+## Build A Custom UI
+
+Until npm publishing is enabled, install the exact GitHub release tarball:
 
 ```sh
-cp .env.example .env
+npm install https://github.com/bielcarpi/hermes-live-voice/releases/download/v0.3.1/hermes-live-voice-0.3.1.tgz
 ```
 
-### Hermes
-
-```sh
-HERMES_BASE_URL=http://127.0.0.1:8642
-HERMES_AGENT_API_SERVER_KEY=...
-```
-
-`HERMES_AGENT_API_SERVER_KEY` must equal Hermes Agent's `API_SERVER_KEY`. The older `HERMES_API_KEY` name remains a compatibility alias.
-
-### Public or LAN gateway
-
-```sh
-HERMES_LIVE_HOST=0.0.0.0
-HERMES_LIVE_AUTH_TOKEN=$(openssl rand -hex 32)
-HERMES_LIVE_ALLOW_ORIGIN=https://voice.example.com
-HERMES_LIVE_DEMO_ENABLED=false
-```
-
-The gateway refuses a network-accessible bind without a strong auth token unless you explicitly set the unsafe `HERMES_LIVE_ALLOW_UNAUTHENTICATED=true` opt-out.
-
-This release is intended for a self-hosted, trusted-user installation. A shared bearer token is not multi-tenant identity. Do not expose the gateway as a public multi-user SaaS without adding per-user authentication, quotas, rate limits, and an identity-to-Hermes-profile policy.
-
-### OpenAI
-
-```sh
-HERMES_LIVE_PROVIDER=openai
-OPENAI_API_KEY=...
-OPENAI_REALTIME_MODEL=gpt-realtime-2.1
-OPENAI_REALTIME_VOICE=marin
-OPENAI_REALTIME_REASONING_EFFORT=low
-OPENAI_REALTIME_TURN_DETECTION=disabled
-```
-
-Use `semantic_vad` or `server_vad` for provider-managed turn detection. `disabled` gives clients an explicit push-to-talk style `audio.end` boundary.
-
-### Gemini
-
-```sh
-HERMES_LIVE_PROVIDER=gemini
-GEMINI_API_KEY=...
-GEMINI_MODEL=gemini-3.1-flash-live-preview
-```
-
-Vertex/Enterprise users can set `GOOGLE_GENAI_USE_ENTERPRISE=true`, `GOOGLE_CLOUD_PROJECT`, and `GOOGLE_CLOUD_LOCATION`.
-
-The complete configuration is documented in [.env.example](.env.example) and [docs/local-setup.md](docs/local-setup.md).
-
-## Client Protocol
-
-Connect to:
-
-```txt
-ws://127.0.0.1:8788/v1/live
-```
-
-Start a session:
-
-```json
-{
-  "type": "session.start",
-  "protocolVersion": 2,
-  "profileId": "default",
-  "userLabel": "alice"
-}
-```
-
-Send text for a smoke test:
-
-```json
-{
-  "type": "text.input",
-  "text": "Inspect this repository and summarize what changed."
-}
-```
-
-Or stream base64 PCM16 audio frames and end the turn with `audio.end`. The server emits provider audio/transcripts, Hermes run events, completion, typed errors, and targeted approval envelopes only when the negotiated Hermes contract supports them.
-
-The package also exposes the dependency-free browser client used by both the Hermes Dashboard integration and the bundled demo:
+The dependency-free browser client is the same one used by the Hermes Dashboard integration and bundled demo:
 
 ```js
-import { HermesLiveAudio, HermesLiveClient } from "hermes-live-voice/browser";
+import { HermesLiveClient } from "hermes-live-voice/browser";
 
 const client = new HermesLiveClient({
-  webSocketUrlProvider: () => getAuthenticatedSameOriginWebSocketUrl(),
-});
-const audio = new HermesLiveAudio(client, {
-  workletUrl: "/mic-worklet.js",
+  webSocketUrlProvider: () => getAuthenticatedWebSocketUrl(),
 });
 
-client.on("approval.request", showApproval);
 client.on("run.completed", ({ output }) => showResult(output));
-client.on("audio.output", (message) => void audio.play(message).catch(showError));
-client.on("input.speech_started", () => audio.interrupt("provider detected user speech"));
-await audio.primePlayback(); // Invoke synchronously from a click or tap handler.
 await client.connect();
-await audio.startMicrophone();
+client.sendText("Inspect this repository and summarize what changed.");
 ```
 
-The gateway serves the canonical worklet at `/mic-worklet.js`; package consumers can also resolve the `hermes-live-voice/browser/mic-worklet.js` export into their own static assets. Call `primePlayback()` directly from a user gesture before other asynchronous work so browser autoplay policy can unlock the output context. The client validates lifecycle messages, returns request IDs, reserves playback capacity before awaiting that context, bounds microphone and playback buffering, and exposes `subscribe()`/`getSnapshot()` for React or other state-driven UIs.
-
-`webSocketUrlProvider` lets a host return a same-origin authenticated proxy URL or a host-issued short-lived ticket. The Hermes Live gateway does not mint per-user tickets itself. Do not embed an installation-wide `HERMES_LIVE_AUTH_TOKEN` in a public web app; the Dashboard integration keeps it server-side through its authenticated plugin proxy.
-
-See [UI integration](docs/ui-integration.md) and the [client protocol](docs/client-protocol.md) before building a client.
+The client also provides microphone capture, bounded playback, interruption, request IDs, lifecycle validation, and state subscriptions. A browser host must return a same-origin authenticated proxy URL or a short-lived ticket—never embed the installation-wide gateway token in public code. See [UI integration](docs/ui-integration.md) and the versioned [client protocol](docs/client-protocol.md).
 
 ## Commands
 
@@ -387,27 +265,13 @@ node dist/cli.js plugin status    # inspect the plugin installation
 npm run verify                    # complete local release gate
 ```
 
-Docker users can start from [examples/docker-compose.yml](examples/docker-compose.yml). The example binds the published port to host loopback by default and runs with a read-only filesystem, no Linux capabilities, `no-new-privileges`, a PID limit, and a bounded writable `/tmp`. Put an authenticated TLS proxy in front instead of widening the host bind directly.
+Docker users can start from [examples/docker-compose.yml](examples/docker-compose.yml). It binds to host loopback and runs read-only, capability-free, and non-root by default. Use an authenticated TLS proxy for remote access.
 
 ## Security And Maturity
 
-Hermes Live Voice is a **developer preview for self-hosted, trusted-client use**. The architecture keeps long-lived credentials server-side and fails closed on unsafe network binds, but it is not a turnkey public multi-tenant service.
+Hermes Live Voice is a **developer preview for self-hosted, trusted-client use**. Long-lived credentials stay server-side; network binds and ambiguous approvals fail closed. Before remote exposure, add TLS, a high-entropy auth token, an exact origin allowlist, edge rate and cost limits, and keep Hermes/provider endpoints private. Review [the security model](docs/security.md) and [vulnerability reporting policy](SECURITY.md).
 
-Before exposing it beyond localhost:
-
-- terminate TLS in front of the gateway;
-- require a high-entropy `HERMES_LIVE_AUTH_TOKEN`;
-- restrict `HERMES_LIVE_ALLOW_ORIGIN` to the exact client origin;
-- disable the bundled demo unless it is intentionally public;
-- keep Hermes and provider endpoints private;
-- add edge rate limits and cost controls;
-- review [docs/security.md](docs/security.md) and [SECURITY.md](SECURITY.md).
-
-Never paste secrets into an issue. Report vulnerabilities privately according to [SECURITY.md](SECURITY.md).
-
-## Project Status
-
-The core bridge is implemented and covered by type checks, unit tests, built-gateway smokes, fake Hermes HTTP/SSE integration, browser-client and terminal tests, Dashboard frontend and authenticated-proxy tests, plugin checks, package installation tests, and a Docker build in CI. Release candidates are also exercised manually inside the current official Hermes Docker image through the Dashboard and terminal surfaces.
+The release gate covers 354 tests plus type, docs, browser, Dashboard, plugin, CLI, gateway, package, dependency, CodeQL, and Docker checks. v0.3.1 was also exercised against the official Hermes v0.18.2 image and a real Gemini Live connection.
 
 What deterministic CI does **not** prove:
 
@@ -417,7 +281,7 @@ What deterministic CI does **not** prove:
 - public multi-user safety;
 - long-duration session reliability.
 
-That distinction is intentional. See [docs/live-provider-testing.md](docs/live-provider-testing.md) and the [roadmap](docs/roadmap.md).
+See [live-provider testing](docs/live-provider-testing.md) and the [roadmap](docs/roadmap.md). Never paste secrets into an issue; report vulnerabilities privately through [SECURITY.md](SECURITY.md).
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

- reduce the README from 438 lines / 2,722 words to 302 lines / 1,948 words while preserving the product, safety, architecture, UI, and contributor story
- move duplicated configuration, protocol, terminal, and speculative roadmap detail back to the existing canonical docs
- make the tagged local plugin install the reproducible Quick Start path and force replacement of stale installed copies
- correct `.env` guidance: npm scripts read the process environment and do not auto-load a local file
- make provider smoke commands repeat their required provider selection and credential
- add a tested exact-release browser-package install path and remove the misleading raw identity example
- clarify that the first screenshot is deterministic mock mode and that provider credentials remain server-side

## Verification

- `npm run verify` — 21 test files and 354 tests passed; every docs/browser/Dashboard/plugin/CLI/gateway/build/package smoke passed
- `npm audit --audit-level=moderate` — 0 vulnerabilities
- installed the exact v0.3.1 GitHub release tarball into a clean temporary project and imported `hermes-live-voice/browser` as version 0.3.1
- exercised `plugin install --force` against an isolated plugin directory
- manually checked both local anchor targets that the file-level docs checker cannot validate
- `git diff --check`

## Content decision

This remains a technical open-source README, not a shallow landing page. It keeps the honest synchronous-delegation limit, current approval compatibility, developer-preview boundary, CI/manual proof, and unsupported production cases. The cuts remove duplicated mechanics, not evidence.
