### PR TITLE
docs(release): document protected npm recovery

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -46,20 +46,43 @@ Configure the one npm trusted publisher with these exact values:
 | Environment | `npm` |
 | Allowed action | `npm publish` |
 
-Enter only `release.yml`, not `.github/workflows/release.yml`. The workflow filename must already exist on the default branch. Keep the GitHub environment restricted to version tags matching `v*`, require a release approval, and do not add an `NPM_TOKEN`.
+Enter only `release.yml`, not `.github/workflows/release.yml`. The workflow filename must already exist on the default branch. Keep the GitHub environment restricted to version tags matching `v*` plus the protected `main` branch used by the recovery path below, require a release approval, and do not add an `NPM_TOKEN`.
 
 The package must exist before its trusted publisher can be configured. For the initial claim only, enable account-level npm 2FA and manually publish the exact verified tarball from the existing GitHub release:
 
 ```sh
 gh release download vX.Y.Z --pattern 'hermes-live-voice-X.Y.Z.tgz' --pattern SHA256SUMS
 shasum -a 256 -c SHA256SUMS
-NPM_CONFIG_PROVENANCE=false npm publish ./hermes-live-voice-X.Y.Z.tgz --access public --ignore-scripts
+npm publish ./hermes-live-voice-X.Y.Z.tgz --access public --ignore-scripts --provenance=false
 npm view hermes-live-voice@X.Y.Z name version dist.integrity repository --json
 ```
 
-After the registry readback succeeds, create the trusted publisher, set `PUBLISH_NPM=true`, and restrict conventional token-based package publication. Future version tags must publish only through the protected OIDC workflow.
+After the registry readback succeeds, create the trusted publisher, set `PUBLISH_NPM=true`, and restrict conventional token-based package publication:
+
+```sh
+npm access set mfa=publish hermes-live-voice
+```
+
+This setting requires 2FA for interactive publication, disallows granular and automation tokens from publishing, and leaves trusted OIDC publication available. Future version tags must publish only through the protected OIDC workflow.
 
 Publication is retry-safe: an existing version is accepted only when its registry integrity exactly matches the verified tarball. A separate job with no repository or OIDC permissions then verifies the registry integrity, expected dist-tag, SLSA provenance, clean exact-version install, executable version/help output, and registry signatures.
+
+### Recover a failed tag publish
+
+Never move or delete a protected version tag, and never replace assets on an immutable release. If the tag workflow exposes a publishing bug before npm accepts the version:
+
+1. Fix only `.github/workflows/release.yml` through the normal protected pull-request path.
+2. Wait for all required checks on the resulting `main` commit.
+3. Confirm the target npm version is still absent, or already has the exact expected integrity.
+4. Dispatch the recovery path from protected `main`:
+
+   ```sh
+   gh workflow run release.yml --ref main -f release_tag=vX.Y.Z
+   ```
+
+5. Review and approve the resulting `npm` environment deployment.
+
+The recovery path checks out the immutable version tag, requires that the tag remains in protected `main` history, and rejects the run if `main` differs from the tag anywhere except `release.yml`. It then rebuilds the package, byte-compares both release assets, and runs the same OIDC publication and registry verification jobs. If source or documentation changed after the release, prepare a new version instead of weakening these checks.
 
 ## Post-release
 


### PR DESCRIPTION
## Summary
- document the tested protected-main recovery path for an immutable release whose npm publish failed
- correct the one-time bootstrap command so `--provenance=false` has CLI precedence over `publishConfig`
- document the final `mfa=publish` token lock and the environment's `v*` plus protected `main` policy

## Verification
- `npm run check:docs`
- `git diff --check`
- confirmed against the successful v0.3.2 OIDC recovery run and npm package settings readback
