### PR TITLE
chore(release): publish v0.3.2 through npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: hermes-live-release
+  queue: max
+
 jobs:
   verify-package:
     runs-on: ubuntu-latest
@@ -44,12 +48,12 @@ jobs:
           name: release-package
           path: release/
           if-no-files-found: error
-          retention-days: 1
+          retention-days: 30
 
   github-release:
     needs: verify-package
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     env:
       GH_REPO: ${{ github.repository }}
     permissions:
@@ -62,14 +66,91 @@ jobs:
       - name: Verify packaged checksum
         run: sha256sum --check SHA256SUMS
         working-directory: release
-      - name: Verify packaged version
+      - name: Verify packaged metadata
+        id: package
         run: |
           package_file="$(find release -maxdepth 1 -type f -name '*.tgz' -print -quit)"
           test -n "$package_file"
           test "$(find release -maxdepth 1 -type f -name '*.tgz' | wc -l)" -eq 1
-          package_version="$(tar -xOf "$package_file" package/package.json | node -e 'let data=""; process.stdin.on("data", (chunk) => data += chunk).on("end", () => process.stdout.write(JSON.parse(data).version))')"
+          package_metadata="$(tar -xOf "$package_file" package/package.json | node -e 'let data=""; process.stdin.on("data", (chunk) => data += chunk).on("end", () => { const packageJson = JSON.parse(data); process.stdout.write(`${packageJson.name}\t${packageJson.version}`); })')"
+          IFS=$'\t' read -r package_name package_version <<< "$package_metadata"
+          test "$package_name" = "hermes-live-voice"
           test "$GITHUB_REF_NAME" = "v$package_version"
-      - run: gh release create "$GITHUB_REF_NAME" release/*.tgz release/SHA256SUMS --title "$GITHUB_REF_NAME" --generate-notes --verify-tag
+          case "$package_version" in
+            *-*) prerelease=true ;;
+            *) prerelease=false ;;
+          esac
+          echo "file=$package_file" >> "$GITHUB_OUTPUT"
+          echo "name=$package_name" >> "$GITHUB_OUTPUT"
+          echo "version=$package_version" >> "$GITHUB_OUTPUT"
+          echo "prerelease=$prerelease" >> "$GITHUB_OUTPUT"
+      - name: Create or verify GitHub release
+        run: |
+          package_file="${{ steps.package.outputs.file }}"
+          package_basename="$(basename "$package_file")"
+          expected_prerelease="${{ steps.package.outputs.prerelease }}"
+
+          if release_json="$(gh release view "$GITHUB_REF_NAME" --json databaseId,name,isDraft,isPrerelease,assets 2>/dev/null)"; then
+            test "$(jq -r '.name' <<< "$release_json")" = "$GITHUB_REF_NAME"
+            test "$(jq -r '.isPrerelease' <<< "$release_json")" = "${{ steps.package.outputs.prerelease }}"
+            is_draft="$(jq -r '.isDraft' <<< "$release_json")"
+            release_id="$(jq -r '.databaseId' <<< "$release_json")"
+            unexpected_assets="$(jq -r --arg package "$package_basename" '.assets[] | select(.name != $package and .name != "SHA256SUMS") | .name' <<< "$release_json")"
+            if [ -n "$unexpected_assets" ]; then
+              echo "Unexpected assets exist on $GITHUB_REF_NAME:" >&2
+              printf '%s\n' "$unexpected_assets" >&2
+              exit 1
+            fi
+
+            for expected_file in "$package_file" release/SHA256SUMS; do
+              asset_name="$(basename "$expected_file")"
+              if jq -e --arg name "$asset_name" '.assets[] | select(.name == $name)' <<< "$release_json" >/dev/null; then
+                mkdir -p existing-release
+                gh release download "$GITHUB_REF_NAME" --pattern "$asset_name" --dir existing-release
+                cmp "$expected_file" "existing-release/$asset_name"
+              elif [ "$is_draft" = "true" ]; then
+                gh release upload "$GITHUB_REF_NAME" "$expected_file"
+              else
+                echo "Published release $GITHUB_REF_NAME is missing $asset_name." >&2
+                exit 1
+              fi
+            done
+
+            if [ "$is_draft" = "true" ]; then
+              if [ "$expected_prerelease" = "true" ]; then
+                make_latest=false
+              else
+                make_latest=true
+              fi
+              gh api --method PATCH "repos/$GITHUB_REPOSITORY/releases/$release_id" \
+                -F draft=false \
+                -F prerelease="$expected_prerelease" \
+                -f make_latest="$make_latest" >/dev/null
+              echo "Recovered and published the matching draft release."
+            else
+              echo "Existing published release matches the verified artifacts."
+            fi
+          elif [ "$expected_prerelease" = "true" ]; then
+            gh release create "$GITHUB_REF_NAME" release/*.tgz release/SHA256SUMS \
+              --title "$GITHUB_REF_NAME" --generate-notes --verify-tag --prerelease --latest=false
+          else
+            gh release create "$GITHUB_REF_NAME" release/*.tgz release/SHA256SUMS \
+              --title "$GITHUB_REF_NAME" --generate-notes --verify-tag --latest
+          fi
+
+          final_release="$(gh release view "$GITHUB_REF_NAME" --json isDraft,isImmutable,isPrerelease)"
+          test "$(jq -r '.isDraft' <<< "$final_release")" = "false"
+          test "$(jq -r '.isImmutable' <<< "$final_release")" = "true"
+          test "$(jq -r '.isPrerelease' <<< "$final_release")" = "$expected_prerelease"
+          rm -rf verified-release
+          mkdir verified-release
+          gh release download "$GITHUB_REF_NAME" \
+            --pattern "$package_basename" \
+            --pattern SHA256SUMS \
+            --dir verified-release
+          test "$(find verified-release -maxdepth 1 -type f | wc -l)" -eq 2
+          cmp "$package_file" "verified-release/$package_basename"
+          cmp release/SHA256SUMS verified-release/SHA256SUMS
         env:
           GH_TOKEN: ${{ github.token }}
 
@@ -79,6 +160,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: npm
+    outputs:
+      package_name: ${{ steps.package.outputs.name }}
+      package_version: ${{ steps.package.outputs.version }}
+      npm_tag: ${{ steps.package.outputs.npm_tag }}
+      integrity: ${{ steps.package.outputs.integrity }}
+      published_now: ${{ steps.publish.outputs.published_now }}
     permissions:
       id-token: write
     steps:
@@ -114,11 +201,159 @@ jobs:
       - name: Verify packaged checksum
         run: sha256sum --check SHA256SUMS
         working-directory: release
-      - name: Verify tag matches package version
+      - name: Verify packaged metadata
+        id: package
         run: |
           package_file="$(find release -maxdepth 1 -type f -name '*.tgz' -print -quit)"
           test -n "$package_file"
           test "$(find release -maxdepth 1 -type f -name '*.tgz' | wc -l)" -eq 1
-          package_version="$(tar -xOf "$package_file" package/package.json | node -e 'let data=""; process.stdin.on("data", (chunk) => data += chunk).on("end", () => process.stdout.write(JSON.parse(data).version))')"
+          package_metadata="$(tar -xOf "$package_file" package/package.json | node -e 'let data=""; process.stdin.on("data", (chunk) => data += chunk).on("end", () => { const packageJson = JSON.parse(data); process.stdout.write(`${packageJson.name}\t${packageJson.version}`); })')"
+          IFS=$'\t' read -r package_name package_version <<< "$package_metadata"
+          test "$package_name" = "hermes-live-voice"
           test "$GITHUB_REF_NAME" = "v$package_version"
-      - run: npm publish ./release/*.tgz --access public --provenance
+          case "$package_version" in
+            *-*) npm_tag=next ;;
+            *) npm_tag=latest ;;
+          esac
+          integrity="$(node -e 'const crypto = require("node:crypto"); const fs = require("node:fs"); process.stdout.write(`sha512-${crypto.createHash("sha512").update(fs.readFileSync(process.argv[1])).digest("base64")}`);' "$package_file")"
+          echo "PACKAGE_FILE=$package_file" >> "$GITHUB_ENV"
+          echo "PACKAGE_NAME=$package_name" >> "$GITHUB_ENV"
+          echo "PACKAGE_VERSION=$package_version" >> "$GITHUB_ENV"
+          echo "NPM_TAG=$npm_tag" >> "$GITHUB_ENV"
+          echo "EXPECTED_INTEGRITY=$integrity" >> "$GITHUB_ENV"
+          echo "name=$package_name" >> "$GITHUB_OUTPUT"
+          echo "version=$package_version" >> "$GITHUB_OUTPUT"
+          echo "npm_tag=$npm_tag" >> "$GITHUB_OUTPUT"
+          echo "integrity=$integrity" >> "$GITHUB_OUTPUT"
+      - name: Publish verified package with OIDC
+        id: publish
+        run: |
+          package_spec="$PACKAGE_NAME@$PACKAGE_VERSION"
+          set +e
+          existing_integrity="$(npm view "$package_spec" dist.integrity --registry=https://registry.npmjs.org/ 2>npm-view-error.log)"
+          view_status=$?
+          set -e
+
+          if [ "$view_status" -eq 0 ]; then
+            test "$existing_integrity" = "$EXPECTED_INTEGRITY"
+            echo "$package_spec already exists with the verified integrity; treating this as an idempotent rerun."
+            echo "published_now=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if ! grep -q 'E404' npm-view-error.log; then
+            sed -n '1,120p' npm-view-error.log >&2
+            exit "$view_status"
+          fi
+
+          set +e
+          npm publish "$PACKAGE_FILE" \
+            --access public \
+            --provenance \
+            --ignore-scripts \
+            --tag "$NPM_TAG" \
+            --registry=https://registry.npmjs.org/
+          publish_status=$?
+          set -e
+
+          if [ "$publish_status" -eq 0 ]; then
+            echo "published_now=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Publish returned status $publish_status; checking whether the registry accepted the immutable version before failing."
+          for attempt in 1 2 3 4 5 6; do
+            set +e
+            existing_integrity="$(npm view "$package_spec" dist.integrity --registry=https://registry.npmjs.org/ 2>npm-view-after-publish.log)"
+            view_status=$?
+            set -e
+            if [ "$view_status" -eq 0 ] && [ "$existing_integrity" = "$EXPECTED_INTEGRITY" ]; then
+              echo "$package_spec exists with the verified integrity after an ambiguous publish response."
+              echo "published_now=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            if [ "$view_status" -eq 0 ] && [ -n "$existing_integrity" ]; then
+              echo "Registry integrity mismatch for $package_spec after the ambiguous publish response." >&2
+              echo "Expected: $EXPECTED_INTEGRITY" >&2
+              echo "Observed: $existing_integrity" >&2
+              exit 1
+            fi
+            if [ "$attempt" -lt 6 ]; then
+              sleep 5
+            fi
+          done
+          sed -n '1,120p' npm-view-after-publish.log >&2
+          exit "$publish_status"
+
+  npm-verify:
+    if: vars.PUBLISH_NPM == 'true'
+    needs: npm-publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions: {}
+    env:
+      PACKAGE_NAME: ${{ needs.npm-publish.outputs.package_name }}
+      PACKAGE_VERSION: ${{ needs.npm-publish.outputs.package_version }}
+      NPM_TAG: ${{ needs.npm-publish.outputs.npm_tag }}
+      EXPECTED_INTEGRITY: ${{ needs.npm-publish.outputs.integrity }}
+      PUBLISHED_NOW: ${{ needs.npm-publish.outputs.published_now }}
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-package
+          path: release
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+      - name: Install verification npm CLI
+        run: npm install --global --ignore-scripts npm@11.18.0
+      - name: Verify registry package, provenance, and installed CLI
+        run: |
+          (cd release && sha256sum --check SHA256SUMS)
+          package_file="$(find release -maxdepth 1 -type f -name '*.tgz' -print -quit)"
+          test -n "$package_file"
+          test "$(find release -maxdepth 1 -type f -name '*.tgz' | wc -l)" -eq 1
+          artifact_integrity="$(node -e 'const crypto = require("node:crypto"); const fs = require("node:fs"); process.stdout.write(`sha512-${crypto.createHash("sha512").update(fs.readFileSync(process.argv[1])).digest("base64")}`);' "$package_file")"
+          test "$artifact_integrity" = "$EXPECTED_INTEGRITY"
+
+          package_spec="$PACKAGE_NAME@$PACKAGE_VERSION"
+          registry_integrity=""
+          registry_tag=""
+          provenance_type=""
+          for attempt in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24; do
+            registry_integrity="$(npm view "$package_spec" dist.integrity --registry=https://registry.npmjs.org/ 2>/dev/null || true)"
+            registry_tag="$(npm view "$PACKAGE_NAME" "dist-tags.$NPM_TAG" --registry=https://registry.npmjs.org/ 2>/dev/null || true)"
+            provenance_type="$(npm view "$package_spec" dist.attestations.provenance.predicateType --registry=https://registry.npmjs.org/ 2>/dev/null || true)"
+            if [ "$registry_integrity" = "$EXPECTED_INTEGRITY" ] && \
+               [ "$provenance_type" = "https://slsa.dev/provenance/v1" ] && \
+               { [ "$PUBLISHED_NOW" != "true" ] || [ "$registry_tag" = "$PACKAGE_VERSION" ]; }; then
+              break
+            fi
+            if [ "$attempt" -lt 24 ]; then
+              sleep 5
+            fi
+          done
+          if [ "$registry_integrity" != "$EXPECTED_INTEGRITY" ] || \
+             [ "$provenance_type" != "https://slsa.dev/provenance/v1" ] || \
+             { [ "$PUBLISHED_NOW" = "true" ] && [ "$registry_tag" != "$PACKAGE_VERSION" ]; }; then
+            echo "Registry verification timed out." >&2
+            echo "Expected integrity: $EXPECTED_INTEGRITY" >&2
+            echo "Observed integrity: $registry_integrity" >&2
+            echo "Expected $NPM_TAG on a new publish: $PACKAGE_VERSION" >&2
+            echo "Observed $NPM_TAG: $registry_tag" >&2
+            echo "Observed provenance predicate: $provenance_type" >&2
+            npm view "$package_spec" dist.integrity dist.attestations --json --registry=https://registry.npmjs.org/ >&2 || true
+            npm view "$PACKAGE_NAME" dist-tags --json --registry=https://registry.npmjs.org/ >&2 || true
+            exit 1
+          fi
+          test "$registry_integrity" = "$EXPECTED_INTEGRITY"
+          test "$provenance_type" = "https://slsa.dev/provenance/v1"
+
+          install_dir="$(mktemp -d)"
+          trap 'rm -rf "$install_dir"' EXIT
+          npm install --prefix "$install_dir" --ignore-scripts --omit=dev --no-audit --no-fund "$package_spec"
+          test "$("$install_dir/node_modules/.bin/hermes-live" --version)" = "$PACKAGE_VERSION"
+          "$install_dir/node_modules/.bin/hermes-live" --help | grep -q 'provider-smoke'
+          npm audit signatures --prefix "$install_dir"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+## 0.3.2 - 2026-07-15
+
+- Publish `hermes-live-voice` on npm and make the installed `hermes-live` CLI the primary setup path for the gateway, Hermes plugin, terminal, and custom browser clients.
+- Serialize tagged releases, protect immutable version tags/assets, select explicit npm dist-tags, make GitHub release creation retry-safe, and verify the exact npm tarball, provenance, dist-tag, and installed CLI after trusted publication.
+- Streamline the README around a Dashboard-first quick start, clearer client choices, and concise production-readiness evidence.
+- Update the runtime WebSocket dependency to `ws` 8.21.1 and move the development toolchain to TypeScript 7.0.2 and tsx 4.23.1, with an explicit TypeScript build root.
+- Upgrade the GitHub Actions setup and artifact actions, make checksum manifests portable, group compatible Dependabot updates, and preserve the intentional Node 20 runtime baseline.
+- Harden contribution guidance, checkout credential handling, and ignored secret, build, and editor artifacts for safer community contributions.
+
 ## 0.3.1 - 2026-07-14
 
 - Negotiate targeted Hermes approval responses explicitly. Any current uncorrelated approval triggers deny-all where possible, run stop, fatal session closure, and an operator-verification warning; interactive choices require stable upstream IDs and exact run/approval/choice/count confirmation.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 
 <p align="center">
   <a href="https://github.com/bielcarpi/hermes-live-voice/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/bielcarpi/hermes-live-voice/actions/workflows/ci.yml/badge.svg"></a>
+  <a href="https://www.npmjs.com/package/hermes-live-voice"><img alt="npm version" src="https://img.shields.io/npm/v/hermes-live-voice"></a>
   <a href="https://github.com/bielcarpi/hermes-live-voice/releases"><img alt="Release" src="https://img.shields.io/github/v/release/bielcarpi/hermes-live-voice?display_name=tag"></a>
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-16a34a"></a>
   <img alt="Node 20+" src="https://img.shields.io/badge/node-%3E%3D20-339933">
@@ -55,7 +56,7 @@ Ask it to inspect a repository, use memory, research something current, or run a
 
 Try a request that makes the agent do real work: *“Inspect this repository, run the tests, and tell me whether it is safe to release.”*
 
-> **Approval safety:** Hermes Agent v0.18.2, tested for this release, does not expose stable approval IDs. Hermes Live Voice never guesses: it attempts denial, stops the run, and closes the voice session. Interactive decisions enable only after Hermes negotiates targeted approval identity. See the [security model](docs/security.md).
+> **Approval safety:** The most recently integration-tested Hermes Agent version, v0.18.2, does not expose stable approval IDs. Hermes Live Voice never guesses: it attempts denial, stops the run, and closes the voice session. Interactive decisions enable only after Hermes negotiates targeted approval identity. See the [security model](docs/security.md).
 
 ## Why Not Just Use Hermes Voice Mode?
 
@@ -93,23 +94,19 @@ An OpenAI-compatible chat endpoint alone does not provide this realtime audio an
 - A running [Hermes Agent API Server](https://hermes-agent.nousresearch.com/docs/user-guide/features/api-server/) with its `API_SERVER_KEY` configured.
 - A Gemini or OpenAI key for real speech. No provider key is needed for mock mode.
 
-### 1. Install and build
-
-Until the first npm publication, install from GitHub:
+### 1. Install
 
 ```sh
-git clone --branch v0.3.1 --depth 1 https://github.com/bielcarpi/hermes-live-voice.git
-cd hermes-live-voice
-npm ci
-npm run build
+npm install --global hermes-live-voice
+hermes-live --version
 ```
 
 ### 2. Install the Hermes plugin
 
-Install the plugin from the tagged checkout you just built:
+Install the matching packaged plugin:
 
 ```sh
-node dist/cli.js plugin install --force
+hermes-live plugin install --force
 hermes plugins enable hermes-live
 ```
 
@@ -123,7 +120,7 @@ Use the same value for `HERMES_AGENT_API_SERVER_KEY` that Hermes uses for `API_S
 HERMES_BASE_URL=http://127.0.0.1:8642 \
 HERMES_AGENT_API_SERVER_KEY=your-hermes-api-server-key \
 HERMES_LIVE_PROVIDER=mock \
-npm run dev
+hermes-live serve
 ```
 
 Start or restart Hermes Dashboard after enabling the plugin:
@@ -134,7 +131,7 @@ hermes dashboard
 
 Open **Live Voice**, connect, and send a text message. Mock mode verifies the Dashboard proxy, gateway, client protocol, and Hermes run bridge without spending realtime-provider credits. It intentionally disables microphone input and audio output.
 
-The standalone development UI remains available at <http://127.0.0.1:8788>. Use it when developing the gateway or debugging an installation without the Dashboard.
+The bundled browser demo remains available at <http://127.0.0.1:8788>. Use it when developing the gateway or debugging an installation without the Dashboard.
 
 ### 4. Turn on live speech
 
@@ -144,7 +141,7 @@ Gemini Live:
 HERMES_LIVE_PROVIDER=gemini \
 GEMINI_API_KEY=your-gemini-key \
 HERMES_AGENT_API_SERVER_KEY=your-hermes-api-server-key \
-npm run dev
+hermes-live serve
 ```
 
 OpenAI Realtime:
@@ -154,15 +151,15 @@ HERMES_LIVE_PROVIDER=openai \
 OPENAI_API_KEY=your-openai-key \
 OPENAI_REALTIME_MODEL=gpt-realtime-2.1 \
 HERMES_AGENT_API_SERVER_KEY=your-hermes-api-server-key \
-npm run dev
+hermes-live serve
 ```
 
 Before calling a real-provider deployment ready, repeat the provider selection and credential in a second shell for an actual connect/close smoke test:
 
 ```sh
-HERMES_LIVE_PROVIDER=gemini GEMINI_API_KEY=your-gemini-key npm run check:live-provider
+HERMES_LIVE_PROVIDER=gemini GEMINI_API_KEY=your-gemini-key hermes-live provider-smoke
 # or
-HERMES_LIVE_PROVIDER=openai OPENAI_API_KEY=your-openai-key npm run check:live-provider
+HERMES_LIVE_PROVIDER=openai OPENAI_API_KEY=your-openai-key hermes-live provider-smoke
 ```
 
 Then complete the audio and negative-case checklist in [live provider testing](docs/live-provider-testing.md).
@@ -174,10 +171,10 @@ For local terminal microphone use, run `hermes` and press **Ctrl+B**. For a remo
 ```sh
 HERMES_LIVE_URL=https://voice.example.com \
 HERMES_LIVE_AUTH_TOKEN=your-gateway-token \
-node dist/cli.js terminal
+hermes-live terminal
 ```
 
-The console shows transcripts and Hermes progress, with separate `/interrupt` and `/stop` controls. It is intentionally text-only; use the Dashboard or browser client for gateway audio. Scripts can use `node dist/cli.js client "What is the current status?"`. See [UI integration](docs/ui-integration.md#terminal).
+The console shows transcripts and Hermes progress, with separate `/interrupt` and `/stop` controls. It is intentionally text-only; use the Dashboard or browser client for gateway audio. Scripts can use `hermes-live client "What is the current status?"`. See [UI integration](docs/ui-integration.md#terminal).
 
 ## Supported Providers
 
@@ -220,18 +217,16 @@ Read the [architecture](docs/architecture.md) and [client protocol](docs/client-
 
 ## Configuration
 
-The gateway reads the process environment. npm scripts do **not** load a local `.env` automatically, so export variables or pass them inline as shown in Quick Start. Docker Compose can consume one explicitly with `--env-file`.
+The gateway reads the process environment and does **not** load a local `.env` automatically, so export variables or pass them inline as shown in Quick Start. Docker Compose can consume one explicitly with `--env-file`.
 
-At minimum, set `HERMES_AGENT_API_SERVER_KEY` to Hermes Agent's `API_SERVER_KEY`, then select `mock` or provide the chosen realtime-provider credential. [.env.example](.env.example) is the complete reference; [local setup](docs/local-setup.md) explains every runtime path.
+At minimum, set `HERMES_AGENT_API_SERVER_KEY` to Hermes Agent's `API_SERVER_KEY`, then select `mock` or provide the chosen realtime-provider credential. [.env.example](.env.example) is the complete reference; [plugin usage](docs/plugin.md#runtime-usage) covers packaged operation and [local setup](docs/local-setup.md) covers checkout development.
 
 A network-accessible bind requires a strong `HERMES_LIVE_AUTH_TOKEN` and should use an exact `HERMES_LIVE_ALLOW_ORIGIN`. This developer preview is not a turnkey public multi-user service; review the [deployment security model](docs/security.md) before exposing it beyond localhost.
 
 ## Build A Custom UI
 
-Until npm publishing is enabled, install the exact GitHub release tarball:
-
 ```sh
-npm install https://github.com/bielcarpi/hermes-live-voice/releases/download/v0.3.1/hermes-live-voice-0.3.1.tgz
+npm install hermes-live-voice
 ```
 
 The dependency-free browser client is the same one used by the Hermes Dashboard integration and bundled demo:
@@ -253,17 +248,17 @@ The client also provides microphone capture, bounded playback, interruption, req
 ## Commands
 
 ```sh
-npm run dev                       # run the gateway from source
-npm run build                     # compile the distributable CLI/library
-node dist/cli.js client "..."     # one-shot text client
-node dist/cli.js terminal         # persistent text-control console
-node dist/cli.js chat             # alias for terminal
-node dist/cli.js check            # gateway + Hermes + provider config
-node dist/cli.js provider-smoke   # real provider connect/close test
-node dist/cli.js plugin install   # install the Hermes plugin
-node dist/cli.js plugin status    # inspect the plugin installation
-npm run verify                    # complete local release gate
+hermes-live serve                 # start the gateway and bundled demo
+hermes-live client "..."          # one-shot text client
+hermes-live terminal              # persistent text-control console
+hermes-live chat                  # alias for terminal
+hermes-live check                 # gateway + Hermes + provider config
+hermes-live provider-smoke        # real provider connect/close test
+hermes-live plugin install        # install the Hermes plugin
+hermes-live plugin status         # inspect the plugin installation
 ```
+
+Contributors working from a repository checkout can use `npm run dev`, `npm run build`, and `npm run verify`; see [local setup](docs/local-setup.md) and [contributing](CONTRIBUTING.md).
 
 Docker users can start from [examples/docker-compose.yml](examples/docker-compose.yml). It binds to host loopback and runs read-only, capability-free, and non-root by default. Use an authenticated TLS proxy for remote access.
 
@@ -271,7 +266,7 @@ Docker users can start from [examples/docker-compose.yml](examples/docker-compos
 
 Hermes Live Voice is a **developer preview for self-hosted, trusted-client use**. Long-lived credentials stay server-side; network binds and ambiguous approvals fail closed. Before remote exposure, add TLS, a high-entropy auth token, an exact origin allowlist, edge rate and cost limits, and keep Hermes/provider endpoints private. Review [the security model](docs/security.md) and [vulnerability reporting policy](SECURITY.md).
 
-The release gate covers 354 tests plus type, docs, browser, Dashboard, plugin, CLI, gateway, package, dependency, CodeQL, and Docker checks. v0.3.1 was also exercised against the official Hermes v0.18.2 image and a real Gemini Live connection.
+The release gate covers 354 tests plus type, docs, browser, Dashboard, plugin, CLI, gateway, package, dependency, CodeQL, and Docker checks. The v0.3.2 package was also exercised against the official Hermes v0.18.2 image and a real `gemini-3.1-flash-live-preview` connection.
 
 What deterministic CI does **not** prove:
 

--- a/docs/client-protocol.md
+++ b/docs/client-protocol.md
@@ -11,10 +11,12 @@ Use `wss://` behind TLS in production.
 For a one-shot terminal smoke test, use:
 
 ```sh
-node dist/cli.js client "What is the current status?"
+hermes-live client "What is the current status?"
 ```
 
-For a persistent text-control session, use `node dist/cli.js terminal`. It exercises this same protocol while exposing task progress, provider interruption, Hermes task stop, and targeted approvals as terminal commands. Approval commands are enabled only when Hermes advertises `run_approval_response_by_id` and supplies a stable ID for the request. With a legacy uncorrelated approval contract, the terminal shows no actionable approval prompt; the gateway attempts to deny the pending queue, stops the Hermes run, and closes the voice session for operator verification. The terminal intentionally has no native audio dependency: use official Hermes Voice Mode (Ctrl+B) for a local microphone, or the Dashboard/browser client for remote gateway audio.
+For a persistent text-control session, use `hermes-live terminal`. It exercises this same protocol while exposing task progress, provider interruption, Hermes task stop, and targeted approvals as terminal commands. Approval commands are enabled only when Hermes advertises `run_approval_response_by_id` and supplies a stable ID for the request. With a legacy uncorrelated approval contract, the terminal shows no actionable approval prompt; the gateway attempts to deny the pending queue, stops the Hermes run, and closes the voice session for operator verification. The terminal intentionally has no native audio dependency: use official Hermes Voice Mode (Ctrl+B) for a local microphone, or the Dashboard/browser client for remote gateway audio.
+
+From a built source checkout, replace `hermes-live` with `node dist/cli.js`.
 
 ## Browser Client
 
@@ -70,7 +72,7 @@ Query-token auth is not accepted for `/ready` or `/v1/capabilities`.
 
 ## HTTP Readiness
 
-`GET /ready` returns the same gateway, Hermes, and realtime readiness sections as `node dist/cli.js check`.
+`GET /ready` returns the same gateway, Hermes, and realtime readiness sections as `hermes-live check`.
 
 ```json
 {

--- a/docs/live-provider-testing.md
+++ b/docs/live-provider-testing.md
@@ -4,6 +4,8 @@ Default CI uses fake Hermes clients and the mock realtime provider. That keeps p
 
 Use this page before claiming a hosted gateway is ready.
 
+Commands below assume the globally installed package. From a source checkout, use `npm run check`, `npm run check:live-provider`, and `npm run dev` in place of `hermes-live check`, `hermes-live provider-smoke`, and `hermes-live serve`.
+
 ## Prerequisites
 
 - Hermes API Server running with run endpoints enabled.
@@ -16,7 +18,7 @@ Use this page before claiming a hosted gateway is ready.
 ## Step 1: Check Hermes And Provider Config
 
 ```sh
-npm run check
+hermes-live check
 ```
 
 Expected:
@@ -59,12 +61,6 @@ The exact Hermes capability fields can vary by Hermes version. This proves gatew
 After setting `HERMES_LIVE_PROVIDER` and the provider credentials, run:
 
 ```sh
-npm run check:live-provider
-```
-
-For an installed package or Docker image, run the CLI directly:
-
-```sh
 hermes-live provider-smoke
 ```
 
@@ -91,7 +87,7 @@ GEMINI_API_KEY=... \
 HERMES_BASE_URL=http://127.0.0.1:8642 \
 HERMES_AGENT_API_SERVER_KEY=... \
 HERMES_LIVE_AUTH_TOKEN=local-test-token \
-npm run dev
+hermes-live serve
 ```
 
 Gemini Enterprise / Vertex:
@@ -104,7 +100,7 @@ GOOGLE_CLOUD_LOCATION=us-central1 \
 HERMES_BASE_URL=http://127.0.0.1:8642 \
 HERMES_AGENT_API_SERVER_KEY=... \
 HERMES_LIVE_AUTH_TOKEN=local-test-token \
-npm run dev
+hermes-live serve
 ```
 
 OpenAI Realtime:
@@ -117,7 +113,7 @@ OPENAI_REALTIME_TURN_DETECTION=disabled \
 HERMES_BASE_URL=http://127.0.0.1:8642 \
 HERMES_AGENT_API_SERVER_KEY=... \
 HERMES_LIVE_AUTH_TOKEN=local-test-token \
-npm run dev
+hermes-live serve
 ```
 
 Override `OPENAI_REALTIME_MODEL` only when intentionally validating another documented Realtime-compatible model.

--- a/docs/local-setup.md
+++ b/docs/local-setup.md
@@ -1,4 +1,6 @@
-# Local Setup
+# Local Setup From Source
+
+This guide is for contributors running a repository checkout. For the packaged installation, start with the npm-first [Quick Start](../README.md#quick-start).
 
 ## 1. Start Hermes
 
@@ -91,7 +93,9 @@ If you bind the gateway to `0.0.0.0`, set a strong `HERMES_LIVE_AUTH_TOKEN`; oth
 Install and enable the plugin, start the companion gateway, then start or restart Hermes Dashboard:
 
 ```sh
-hermes plugins install bielcarpi/hermes-live-voice/plugins/hermes-live --enable
+npm run build
+node dist/cli.js plugin install --symlink
+hermes plugins enable hermes-live
 hermes dashboard
 ```
 

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -80,7 +80,21 @@ The `ready` argument includes the authenticated `/ready` probe when `HERMES_LIVE
 
 ## Runtime Usage
 
-Run the gateway from a GitHub clone:
+Install the package and its matching Hermes plugin:
+
+```sh
+npm install --global hermes-live-voice
+hermes-live plugin install --force
+hermes plugins enable hermes-live
+```
+
+Start the installed gateway:
+
+```sh
+HERMES_BASE_URL=http://127.0.0.1:8642 HERMES_AGENT_API_SERVER_KEY=... HERMES_LIVE_PROVIDER=mock hermes-live serve
+```
+
+For source development, run from a GitHub clone instead:
 
 ```sh
 npm ci
@@ -88,12 +102,6 @@ npm run build
 node dist/cli.js plugin install --symlink
 hermes plugins enable hermes-live
 HERMES_BASE_URL=http://127.0.0.1:8642 HERMES_AGENT_API_SERVER_KEY=... HERMES_LIVE_PROVIDER=mock npm run dev
-```
-
-Or run the built CLI directly:
-
-```sh
-HERMES_BASE_URL=http://127.0.0.1:8642 HERMES_AGENT_API_SERVER_KEY=... HERMES_LIVE_PROVIDER=mock node dist/cli.js serve
 ```
 
 Or with Docker:
@@ -108,16 +116,18 @@ Then connect clients to:
 ws://localhost:8788/v1/live
 ```
 
+The commands below assume the globally installed package. From a built source checkout, replace `hermes-live` with `node dist/cli.js`.
+
 For a terminal smoke test:
 
 ```sh
-node dist/cli.js client "What should I work on next?"
+hermes-live client "What should I work on next?"
 ```
 
 For a persistent remote/headless session:
 
 ```sh
-node dist/cli.js terminal
+hermes-live terminal
 ```
 
 The terminal surface is text-control only. Use Hermes Ctrl+B Voice Mode for local terminal audio or the Dashboard/browser client for gateway audio.
@@ -128,27 +138,27 @@ The realtime provider does not receive Hermes tools directly. It receives gatewa
 
 ## Install In Hermes
 
-Current Hermes releases can clone the plugin subdirectory, install it under `~/.hermes/plugins/hermes-live/`, and enable it in one command:
+The npm package can install its bundled plugin under `~/.hermes/plugins/hermes-live/`:
+
+```sh
+hermes-live plugin install --force
+hermes plugins enable hermes-live
+```
+
+Current Hermes releases can also install the latest plugin source directly from GitHub:
 
 ```sh
 hermes plugins install bielcarpi/hermes-live-voice/plugins/hermes-live --enable
 ```
 
-For a local clone or npm package, copy or symlink the packaged plugin directory instead:
-
-```sh
-node dist/cli.js plugin install
-hermes plugins enable hermes-live
-```
-
 Useful installer options:
 
 ```sh
-node dist/cli.js plugin status
-node dist/cli.js plugin path
-node dist/cli.js plugin install --force
-node dist/cli.js plugin install --symlink
-node dist/cli.js plugin install --dir /custom/hermes/plugins
+hermes-live plugin status
+hermes-live plugin path
+hermes-live plugin install --force
+hermes-live plugin install --symlink
+hermes-live plugin install --dir /custom/hermes/plugins
 ```
 
 Project-local plugins can also be used under `.hermes/plugins/` when `HERMES_ENABLE_PROJECT_PLUGINS=true` is set for trusted repositories.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -5,7 +5,7 @@ Releases are tag-driven and must be reproducible from a clean `main` branch.
 ## Prepare
 
 1. Move user-visible entries from `Unreleased` into a versioned changelog section.
-2. Update `package.json` and `package-lock.json` to the same semantic version.
+2. Update `package.json`, `package-lock.json`, `plugins/hermes-live/plugin.yaml`, and `plugins/hermes-live/dashboard/manifest.json` to the same semantic version.
 3. Confirm the documented provider defaults against official provider documentation.
 4. Run the complete local gate:
 
@@ -29,26 +29,42 @@ git tag -a vX.Y.Z -m "vX.Y.Z"
 git push origin vX.Y.Z
 ```
 
-The release workflow reruns verification, audits dependencies, packs the npm tarball, and records its SHA-256 checksum in a read-only job. The checksum manifest stores only the tarball basename so users can download both release assets into one directory and verify them directly with `sha256sum --check SHA256SUMS` (or `shasum -a 256 -c SHA256SUMS` on macOS). A separate job with `contents: write` downloads only those artifacts and creates the GitHub release; it never checks out or executes repository/dependency code with the write credential.
+The repository ruleset prevents updates or deletion of `v*` tags, and immutable releases protect their tags and assets after publication. The release workflow serializes version tags, reruns verification, audits dependencies, packs the npm tarball, and records its SHA-256 checksum in a read-only job. The checksum manifest stores only the tarball basename so users can download both release assets into one directory and verify them directly with `sha256sum --check SHA256SUMS` (or `shasum -a 256 -c SHA256SUMS` on macOS). A separate job with `contents: write` downloads only those artifacts and creates the GitHub release; it never checks out or executes repository/dependency code with the write credential. If a rerun finds an existing release or recoverable draft, it requires every existing asset to match instead of replacing it.
 
 ## npm publication
 
-The workflow contains an optional npm trusted-publishing job. It runs only when the repository variable `PUBLISH_NPM` is set to `true` and the npm package has a trusted publisher configured for this GitHub repository and workflow. That job deliberately uses Node 24, installs the pinned npm 11 CLI without lifecycle scripts, verifies the staged tarball checksum/version, and publishes that already-verified artifact without checking out or installing project dependencies under the OIDC credential.
+The workflow publishes only when the repository variable `PUBLISH_NPM` is `true`. Its OIDC job uses the protected `npm` environment, Node 24, and a pinned npm 11 CLI. It verifies the downloaded tarball and publishes that exact artifact without checking out or installing repository dependencies under the OIDC credential. Stable versions use the `latest` dist-tag and prereleases use `next`.
 
-Before enabling it:
+Configure the one npm trusted publisher with these exact values:
 
-1. Claim `hermes-live-voice` on npm.
-2. Configure npm trusted publishing for `bielcarpi/hermes-live-voice` and `.github/workflows/release.yml`.
-3. Create a protected GitHub environment named `npm` if release approval is desired.
-4. Set the repository variable `PUBLISH_NPM=true`.
-5. Verify the package name, version, files, provenance, README rendering, and executable from the packed tarball.
+| Field | Value |
+| --- | --- |
+| Provider | GitHub Actions |
+| Organization or user | `bielcarpi` |
+| Repository | `hermes-live-voice` |
+| Workflow filename | `release.yml` |
+| Environment | `npm` |
+| Allowed action | `npm publish` |
 
-Do not add a long-lived npm token when trusted publishing is available.
+Enter only `release.yml`, not `.github/workflows/release.yml`. The workflow filename must already exist on the default branch. Keep the GitHub environment restricted to version tags matching `v*`, require a release approval, and do not add an `NPM_TOKEN`.
+
+The package must exist before its trusted publisher can be configured. For the initial claim only, enable account-level npm 2FA and manually publish the exact verified tarball from the existing GitHub release:
+
+```sh
+gh release download vX.Y.Z --pattern 'hermes-live-voice-X.Y.Z.tgz' --pattern SHA256SUMS
+shasum -a 256 -c SHA256SUMS
+NPM_CONFIG_PROVENANCE=false npm publish ./hermes-live-voice-X.Y.Z.tgz --access public --ignore-scripts
+npm view hermes-live-voice@X.Y.Z name version dist.integrity repository --json
+```
+
+After the registry readback succeeds, create the trusted publisher, set `PUBLISH_NPM=true`, and restrict conventional token-based package publication. Future version tags must publish only through the protected OIDC workflow.
+
+Publication is retry-safe: an existing version is accepted only when its registry integrity exactly matches the verified tarball. A separate job with no repository or OIDC permissions then verifies the registry integrity, expected dist-tag, SLSA provenance, clean exact-version install, executable version/help output, and registry signatures.
 
 ## Post-release
 
 - Install the exact released package or tarball into a clean temporary directory.
 - Run `hermes-live --help`, `hermes-live plugin status`, and the mock quick start.
 - Download the GitHub release tarball and `SHA256SUMS` into one directory, verify the checksum, and inspect the release notes.
-- Verify the npm package and provenance when npm publishing is enabled.
-- Update README install instructions only after the npm registry readback succeeds.
+- Verify the npm package metadata, dist-tag, provenance, signatures, README rendering, and executable from a clean registry install.
+- Confirm the npm package page and GitHub release both point to the same version before announcing the release.

--- a/docs/ui-integration.md
+++ b/docs/ui-integration.md
@@ -18,9 +18,13 @@ Hermes Live Voice is a gateway and client protocol, not one fixed application. T
 Install and enable the plugin, run the companion gateway, and restart the Dashboard:
 
 ```sh
-hermes plugins install bielcarpi/hermes-live-voice/plugins/hermes-live --enable
+npm install --global hermes-live-voice
+hermes-live plugin install --force
+hermes plugins enable hermes-live
 hermes dashboard
 ```
+
+See [plugin installation](plugin.md#install-in-hermes) for the latest-source and development alternatives.
 
 Choose **Live Voice** in the plugin navigation group.
 
@@ -52,11 +56,17 @@ HERMES_LIVE_AUTH_TOKEN=your-random-gateway-token
 
 `HERMES_LIVE_URL` must be a credential-free HTTP(S) origin. The Dashboard backend rejects user information, paths, query parameters, fragments, and WS(S) schemes. The token is a separate server-side value.
 
-Hermes Live Voice v0.3.1 was manually exercised in the official `nousresearch/hermes-agent:latest` Docker image running Hermes Agent v0.18.2. Compatibility is also guarded by captured upstream fixtures, plugin manifest, Python backend, generated-asset, browser-client, package, and protocol tests.
+Hermes Live Voice v0.3.2 was manually exercised in the official `nousresearch/hermes-agent:latest` Docker image running Hermes Agent v0.18.2. The packaged plugin, authenticated readiness path, mock WebSocket session, and real Gemini Live handshake were verified. Compatibility is also guarded by captured upstream fixtures, plugin manifest, Python backend, generated-asset, browser-client, package, and protocol tests.
 
 ## Custom Or Community Browser UI
 
-Install the package after it is published, or consume the same exports from a GitHub checkout/package tarball:
+Install the package in your UI project:
+
+```sh
+npm install hermes-live-voice
+```
+
+Import the dependency-free browser client:
 
 ```js
 import { HermesLiveAudio, HermesLiveClient } from "hermes-live-voice/browser";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hermes-live-voice",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes-live-voice",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "@google/genai": "^2.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-live-voice",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Give Hermes Agent a realtime voice with interruptible conversation, tool-powered work, live progress, and Dashboard, browser, and terminal clients.",
   "type": "module",
   "main": "./dist/index.js",

--- a/plugins/hermes-live/README.md
+++ b/plugins/hermes-live/README.md
@@ -10,13 +10,13 @@ It registers:
 - a Hermes Dashboard **Live Voice** integration;
 - an authenticated same-origin Dashboard proxy that keeps gateway credentials out of browser code.
 
-The plugin does not run the audio gateway inside Hermes. From a built repository checkout, start the Node.js companion runtime separately:
+The plugin does not run the audio gateway inside Hermes. Start the installed Node.js companion runtime separately:
 
 ```sh
-node dist/cli.js serve
+hermes-live serve
 ```
 
-After installing the npm package, the equivalent command is `hermes-live serve`.
+From a built repository checkout, the equivalent command is `node dist/cli.js serve`.
 
 Set `HERMES_LIVE_URL` when the gateway is not at `http://127.0.0.1:8788`. Set `HERMES_LIVE_AUTH_TOKEN` in the Hermes process when the gateway requires authentication. The status tool reports whether a token is configured but never returns its value.
 

--- a/plugins/hermes-live/after-install.md
+++ b/plugins/hermes-live/after-install.md
@@ -4,15 +4,17 @@ The Hermes plugin, Dashboard tab, and server-side Dashboard proxy are now availa
 
 ## 1. Start the companion gateway
 
-From a built checkout of `hermes-live-voice`:
+From the installed `hermes-live-voice` package:
 
 ```sh
 HERMES_BASE_URL=http://127.0.0.1:8642 \
 HERMES_AGENT_API_SERVER_KEY=your-hermes-api-server-key \
 HERMES_LIVE_PROVIDER=gemini \
 GEMINI_API_KEY=your-gemini-key \
-node dist/cli.js serve
+hermes-live serve
 ```
+
+From a built source checkout, the equivalent command is `node dist/cli.js serve`.
 
 Use `HERMES_LIVE_PROVIDER=openai` with `OPENAI_API_KEY` for OpenAI Realtime, or `HERMES_LIVE_PROVIDER=mock` for a text-only, no-provider-cost integration check.
 

--- a/plugins/hermes-live/dashboard/manifest.json
+++ b/plugins/hermes-live/dashboard/manifest.json
@@ -3,7 +3,7 @@
   "label": "Live Voice",
   "description": "Talk to Hermes in real time with interruption, task progress, and fail-closed controls.",
   "icon": "Zap",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "tab": {
     "path": "/live-voice",
     "position": "after:chat"

--- a/plugins/hermes-live/plugin.yaml
+++ b/plugins/hermes-live/plugin.yaml
@@ -1,5 +1,5 @@
 name: hermes-live
-version: 0.3.1
+version: 0.3.2
 description: "Connect Hermes Agent to an interruptible Gemini Live or OpenAI Realtime voice session through the self-hosted Hermes Live Voice gateway."
 author: Biel Carpi and Hermes Live contributors
 kind: standalone


### PR DESCRIPTION
## Summary

- prepare package, plugin, Dashboard manifest, changelog, and npm-first documentation for v0.3.2
- harden the tag-driven GitHub/npm release workflow with queued serialization, immutable artifact verification, draft recovery, exact-integrity idempotency, explicit latest/next dist-tags, OIDC trusted publishing, and an unprivileged registry/provenance/signature/install verification job
- streamline README and integration docs around the installed `hermes-live` CLI while preserving clearly labeled source-development paths

## Verification

- `npm ci`
- `npm run verify` — 21 files / 354 tests passed
- `npm audit --audit-level=moderate` — 0 vulnerabilities
- `npm pack --dry-run` — 174 files; clean install and CLI package smoke passed
- `docker build --pull -t hermes-live-voice:release .`
- official `nousresearch/hermes-agent:latest` v0.18.2 container + packaged v0.3.2 plugin + authenticated readiness + protocol v2 WebSocket `session.ready`
- real Gemini Live connect/close: `gemini-3.1-flash-live-preview`

## Release gate

The package name is available and npm authentication is valid. Registry bootstrap, trusted-publisher creation, merge, and the v0.3.2 tag remain intentionally gated on account-level npm 2FA and registry readback.
