### PR TITLE
feat: one-command activation for v0.6.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
+# Containers and source development use this file as a reference. A normal npm
+# install should run `hermes-live setup`, which writes a private managed config
+# under ~/.hermes/hermes-live. The runtime never auto-loads project .env files.
+
 # Hermes Agent API Server
 # Credential-free HTTP(S) root origin only; put the bearer in the key field below.
 HERMES_BASE_URL=http://127.0.0.1:8642

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -31,7 +31,7 @@ Include redacted output from:
 
 ```sh
 hermes-live print-config
-hermes-live check
+hermes-live doctor
 ```
 
 From a built source checkout, replace `hermes-live` with `node dist/cli.js`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+## 0.6.0 - 2026-07-18
+
+- Add `hermes-live setup` as the normal installation path. It securely reuses Hermes's existing API Server key when available, prompts without echoing missing provider credentials, writes an allowlisted private config, installs and enables the matching plugin, verifies Hermes capabilities and a real Gemini/OpenAI session, and waits for the gateway to become ready.
+- Add a native user-service lifecycle through launchd on macOS and systemd on Linux. `hermes-live service install|uninstall|start|stop|restart|status|logs` keeps the gateway available without a dedicated terminal, while service definitions contain only the managed-config path and never API keys.
+- Add `hermes-live doctor` with human and JSON output for Node compatibility, config integrity, plugin/runtime version parity, Hermes CLI and durable-run capabilities, provider configuration and optional live session, service state, and gateway readiness. Every failed check includes an exact remediation.
+- Store managed settings under `~/.hermes/hermes-live/config.env` with private permissions, atomic writes, process-environment precedence, an explicit key allowlist, and strict rejection of symlinks, unsafe permissions, duplicate/unexpected settings, oversized input, and non-string values. Project `.env` files are never loaded or executed.
+- Make setup the primary README, plugin, Dashboard, and support path. The Dashboard now turns missing configuration, offline services, and failed readiness into the corresponding setup, service, and doctor commands.
+- Verify the complete activation path from a clean packed npm install: Hermes key import, managed config permissions, exact plugin version, gateway startup, real readiness response, and redacted doctor output. Protocol v3 and the durable background-task contract are unchanged.
+
 ## 0.5.0 - 2026-07-16
 
 - Keep the realtime conversation open while Hermes works. Delegated work is now owned by a durable server-side supervisor, survives client detachment, and reports retained results through an unread completion inbox after reconnect.

--- a/README.md
+++ b/README.md
@@ -33,44 +33,29 @@ Hermes still owns the intelligence and execution: its tools, memory, and skills 
 
 ## Quick start
 
-You need Node.js 20+, a running [Hermes Agent API Server](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/user-guide/features/api-server.md), and its `API_SERVER_KEY`. Mock mode needs no speech-provider key.
+You need Node.js 20+, Hermes Agent with its API Server running, and a Gemini or OpenAI API key. Keep Hermes's `API_SERVER_KEY` in `~/.hermes/.env`; setup can reuse it without printing it.
 
 ```sh
 npm install --global hermes-live-voice
-hermes-live plugin install --force
-hermes plugins enable hermes-live
+hermes-live setup
+hermes dashboard
 ```
 
-Start the gateway with the same key configured in `~/.hermes/.env`:
+Choose **Live Voice** in Dashboard. Setup asks which voice provider to use, verifies a real provider connection, installs and enables the matching plugin, and keeps the gateway running as a user service.
+
+No clone, build, project `.env`, or second terminal is required. You can also open the local browser client at <http://127.0.0.1:8788> or use the terminal:
 
 ```sh
-HERMES_AGENT_API_SERVER_KEY=your-hermes-api-server-key \
-HERMES_LIVE_PROVIDER=mock \
-hermes-live serve
+hermes-live terminal
 ```
 
-Then choose a client:
+If something is not ready, run:
 
 ```sh
-hermes dashboard       # open the Live Voice tab
-hermes-live terminal   # text control from a shell
+hermes-live doctor
 ```
 
-The development client is also available at <http://127.0.0.1:8788>. Ask it to inspect a repository or run a test suite. Mock mode exercises the real Hermes run bridge, task store, reconnect flow, and UI without using a microphone or provider credits.
-
-For speech, restart with a provider key:
-
-```sh
-# Gemini Live
-HERMES_AGENT_API_SERVER_KEY=your-hermes-api-server-key \
-GEMINI_API_KEY=your-key HERMES_LIVE_PROVIDER=gemini hermes-live serve
-
-# OpenAI Realtime
-HERMES_AGENT_API_SERVER_KEY=your-hermes-api-server-key \
-OPENAI_API_KEY=your-key HERMES_LIVE_PROVIDER=openai hermes-live serve
-```
-
-Run `hermes-live provider-smoke` with the same environment before relying on speech. See [live provider testing](docs/live-provider-testing.md) for the microphone, playback, interruption, and notification checks.
+It checks Node, private config permissions, plugin/runtime version parity, Hermes capabilities, provider configuration, the managed service, and gateway readiness, then prints the exact fix. See [setup and service management](docs/setup.md) for noninteractive setup, mock mode, custom paths, and uninstalling the service.
 
 ## Pick a client
 
@@ -131,12 +116,13 @@ Read [background tasks](docs/background-tasks.md) for recovery details and [arch
 
 ## Deploy safely
 
-The gateway does not load `.env` automatically. Copy settings from [.env.example](.env.example), keep provider and Hermes credentials server-side, and use the hardened [Docker Compose example](examples/docker-compose.yml).
+`hermes-live setup` writes only supported keys to `~/.hermes/hermes-live/config.env` with private permissions. Environment variables override it. The gateway never loads a project `.env` or executes config as shell code. For containers and source deployments, use [.env.example](.env.example) and the hardened [Docker Compose example](examples/docker-compose.yml).
 
 For any non-loopback bind, set a strong `HERMES_LIVE_AUTH_TOKEN`, exact `HERMES_LIVE_ALLOW_ORIGIN`, TLS, and edge rate limits. Keep Hermes itself private. This package is self-hosted infrastructure, not turnkey public multi-tenancy. Review [the security model](docs/security.md) and report vulnerabilities through [GitHub private reporting](https://github.com/bielcarpi/hermes-live-voice/security/advisories/new).
 
 ## Documentation
 
+- [Setup and service](docs/setup.md) — one-command activation, diagnostics, and lifecycle controls
 - [Local setup](docs/local-setup.md) — source builds, providers, Dashboard, terminal, and Docker
 - [Dashboard plugin](docs/plugin.md) — install, relay, and Hermes integration
 - [Background tasks](docs/background-tasks.md) — scheduling, persistence, recovery, and notifications

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -18,13 +18,12 @@ Run:
 ```sh
 node --version
 hermes-live --version
-hermes-live print-config
-hermes-live check
+hermes-live doctor
 ```
 
-`print-config` redacts configured secrets. Review the output again before publishing it.
+`doctor` reports config presence and paths but never credential values. Review the output again before publishing it.
 
-For provider problems, also run `hermes-live provider-smoke` with the same environment. This opens a real provider session but does not send audio or start a Hermes run.
+For provider problems, also run `hermes-live doctor --provider-smoke`. This opens a real provider session but does not send audio or start a Hermes run.
 
 From a source checkout, run `npm run verify` and replace `hermes-live` with `node dist/cli.js` in the diagnostics above.
 

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -18,30 +18,17 @@ The Dashboard tab supports browser voice, text fallback, transcript, speech inte
 
 ## Install The Published Plugin
 
-Install the package and copy its matching bundled plugin to `~/.hermes/plugins/hermes-live/`:
+The normal path installs, enables, verifies, and starts everything:
 
 ```sh
 npm install --global hermes-live-voice
-hermes-live plugin install --force
-hermes plugins enable hermes-live
-```
-
-Start the gateway:
-
-```sh
-HERMES_BASE_URL=http://127.0.0.1:8642 \
-HERMES_AGENT_API_SERVER_KEY=... \
-HERMES_LIVE_PROVIDER=mock \
-hermes-live serve
-```
-
-Then start or restart Dashboard:
-
-```sh
+hermes-live setup
 hermes dashboard
 ```
 
 Choose **Live Voice** in the plugin navigation group.
+
+Setup installs the exact plugin bundled with the CLI, reuses Hermes's existing `API_SERVER_KEY` when available, verifies required Hermes capabilities and a real voice-provider session, and installs a user service. Run `hermes-live doctor` for exact remediation.
 
 Useful installer commands:
 
@@ -52,6 +39,8 @@ hermes-live plugin install --force
 hermes-live plugin install --symlink
 hermes-live plugin install --dir /custom/hermes/plugins
 ```
+
+These lower-level commands are mainly for source development and custom layouts. See [Setup and service management](setup.md) for automation and lifecycle commands.
 
 Project-local plugins under `.hermes/plugins/` require `HERMES_ENABLE_PROJECT_PLUGINS=true` and should be enabled only for trusted repositories.
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,86 @@
+# Setup And Service Management
+
+The published package can activate a local Hermes Live Voice installation without cloning the repository or keeping a gateway terminal open.
+
+## Activate
+
+Before setup, start Hermes Agent's API Server and keep its `API_SERVER_KEY` in `~/.hermes/.env`. Then run:
+
+```sh
+npm install --global hermes-live-voice
+hermes-live setup
+hermes dashboard
+```
+
+Setup:
+
+- asks for Gemini, OpenAI, or text-only mock mode;
+- reuses the Hermes key and any existing provider key when available;
+- prompts without echoing missing secrets;
+- writes a private managed config;
+- installs the exact bundled Hermes plugin and enables it;
+- verifies the Hermes durable-run API and a real provider session;
+- installs and starts a macOS launchd or Linux systemd user service;
+- waits until the gateway reports ready.
+
+The local browser client is available at <http://127.0.0.1:8788>. The Dashboard is the recommended everyday UI; `hermes-live terminal` is the headless text client.
+
+## Managed Configuration
+
+The default file is:
+
+```txt
+~/.hermes/hermes-live/config.env
+```
+
+Its directory and file use `0700` and `0600` permissions on POSIX systems. The parser accepts only documented Hermes Live settings and JSON-quoted string values. It refuses symlinks, unexpected keys, duplicate keys, unsafe permissions, oversized files, and non-string values. The runtime does not source the file or load a project `.env`.
+
+Process environment variables take precedence. Use `HERMES_LIVE_CONFIG_FILE` to select another managed file. Containers should keep using explicit environment injection or an orchestrator secret store.
+
+## Diagnostics
+
+```sh
+hermes-live doctor
+hermes-live doctor --provider-smoke
+hermes-live doctor --json
+```
+
+The default check covers Node, managed-config integrity, plugin/runtime version parity, the Hermes CLI, required Hermes API capabilities, provider configuration, the user service, and gateway readiness. `--provider-smoke` also opens and closes a real provider session.
+
+## Service Lifecycle
+
+```sh
+hermes-live service status
+hermes-live service restart
+hermes-live service logs
+hermes-live service stop
+hermes-live service start
+hermes-live service uninstall
+```
+
+macOS uses `~/Library/LaunchAgents/dev.hermes-live-voice.gateway.plist`. Linux uses `~/.config/systemd/user/dev.hermes-live-voice.gateway.service`. Definitions contain the absolute Node/CLI paths and managed-config path, not API keys.
+
+Run `hermes-live setup` again after changing provider credentials or upgrading the package. It safely rewrites the managed config, replaces the bundled plugin, rechecks both upstream services, and refreshes the gateway service.
+
+## Automation And Custom Layouts
+
+Noninteractive setup never prompts and prints a safe machine-readable report:
+
+```sh
+HERMES_AGENT_API_SERVER_KEY=... \
+GEMINI_API_KEY=... \
+hermes-live setup --provider gemini --non-interactive --json
+```
+
+The credentials remain environment values; there are deliberately no secret CLI flags. Useful layout options are:
+
+```txt
+--hermes-url <url>
+--config <path>
+--plugins-dir <path>
+--hermes-command <path>
+--no-enable
+--no-service
+```
+
+Use `--no-service` for containers, unsupported operating systems, or a separately supervised gateway. Start it with `hermes-live serve`.

--- a/docs/ui-integration.md
+++ b/docs/ui-integration.md
@@ -17,12 +17,11 @@ This documents compatibility with Hermes Agent and community projects, not endor
 
 ## Hermes Dashboard
 
-Install the package/plugin, start the companion gateway, and restart Dashboard:
+Install the package, activate Live Voice, and start Dashboard:
 
 ```sh
 npm install --global hermes-live-voice
-hermes-live plugin install --force
-hermes plugins enable hermes-live
+hermes-live setup
 hermes dashboard
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hermes-live-voice",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes-live-voice",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@google/genai": "2.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-live-voice",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Real-time voice for Hermes Agent—talk naturally while it works in the background.",
   "type": "module",
   "main": "./dist/index.js",

--- a/plugins/hermes-live/README.md
+++ b/plugins/hermes-live/README.md
@@ -10,16 +10,17 @@ It registers:
 - a Hermes Dashboard **Live Voice** integration;
 - an authenticated same-origin Dashboard proxy that keeps gateway credentials out of browser code.
 
-The plugin does not run the audio gateway inside Hermes. Start the installed Node.js companion runtime separately:
+The plugin does not run the audio gateway inside Hermes. The npm setup command installs the plugin, verifies the connection, and manages the companion runtime:
 
 ```sh
-hermes-live serve
+npm install --global hermes-live-voice
+hermes-live setup
 ```
 
-From a built repository checkout, the equivalent command is `node dist/cli.js serve`.
+Use `hermes-live doctor` for exact fixes and `hermes-live service status` for the managed gateway. From a source checkout, the manual equivalent is `node dist/cli.js serve`.
 
 Set `HERMES_LIVE_URL` when the gateway is not at `http://127.0.0.1:8788`. Set `HERMES_LIVE_AUTH_TOKEN` in the Hermes process when the gateway requires authentication. The status tool reports whether a token is configured but never returns its value.
 
-Start or restart `hermes dashboard` after enabling the plugin, then choose **Live Voice**. The Dashboard tab keeps voice and text conversation responsive while delegated tasks continue in a durable task inbox. It shows active and recent work, unread completion updates, stable task IDs, result details, and an exact stop control for each active task. Disconnecting ends only the voice session; background tasks keep working and synchronize when you reconnect. Its backend applies the gateway bearer server-side, so the browser connects only to an authenticated same-origin plugin WebSocket.
+Start or restart `hermes dashboard`, then choose **Live Voice**. The Dashboard tab keeps voice and text conversation responsive while delegated tasks continue in a durable task inbox. It shows active and recent work, unread completion updates, stable task IDs, result details, and an exact stop control for each active task. Disconnecting ends only the voice session; background tasks keep working and synchronize when you reconnect. Its backend applies the gateway bearer server-side, so the browser connects only to an authenticated same-origin plugin WebSocket.
 
 For installation, provider configuration, architecture, and security guidance, see the main [Hermes Live Voice repository](https://github.com/bielcarpi/hermes-live-voice).

--- a/plugins/hermes-live/after-install.md
+++ b/plugins/hermes-live/after-install.md
@@ -1,47 +1,24 @@
 # Hermes Live Voice is installed
 
-The Hermes plugin, Dashboard tab, and server-side Dashboard proxy are now available. The plugin does **not** start the companion voice gateway for you.
+The plugin adds the **Live Voice** Dashboard tab, status tool, slash command, and authenticated browser relay. The matching npm package runs the companion gateway.
 
-## 1. Start the companion gateway
-
-Start in deterministic, no-provider-cost mock mode:
+For the normal local setup:
 
 ```sh
-HERMES_BASE_URL=http://127.0.0.1:8642 \
-HERMES_AGENT_API_SERVER_KEY=your-hermes-api-server-key \
-HERMES_LIVE_PROVIDER=mock \
-hermes-live serve
-```
-
-The `hermes-live` command comes from the matching `hermes-live-voice` npm package. A plugin installed directly from GitHub does not install that CLI and follows unpinned `main`; use it only with a gateway built from the same checkout. From a built checkout, replace `hermes-live` with `node dist/cli.js`.
-
-After mock mode completes a delegated task, restart with `HERMES_LIVE_PROVIDER=gemini` plus `GEMINI_API_KEY`, or `HERMES_LIVE_PROVIDER=openai` plus `OPENAI_API_KEY`, for live speech.
-
-If the gateway requires authentication, give the gateway and the Hermes Dashboard process the same strong value:
-
-```sh
-HERMES_LIVE_AUTH_TOKEN=your-random-gateway-token
-```
-
-Set `HERMES_LIVE_URL` in the Hermes Dashboard process when the gateway is not available at the default `http://127.0.0.1:8788`.
-
-## 2. Start or restart the Dashboard
-
-```sh
+npm install --global hermes-live-voice
+hermes-live setup
 hermes dashboard
 ```
 
-Open the Dashboard and choose **Live Voice**. The page reports gateway readiness before you connect. Microphone access works on `localhost` or another browser secure context.
+Choose **Live Voice**. The Dashboard stays responsive while delegated tasks run, keeps their results in a durable inbox, and reports back when they finish.
 
-The Dashboard browser never receives the gateway credential or upstream gateway URL. It opens an authenticated, same-origin WebSocket to the plugin backend; the backend connects to the companion gateway and applies the credential server-side.
+Useful commands:
 
-## 3. Know the controls
+```sh
+hermes-live doctor
+hermes-live service status
+hermes-live service logs
+hermes-live terminal
+```
 
-- **Interrupt speech** clears queued local playback and requests provider cancellation/truncation when supported, while leaving an active Hermes task running. Provider-side cancellation semantics differ; test the selected provider with real audio.
-- **Stop task** appears on each active task card and targets that card's stable task ID. It leaves both the voice session and every other task untouched.
-- **Mark read** acknowledges one completion or status notification. Results remain available in the recent task inbox.
-- **Disconnect voice** ends the realtime voice session only. Durable tasks keep working, and the Dashboard synchronizes their latest state after reconnecting.
-
-For a terminal-only conversation on the same machine, Hermes' built-in Voice Mode remains the shortest path. Hermes Live Voice is the realtime gateway and client surface for the Dashboard, browsers, mobile or desktop apps, and other custom clients.
-
-See the project README for provider configuration, Docker deployment, security guidance, and end-to-end testing.
+Setup reads Hermes's `API_SERVER_KEY` from `~/.hermes/.env` when available and prompts securely for missing provider credentials. It never prints API keys. For a remote gateway, Docker, source development, or custom browser UI, see the project README and `docs/` directory.

--- a/plugins/hermes-live/dashboard/dist/index.js
+++ b/plugins/hermes-live/dashboard/dist/index.js
@@ -230,20 +230,24 @@
     if (status.configured === false) return {
       label: "Setup needed",
       tone: "warning",
-      detail: "Configure the companion gateway in the Hermes environment.",
+      detail: "Run hermes-live setup, then restart Hermes Dashboard.",
     };
     if (status.reachable === false) return {
       label: "Offline",
       tone: "danger",
-      detail: "The companion gateway is configured but cannot be reached.",
+      detail: "The gateway is offline. Run hermes-live service status, then hermes-live doctor.",
     };
     if (status.ready === false) return {
       label: "Not ready",
       tone: "warning",
-      detail: status.error || "The gateway is reachable but its provider or Hermes bridge is not ready.",
+      detail: (status.error || "The provider or Hermes bridge is not ready.") + " Run hermes-live doctor for the exact fix.",
     };
     if (status.ready === true) return { label: "Ready", tone: "success", detail: "Gateway and Hermes bridge are ready." };
-    if (status.error) return { label: "Unavailable", tone: "danger", detail: status.error };
+    if (status.error) return {
+      label: "Unavailable",
+      tone: "danger",
+      detail: status.error + " Run hermes-live doctor for the exact fix.",
+    };
     return { label: "Unknown", tone: "neutral", detail: "Gateway readiness has not been reported." };
   }
 

--- a/plugins/hermes-live/dashboard/manifest.json
+++ b/plugins/hermes-live/dashboard/manifest.json
@@ -3,7 +3,7 @@
   "label": "Live Voice",
   "description": "Talk to Hermes in real time while durable background tasks keep working and report back.",
   "icon": "Zap",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "tab": {
     "path": "/live-voice",
     "position": "after:chat"

--- a/plugins/hermes-live/plugin.yaml
+++ b/plugins/hermes-live/plugin.yaml
@@ -1,5 +1,5 @@
 name: hermes-live
-version: 0.5.0
+version: 0.6.0
 description: "Keep talking while Hermes keeps working through realtime voice, durable background tasks, and completion notifications."
 author: Biel Carpi and Hermes Live contributors
 kind: standalone

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -53,6 +53,12 @@ try {
     "dist/cli.js",
     "dist/cli/task-operator.js",
     "dist/cli/terminal-session.js",
+    "dist/cli/doctor.js",
+    "dist/cli/managed-config.js",
+    "dist/cli/plugin-installer.js",
+    "dist/cli/process.js",
+    "dist/cli/service-manager.js",
+    "dist/cli/setup.js",
     "dist/config.js",
     "dist/live-provider-smoke.js",
     "dist/adapters/inbound/http/server.js",
@@ -88,6 +94,7 @@ try {
     "docs/background-tasks.md",
     "docs/client-protocol.md",
     "docs/live-provider-testing.md",
+    "docs/setup.md",
     "examples/docker-compose.yml",
     "plugins/hermes-live/plugin.yaml",
     "plugins/hermes-live/__init__.py",
@@ -167,6 +174,9 @@ try {
     help.status !== 0 ||
     !help.stdout.includes("hermes-live") ||
     !help.stdout.includes("terminal") ||
+    !help.stdout.includes("setup") ||
+    !help.stdout.includes("doctor") ||
+    !help.stdout.includes("service") ||
     !help.stdout.includes("provider-smoke") ||
     !help.stdout.includes("HERMES_LIVE_PROVIDER")
   ) {
@@ -179,6 +189,20 @@ try {
       `Installed CLI version failed with status ${version.status ?? "null"}; expected ${packageJson.version}.\n${version.stdout}\n${version.stderr}`,
     );
   }
+
+  const activation = spawnSync(process.execPath, [
+    "scripts/packed-activation-smoke.mjs",
+    bin,
+    workDir,
+    packageJson.version,
+  ], {
+    encoding: "utf8",
+    env: { ...process.env, npm_config_cache: cacheDir, NPM_CONFIG_CACHE: cacheDir },
+  });
+  if (activation.status !== 0) {
+    throw new Error(`Installed activation smoke failed with status ${activation.status ?? "null"}\n${activation.stdout}\n${activation.stderr}`);
+  }
+  process.stdout.write(activation.stdout);
 
   const hermesPluginsDir = join(workDir, "hermes-plugins");
   mkdirSync(hermesPluginsDir, { recursive: true });

--- a/scripts/packed-activation-smoke.mjs
+++ b/scripts/packed-activation-smoke.mjs
@@ -1,0 +1,153 @@
+import { spawn } from "node:child_process";
+import { chmod, mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import { dirname, join } from "node:path";
+
+const [bin, workDir, expectedVersion] = process.argv.slice(2);
+if (!bin || !workDir || !expectedVersion) {
+  throw new Error("Usage: packed-activation-smoke.mjs <bin> <work-dir> <version>");
+}
+
+const home = join(workDir, "activation-home");
+const pluginsDir = join(home, ".hermes", "plugins");
+const hermesCommand = join(home, "bin", "hermes");
+const privateKey = "packed-activation-private-key";
+await mkdir(join(home, ".hermes"), { recursive: true, mode: 0o700 });
+await mkdir(dirname(hermesCommand), { recursive: true, mode: 0o700 });
+await writeFile(join(home, ".hermes", ".env"), `API_SERVER_KEY=${privateKey}\n`, { mode: 0o600 });
+await writeFile(hermesCommand, "#!/usr/bin/env node\nprocess.exit(0);\n", { mode: 0o700 });
+await chmod(hermesCommand, 0o700);
+
+const hermes = createServer((request, response) => {
+  response.setHeader("content-type", "application/json");
+  if (request.url === "/v1/capabilities") {
+    response.end(JSON.stringify({
+      model: "hermes-agent",
+      features: {
+        run_submission: true,
+        run_status: true,
+        run_events_sse: true,
+        run_stop: true,
+        run_approval_response: true,
+      },
+    }));
+    return;
+  }
+  response.statusCode = 404;
+  response.end("{}");
+});
+await new Promise((resolveListen) => hermes.listen(0, "127.0.0.1", resolveListen));
+const address = hermes.address();
+if (!address || typeof address === "string") throw new Error("Packed activation Hermes server did not bind TCP.");
+const gatewayPort = await availablePort();
+
+const env = {
+  HOME: home,
+  PATH: `${dirname(process.execPath)}:${dirname(hermesCommand)}:${process.env.PATH ?? ""}`,
+  HERMES_LIVE_PORT: String(gatewayPort),
+};
+let gateway;
+let gatewayStdout = "";
+let gatewayStderr = "";
+try {
+  const setup = await run(bin, [
+    "setup",
+    "--provider", "mock",
+    "--hermes-url", `http://127.0.0.1:${address.port}`,
+    "--plugins-dir", pluginsDir,
+    "--hermes-command", hermesCommand,
+    "--no-service",
+    "--non-interactive",
+    "--json",
+  ], env);
+  if (setup.code !== 0) throw new Error(`Packed setup failed.\n${setup.stdout}\n${setup.stderr}`);
+  const report = JSON.parse(setup.stdout);
+  if (!report.ok || !report.plugin?.manifestFound || !report.hermesCli?.enabled || !report.readiness?.ok) {
+    throw new Error(`Packed setup returned an invalid report.\n${setup.stdout}`);
+  }
+  if (setup.stdout.includes(privateKey) || setup.stderr.includes(privateKey)) {
+    throw new Error("Packed setup exposed the imported Hermes key.");
+  }
+
+  const configPath = join(home, ".hermes", "hermes-live", "config.env");
+  const config = await readFile(configPath, "utf8");
+  if (!config.includes("HERMES_AGENT_API_SERVER_KEY") || !config.includes("HERMES_LIVE_PROVIDER=\"mock\"")) {
+    throw new Error("Packed setup did not write the expected managed settings.");
+  }
+  if (process.platform !== "win32") {
+    if (((await stat(configPath)).mode & 0o777) !== 0o600) throw new Error("Packed setup config is not 0600.");
+    if (((await stat(dirname(configPath))).mode & 0o777) !== 0o700) throw new Error("Packed setup directory is not 0700.");
+  }
+  const pluginManifest = await readFile(join(pluginsDir, "hermes-live", "plugin.yaml"), "utf8");
+  if (!pluginManifest.includes(`version: ${expectedVersion}`)) {
+    throw new Error("Packed setup installed a plugin with the wrong version.");
+  }
+
+  gateway = spawn(bin, ["serve"], { env, stdio: ["ignore", "pipe", "pipe"] });
+  gateway.stdout.on("data", (chunk) => { gatewayStdout += chunk; });
+  gateway.stderr.on("data", (chunk) => { gatewayStderr += chunk; });
+  const readyUrl = `http://127.0.0.1:${gatewayPort}/ready`;
+  try {
+    await waitForReady(readyUrl, 15_000);
+  } catch (error) {
+    throw new Error(`${error.message}\nGateway stdout:\n${gatewayStdout}\nGateway stderr:\n${gatewayStderr}`);
+  }
+  const doctor = await run(bin, [
+    "doctor",
+    "--json",
+    "--plugins-dir", pluginsDir,
+    "--hermes-command", hermesCommand,
+  ], env);
+  if (doctor.code !== 0) throw new Error(`Packed doctor failed.\n${doctor.stdout}\n${doctor.stderr}`);
+  const doctorReport = JSON.parse(doctor.stdout);
+  if (!doctorReport.ok || doctorReport.checks?.find((check) => check.id === "gateway")?.status !== "pass") {
+    throw new Error(`Packed doctor did not verify the running gateway.\n${doctor.stdout}`);
+  }
+  if (doctor.stdout.includes(privateKey) || doctor.stderr.includes(privateKey)) {
+    throw new Error("Packed doctor exposed the imported Hermes key.");
+  }
+} finally {
+  gateway?.kill("SIGTERM");
+  if (gateway) await new Promise((resolveClose) => gateway.once("close", resolveClose));
+  await new Promise((resolveClose, reject) => hermes.close((error) => error ? reject(error) : resolveClose()));
+}
+
+console.log("Packed activation smoke ok: setup, managed config, plugin, gateway, and doctor verified.");
+
+async function run(command, args, commandEnv) {
+  return await new Promise((resolveRun) => {
+    const child = spawn(command, args, { env: commandEnv, stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.on("close", (code) => resolveRun({ code: code ?? 1, stdout, stderr }));
+  });
+}
+
+async function waitForReady(url, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  let lastDetail = "No response.";
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url);
+      const body = await response.text();
+      lastDetail = `HTTP ${response.status}: ${body.slice(0, 2_000)}`;
+      const parsed = JSON.parse(body);
+      if (response.ok && (parsed.ok === true || parsed.status === "ready")) return;
+    } catch (error) {
+      lastDetail = error instanceof Error ? error.message : String(error);
+    }
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 100));
+  }
+  throw new Error(`Packed gateway did not become ready. Last probe: ${lastDetail}`);
+}
+
+async function availablePort() {
+  const server = createServer();
+  await new Promise((resolveListen) => server.listen(0, "127.0.0.1", resolveListen));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("Could not reserve a gateway smoke port.");
+  await new Promise((resolveClose, reject) => server.close((error) => error ? reject(error) : resolveClose()));
+  return address.port;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,11 +1,6 @@
 #!/usr/bin/env node
-import { constants as fsConstants } from "node:fs";
-import { access, cp, lstat, mkdir, readlink, rm, symlink } from "node:fs/promises";
 import { createRequire } from "node:module";
-import { homedir } from "node:os";
-import { dirname, join, resolve } from "node:path";
 import { stdin as input } from "node:process";
-import { fileURLToPath } from "node:url";
 import WebSocket from "ws";
 import { assertRuntimeConfig, loadConfig, publicBaseUrl } from "./config.js";
 import type { AppConfig } from "./config.js";
@@ -17,6 +12,12 @@ import { runLiveProviderSmoke } from "./live-provider-smoke.js";
 import { errorToMessage } from "./domain/error-message.js";
 import { normalizeGatewayWebSocketUrl, runInteractiveTerminal, sanitizeTerminalText } from "./cli/terminal-session.js";
 import { runOfflineTaskCommand } from "./cli/task-operator.js";
+import {
+  installHermesPlugin,
+  pluginInstallStatus,
+  pluginSourceDir,
+  type PluginInstallOptions,
+} from "./cli/plugin-installer.js";
 import type { PublicTaskSnapshot, ServerMessage } from "./domain/protocol/server-protocol.js";
 import { parseServerMessage as parseProtocolServerMessage } from "./domain/protocol/server-protocol.js";
 
@@ -274,25 +275,8 @@ async function runPluginCommand(args: string[]): Promise<void> {
   process.exitCode = 1;
 }
 
-interface PluginOptions {
-  dir?: string;
-  mode: "copy" | "symlink";
-  force: boolean;
-}
-
-interface PluginInstallStatus {
-  source: string;
-  target: string;
-  installed: boolean;
-  manifestFound: boolean;
-  symlink: boolean;
-  symlinkTarget?: string;
-  mode?: "copy" | "symlink";
-  enabledHint: string;
-}
-
-function parsePluginOptions(args: string[]): PluginOptions {
-  const options: PluginOptions = { mode: "copy", force: false };
+function parsePluginOptions(args: string[]): PluginInstallOptions {
+  const options: PluginInstallOptions = { mode: "copy", force: false };
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
     if (arg === "--copy") {
@@ -315,77 +299,6 @@ function parsePluginOptions(args: string[]): PluginOptions {
     }
   }
   return options;
-}
-
-async function installHermesPlugin(options: PluginOptions): Promise<PluginInstallStatus> {
-  const source = pluginSourceDir();
-  const target = pluginTargetDir(options);
-  await assertPluginSource(source);
-  await mkdir(dirname(target), { recursive: true });
-  const existing = await pluginInstallStatus(options);
-  if (existing.installed) {
-    if (!options.force) {
-      return { ...existing, mode: existing.symlink ? "symlink" : "copy" };
-    }
-    await rm(target, { recursive: true, force: true });
-  }
-
-  if (options.mode === "symlink") {
-    await symlink(source, target, process.platform === "win32" ? "junction" : "dir");
-  } else {
-    await cp(source, target, {
-      recursive: true,
-      filter: (path) => !path.includes("__pycache__") && !path.endsWith(".pyc"),
-    });
-  }
-  return { ...(await pluginInstallStatus(options)), mode: options.mode };
-}
-
-async function pluginInstallStatus(options: PluginOptions): Promise<PluginInstallStatus> {
-  const source = pluginSourceDir();
-  const target = pluginTargetDir(options);
-  const stat = await lstat(target).catch(() => undefined);
-  const symlinkTarget = stat?.isSymbolicLink() ? await readlink(target).catch(() => undefined) : undefined;
-  return {
-    source,
-    target,
-    installed: Boolean(stat),
-    manifestFound: await fileExists(join(target, "plugin.yaml")),
-    symlink: Boolean(stat?.isSymbolicLink()),
-    ...(symlinkTarget ? { symlinkTarget } : {}),
-    enabledHint: "Run `hermes plugins enable hermes-live` after installation.",
-  };
-}
-
-async function assertPluginSource(source: string): Promise<void> {
-  if (!(await fileExists(join(source, "plugin.yaml"))) || !(await fileExists(join(source, "__init__.py")))) {
-    throw new Error(`Hermes plugin source is incomplete: ${source}`);
-  }
-}
-
-function pluginTargetDir(options: PluginOptions): string {
-  return join(hermesPluginsDir(options), "hermes-live");
-}
-
-function hermesPluginsDir(options: PluginOptions): string {
-  return resolve(options.dir ?? process.env.HERMES_LIVE_HERMES_PLUGINS_DIR ?? join(homedir(), ".hermes", "plugins"));
-}
-
-function pluginSourceDir(): string {
-  return join(packageRoot(), "plugins", "hermes-live");
-}
-
-function packageRoot(): string {
-  return dirname(dirname(fileURLToPath(import.meta.url)));
-}
-
-async function fileExists(path: string): Promise<boolean> {
-  try {
-    await access(path, fsConstants.F_OK);
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 async function runTextClient(config: AppConfig, text: string): Promise<void> {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,7 @@ import {
   pluginSourceDir,
   type PluginInstallOptions,
 } from "./cli/plugin-installer.js";
+import { applyManagedConfigToProcess } from "./cli/managed-config.js";
 import type { PublicTaskSnapshot, ServerMessage } from "./domain/protocol/server-protocol.js";
 import { parseServerMessage as parseProtocolServerMessage } from "./domain/protocol/server-protocol.js";
 
@@ -33,6 +34,10 @@ const MAX_TEXT_CLIENT_ID_CHARS = 256;
 
 async function main(): Promise<void> {
   const command = process.argv[2] ?? "serve";
+
+  if (usesManagedRuntimeConfig(command)) {
+    await applyManagedConfigToProcess();
+  }
 
   if (command === "plugin") {
     await runPluginCommand(process.argv.slice(3));
@@ -184,6 +189,21 @@ async function main(): Promise<void> {
   console.error(`Unknown command: ${command}`);
   printHelp();
   process.exitCode = 1;
+}
+
+function usesManagedRuntimeConfig(command: string): boolean {
+  return [
+    "serve",
+    "dev",
+    "client",
+    "terminal",
+    "chat",
+    "check",
+    "provider-smoke",
+    "check-live-provider",
+    "tasks",
+    "print-config",
+  ].includes(command);
 }
 
 function redact(value: string | undefined): string | undefined {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,7 @@ import {
   type PluginInstallOptions,
 } from "./cli/plugin-installer.js";
 import { applyManagedConfigToProcess } from "./cli/managed-config.js";
+import { runServiceAction, type ServiceAction } from "./cli/service-manager.js";
 import type { PublicTaskSnapshot, ServerMessage } from "./domain/protocol/server-protocol.js";
 import { parseServerMessage as parseProtocolServerMessage } from "./domain/protocol/server-protocol.js";
 
@@ -41,6 +42,11 @@ async function main(): Promise<void> {
 
   if (command === "plugin") {
     await runPluginCommand(process.argv.slice(3));
+    return;
+  }
+
+  if (command === "service") {
+    await runServiceCommand(process.argv.slice(3));
     return;
   }
 
@@ -234,6 +240,9 @@ Usage:
   hermes-live plugin install Install the Hermes plugin into ~/.hermes/plugins
   hermes-live plugin status  Show Hermes plugin install status
   hermes-live plugin path    Print this package's Hermes plugin directory
+  hermes-live service install Install and load the user gateway service
+  hermes-live service status  Show whether the gateway service is running
+  hermes-live service logs    Show the most recent gateway service logs
 
 Required environment:
   HERMES_BASE_URL           Hermes API Server URL, default http://127.0.0.1:8642
@@ -272,6 +281,24 @@ Plugin options:
   --symlink                 Symlink plugin directory instead of copying
   --force                   Replace an existing hermes-live plugin install
 `);
+}
+
+async function runServiceCommand(args: string[]): Promise<void> {
+  const action = (args[0] ?? "status") as ServiceAction;
+  if (!["install", "uninstall", "start", "stop", "restart", "status", "logs"].includes(action)) {
+    throw new Error(`Unknown service action: ${action}`);
+  }
+  if (args.length > 1) {
+    throw new Error(`Unknown service option: ${args[1]}`);
+  }
+  const result = await runServiceAction(action);
+  if (action === "logs" && "stdout" in result) {
+    if (result.stdout) process.stdout.write(result.stdout.endsWith("\n") ? result.stdout : `${result.stdout}\n`);
+    if (result.stderr) process.stderr.write(result.stderr.endsWith("\n") ? result.stderr : `${result.stderr}\n`);
+    if (result.code !== 0) process.exitCode = result.code;
+    return;
+  }
+  console.log(JSON.stringify(result, null, 2));
 }
 
 async function runPluginCommand(args: string[]): Promise<void> {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,6 +20,7 @@ import {
 } from "./cli/plugin-installer.js";
 import { applyManagedConfigToProcess } from "./cli/managed-config.js";
 import { runServiceAction, type ServiceAction } from "./cli/service-manager.js";
+import { runSetupCommand } from "./cli/setup.js";
 import type { PublicTaskSnapshot, ServerMessage } from "./domain/protocol/server-protocol.js";
 import { parseServerMessage as parseProtocolServerMessage } from "./domain/protocol/server-protocol.js";
 
@@ -42,6 +43,11 @@ async function main(): Promise<void> {
 
   if (command === "plugin") {
     await runPluginCommand(process.argv.slice(3));
+    return;
+  }
+
+  if (command === "setup") {
+    await runSetupCommand(process.argv.slice(3));
     return;
   }
 
@@ -226,6 +232,7 @@ function printHelp(): void {
 
 Usage:
   hermes-live --version     Print the installed package version
+  hermes-live setup         Configure, install, verify, and start Live Voice
   hermes-live serve         Start the realtime gateway and web demo
   hermes-live dev           Alias for serve
   hermes-live client "..."  Send one prompt; wait for its exact task result

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,6 +21,7 @@ import {
 import { applyManagedConfigToProcess } from "./cli/managed-config.js";
 import { runServiceAction, type ServiceAction } from "./cli/service-manager.js";
 import { runSetupCommand } from "./cli/setup.js";
+import { runDoctorCommand } from "./cli/doctor.js";
 import type { PublicTaskSnapshot, ServerMessage } from "./domain/protocol/server-protocol.js";
 import { parseServerMessage as parseProtocolServerMessage } from "./domain/protocol/server-protocol.js";
 
@@ -48,6 +49,11 @@ async function main(): Promise<void> {
 
   if (command === "setup") {
     await runSetupCommand(process.argv.slice(3));
+    return;
+  }
+
+  if (command === "doctor") {
+    await runDoctorCommand(process.argv.slice(3));
     return;
   }
 
@@ -233,6 +239,7 @@ function printHelp(): void {
 Usage:
   hermes-live --version     Print the installed package version
   hermes-live setup         Configure, install, verify, and start Live Voice
+  hermes-live doctor        Check the installation and print exact fixes
   hermes-live serve         Start the realtime gateway and web demo
   hermes-live dev           Alias for serve
   hermes-live client "..."  Send one prompt; wait for its exact task result

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1,0 +1,291 @@
+import { createRequire } from "node:module";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { loadConfig, type AppConfig } from "../config.js";
+import { runLiveProviderSmoke } from "../live-provider-smoke.js";
+import { buildReadinessReport, type ReadinessReport } from "../readiness.js";
+import { errorToMessage } from "../domain/error-message.js";
+import { readManagedConfig } from "./managed-config.js";
+import { pluginInstallStatus } from "./plugin-installer.js";
+import { findExecutable, type CommandRunner } from "./process.js";
+import { serviceStatus, type ServiceStatus } from "./service-manager.js";
+
+const packageRequire = createRequire(import.meta.url);
+const PACKAGE_VERSION = (packageRequire("../../package.json") as { version: string }).version;
+const MINIMUM_NODE_MAJOR = 20;
+
+export type DiagnosticStatus = "pass" | "warn" | "fail";
+
+export interface DiagnosticCheck {
+  id: string;
+  label: string;
+  status: DiagnosticStatus;
+  detail: string;
+  fix?: string;
+}
+
+export interface DoctorReport {
+  ok: boolean;
+  version: string;
+  checks: DiagnosticCheck[];
+  readiness?: ReadinessReport;
+  service?: ServiceStatus;
+}
+
+export interface DoctorOptions {
+  json: boolean;
+  providerSmoke: boolean;
+  configPath?: string;
+  pluginsDir?: string;
+  hermesCommand?: string;
+}
+
+export interface DoctorDependencies {
+  env?: NodeJS.ProcessEnv;
+  home?: string;
+  platform?: NodeJS.Platform;
+  nodeVersion?: string;
+  runner?: CommandRunner;
+  findCommand?: (name: string, env: NodeJS.ProcessEnv) => Promise<string | undefined>;
+  fetch?: typeof globalThis.fetch;
+}
+
+export function parseDoctorOptions(args: string[]): DoctorOptions {
+  const options: DoctorOptions = { json: false, providerSmoke: false };
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    const nextValue = (): string => {
+      const value = args[index + 1];
+      if (!value) throw new Error(`${argument} requires a value.`);
+      index += 1;
+      return value;
+    };
+    if (argument === "--json") options.json = true;
+    else if (argument === "--provider-smoke") options.providerSmoke = true;
+    else if (argument === "--config") options.configPath = nextValue();
+    else if (argument?.startsWith("--config=")) options.configPath = argument.slice(9);
+    else if (argument === "--plugins-dir") options.pluginsDir = nextValue();
+    else if (argument?.startsWith("--plugins-dir=")) options.pluginsDir = argument.slice(14);
+    else if (argument === "--hermes-command") options.hermesCommand = nextValue();
+    else if (argument?.startsWith("--hermes-command=")) options.hermesCommand = argument.slice(17);
+    else if (argument === "--help" || argument === "-h") throw new DoctorHelpRequested();
+    else if (argument) throw new Error(`Unknown doctor option: ${argument}`);
+  }
+  return options;
+}
+
+export async function runDoctor(
+  options: DoctorOptions,
+  dependencies: DoctorDependencies = {},
+): Promise<DoctorReport> {
+  const env = dependencies.env ?? process.env;
+  const checks: DiagnosticCheck[] = [];
+  const nodeVersion = dependencies.nodeVersion ?? process.versions.node;
+  const nodeMajor = Number(nodeVersion.split(".")[0]);
+  checks.push(Number.isInteger(nodeMajor) && nodeMajor >= MINIMUM_NODE_MAJOR
+    ? pass("node", "Node.js", `v${nodeVersion}`)
+    : fail("node", "Node.js", `v${nodeVersion} is unsupported.`, `Install Node.js ${MINIMUM_NODE_MAJOR} or newer.`));
+
+  let managedValues: NodeJS.ProcessEnv = {};
+  try {
+    const managed = await readManagedConfig({ path: options.configPath, home: dependencies.home });
+    managedValues = managed.values;
+    checks.push(managed.exists
+      ? pass("config", "Managed config", shortHome(managed.path, dependencies.home))
+      : warn("config", "Managed config", "No managed config is installed.", "Run `hermes-live setup`."));
+  } catch (error) {
+    checks.push(fail("config", "Managed config", errorToMessage(error), "Run `hermes-live setup` after fixing the file ownership and permissions."));
+  }
+
+  let config: AppConfig | undefined;
+  try {
+    config = loadConfig({ ...managedValues, ...env });
+    checks.push(pass("settings", "Runtime settings", `${config.realtime.provider} on ${publicGatewayOrigin(config)}`));
+  } catch (error) {
+    checks.push(fail("settings", "Runtime settings", errorToMessage(error), "Run `hermes-live setup` and correct the reported value."));
+  }
+
+  const plugin = await pluginInstallStatus({
+    ...(options.pluginsDir
+      ? { dir: options.pluginsDir }
+      : dependencies.home
+        ? { dir: join(dependencies.home, ".hermes", "plugins") }
+        : {}),
+  });
+  if (!plugin.installed || !plugin.manifestFound) {
+    checks.push(fail("plugin", "Hermes plugin", "The bundled plugin is not installed.", "Run `hermes-live setup`."));
+  } else {
+    const installedVersion = await pluginVersion(plugin.target);
+    checks.push(installedVersion === PACKAGE_VERSION
+      ? pass("plugin", "Hermes plugin", `v${installedVersion} at ${shortHome(plugin.target, dependencies.home)}`)
+      : fail(
+        "plugin",
+        "Hermes plugin",
+        `Installed ${installedVersion ? `v${installedVersion}` : "version is unknown"}; package is v${PACKAGE_VERSION}.`,
+        "Run `hermes-live setup` to install the matching plugin.",
+      ));
+  }
+
+  const findCommand = dependencies.findCommand ?? findExecutable;
+  const hermesCommand = options.hermesCommand
+    ? await findCommand(options.hermesCommand, env)
+    : await findCommand("hermes", env);
+  checks.push(hermesCommand
+    ? pass("hermes-cli", "Hermes CLI", shortHome(hermesCommand, dependencies.home))
+    : warn(
+      "hermes-cli",
+      "Hermes CLI",
+      "The `hermes` command is not on PATH.",
+      "Install Hermes or pass --hermes-command, then enable the plugin.",
+    ));
+
+  let readiness: ReadinessReport | undefined;
+  if (config) {
+    readiness = await buildReadinessReport(config);
+    checks.push(readiness.hermes.ok
+      ? pass("hermes-api", "Hermes API", `${String(readiness.hermes.baseUrl)} supports durable runs`)
+      : fail("hermes-api", "Hermes API", String(readiness.hermes.error ?? "Not ready."), "Start the Hermes API Server, then rerun `hermes-live doctor`."));
+    checks.push(readiness.realtime.ok
+      ? pass("provider-config", "Voice provider", `${config.realtime.provider} configuration is valid`)
+      : fail("provider-config", "Voice provider", String(readiness.realtime.error ?? "Not configured."), "Run `hermes-live setup`."));
+  } else {
+    checks.push(fail("hermes-api", "Hermes API", "Skipped because runtime settings are invalid.", "Fix runtime settings first."));
+    checks.push(fail("provider-config", "Voice provider", "Skipped because runtime settings are invalid.", "Fix runtime settings first."));
+  }
+
+  if (options.providerSmoke) {
+    if (!config || !readiness?.realtime.ok) {
+      checks.push(fail("provider-session", "Provider session", "Skipped because provider configuration is invalid.", "Fix provider configuration first."));
+    } else if (config.realtime.provider === "mock") {
+      checks.push(warn("provider-session", "Provider session", "Mock mode has no external voice session.", "Choose Gemini or OpenAI in `hermes-live setup` for speech."));
+    } else {
+      try {
+        await runLiveProviderSmoke(config, { timeoutMs: config.server.providerReadyTimeoutMs });
+        checks.push(pass("provider-session", "Provider session", `Connected to ${config.realtime.provider} realtime`));
+      } catch (error) {
+        checks.push(fail("provider-session", "Provider session", errorToMessage(error), "Check the provider key, model access, and network, then rerun with --provider-smoke."));
+      }
+    }
+  }
+
+  const service = await serviceStatus({
+    home: dependencies.home,
+    platform: dependencies.platform,
+    runner: dependencies.runner,
+    configPath: options.configPath,
+  });
+  if (service.platform === "unsupported") {
+    checks.push(warn("service", "Gateway service", service.detail, "Run `hermes-live serve` manually."));
+  } else if (!service.installed) {
+    checks.push(warn("service", "Gateway service", service.detail, "Run `hermes-live setup` or `hermes-live service install`."));
+  } else if (!service.running) {
+    checks.push(fail("service", "Gateway service", service.detail, "Run `hermes-live service restart`, then inspect `hermes-live service logs`."));
+  } else {
+    checks.push(pass("service", "Gateway service", `${service.platform}: running`));
+  }
+
+  if (config) {
+    const gateway = await probeGateway(config, dependencies.fetch ?? globalThis.fetch);
+    checks.push(gateway.ok
+      ? pass("gateway", "Live gateway", `${publicGatewayOrigin(config)} is ready`)
+      : fail("gateway", "Live gateway", gateway.error, "Run `hermes-live service restart` and inspect `hermes-live service logs`."));
+  } else {
+    checks.push(fail("gateway", "Live gateway", "Skipped because runtime settings are invalid.", "Fix runtime settings first."));
+  }
+
+  return {
+    ok: checks.every((check) => check.status !== "fail"),
+    version: PACKAGE_VERSION,
+    checks,
+    ...(readiness ? { readiness } : {}),
+    service,
+  };
+}
+
+export async function runDoctorCommand(args: string[]): Promise<void> {
+  let options: DoctorOptions;
+  try {
+    options = parseDoctorOptions(args);
+  } catch (error) {
+    if (error instanceof DoctorHelpRequested) {
+      printDoctorHelp();
+      return;
+    }
+    throw error;
+  }
+  const report = await runDoctor(options);
+  if (options.json) console.log(JSON.stringify(report, null, 2));
+  else printDoctorReport(report);
+  if (!report.ok) process.exitCode = 1;
+}
+
+export function printDoctorHelp(): void {
+  console.log(`hermes-live doctor
+
+Check the complete Hermes Live Voice installation and print exact fixes.
+
+Options:
+  --provider-smoke        Open and close a real provider session
+  --config <path>         Managed config path
+  --plugins-dir <path>    Hermes plugins directory
+  --hermes-command <path> Hermes executable path
+  --json                  Print a machine-readable report
+`);
+}
+
+function printDoctorReport(report: DoctorReport): void {
+  console.log(`Hermes Live Voice doctor v${report.version}`);
+  for (const check of report.checks) {
+    const marker = check.status === "pass" ? "ok" : check.status;
+    console.log(`[${marker}] ${check.label}: ${check.detail}`);
+    if (check.fix) console.log(`       Fix: ${check.fix}`);
+  }
+  console.log(report.ok ? "\nEverything required is ready." : "\nOne or more required checks failed.");
+}
+
+async function probeGateway(config: AppConfig, fetchImplementation: typeof globalThis.fetch): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    const response = await fetchImplementation(`${publicGatewayOrigin(config)}/ready`, {
+      redirect: "error",
+      headers: config.server.authToken ? { authorization: `Bearer ${config.server.authToken}` } : {},
+      signal: AbortSignal.timeout(3_000),
+    });
+    if (!response.ok) return { ok: false, error: `Readiness returned HTTP ${response.status}.` };
+    const body = await response.json() as { ok?: boolean };
+    return body.ok === true
+      ? { ok: true }
+      : { ok: false, error: "Gateway responded but reported that a dependency is not ready." };
+  } catch (error) {
+    return { ok: false, error: errorToMessage(error) };
+  }
+}
+
+function publicGatewayOrigin(config: AppConfig): string {
+  const rawHost = config.server.host === "0.0.0.0" || config.server.host === "::" ? "127.0.0.1" : config.server.host;
+  const host = rawHost.includes(":") && !rawHost.startsWith("[") ? `[${rawHost}]` : rawHost;
+  return `http://${host}:${config.server.port}`;
+}
+
+async function pluginVersion(target: string): Promise<string | undefined> {
+  const manifest = await readFile(`${target}/plugin.yaml`, "utf8").catch(() => "");
+  return /^version:\s*["']?([^\s"']+)["']?\s*$/mu.exec(manifest)?.[1];
+}
+
+function pass(id: string, label: string, detail: string): DiagnosticCheck {
+  return { id, label, status: "pass", detail };
+}
+
+function warn(id: string, label: string, detail: string, fix?: string): DiagnosticCheck {
+  return { id, label, status: "warn", detail, ...(fix ? { fix } : {}) };
+}
+
+function fail(id: string, label: string, detail: string, fix?: string): DiagnosticCheck {
+  return { id, label, status: "fail", detail, ...(fix ? { fix } : {}) };
+}
+
+function shortHome(path: string, configuredHome?: string): string {
+  const home = configuredHome ?? process.env.HOME;
+  return home && path.startsWith(`${home}/`) ? `~/${path.slice(home.length + 1)}` : path;
+}
+
+class DoctorHelpRequested extends Error {}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -251,8 +251,8 @@ async function probeGateway(config: AppConfig, fetchImplementation: typeof globa
       signal: AbortSignal.timeout(3_000),
     });
     if (!response.ok) return { ok: false, error: `Readiness returned HTTP ${response.status}.` };
-    const body = await response.json() as { ok?: boolean };
-    return body.ok === true
+    const body = await response.json() as { ok?: boolean; status?: string };
+    return body.ok === true || body.status === "ready"
       ? { ok: true }
       : { ok: false, error: "Gateway responded but reported that a dependency is not ready." };
   } catch (error) {

--- a/src/cli/managed-config.ts
+++ b/src/cli/managed-config.ts
@@ -231,7 +231,7 @@ async function assertSafeConfigDirectory(directory: string): Promise<void> {
   }
   if (isPosix()) {
     assertOwnedByCurrentUser(directory, stat.uid);
-    if ((stat.mode & 0o077) !== 0) {
+    if ((stat.mode & 0o777) !== CONFIG_DIRECTORY_MODE) {
       throw new Error(`Managed config directory permissions must be 0700: ${directory}`);
     }
   }
@@ -243,7 +243,7 @@ function assertSafeFileStat(path: string, stat: Stats): void {
   }
   if (isPosix()) {
     assertOwnedByCurrentUser(path, stat.uid);
-    if ((stat.mode & 0o177) !== 0) {
+    if ((stat.mode & 0o777) !== CONFIG_FILE_MODE) {
       throw new Error(`Managed config permissions must be 0600: ${path}`);
     }
   }

--- a/src/cli/managed-config.ts
+++ b/src/cli/managed-config.ts
@@ -75,8 +75,8 @@ const managedKeySet = new Set<string>(MANAGED_CONFIG_KEYS);
 export function managedConfigPath(options: ManagedConfigOptions = {}): string {
   return resolve(
     options.path
-      ?? process.env.HERMES_LIVE_CONFIG_FILE
-      ?? join(options.home ?? homedir(), ".hermes", "hermes-live", "config.env"),
+      || process.env.HERMES_LIVE_CONFIG_FILE
+      || join(options.home ?? homedir(), ".hermes", "hermes-live", "config.env"),
   );
 }
 

--- a/src/cli/managed-config.ts
+++ b/src/cli/managed-config.ts
@@ -1,0 +1,270 @@
+import { constants as fsConstants, type Stats } from "node:fs";
+import { chmod, lstat, mkdir, open, rename, rm } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { randomUUID } from "node:crypto";
+
+const MAX_CONFIG_BYTES = 64 * 1024;
+const MAX_VALUE_CHARS = 32 * 1024;
+const CONFIG_DIRECTORY_MODE = 0o700;
+const CONFIG_FILE_MODE = 0o600;
+
+export const MANAGED_CONFIG_KEYS = [
+  "GEMINI_API_KEY",
+  "GEMINI_MODEL",
+  "GOOGLE_API_KEY",
+  "GOOGLE_CLOUD_LOCATION",
+  "GOOGLE_CLOUD_PROJECT",
+  "GOOGLE_GENAI_API_VERSION",
+  "GOOGLE_GENAI_USE_ENTERPRISE",
+  "HERMES_AGENT_API_SERVER_KEY",
+  "HERMES_API_KEY",
+  "HERMES_BASE_URL",
+  "HERMES_LIVE_ALLOW_ORIGIN",
+  "HERMES_LIVE_ALLOW_UNAUTHENTICATED",
+  "HERMES_LIVE_AUTH_TOKEN",
+  "HERMES_LIVE_DEMO_ENABLED",
+  "HERMES_LIVE_HERMES_STREAM_IDLE_TIMEOUT_MS",
+  "HERMES_LIVE_HERMES_TIMEOUT_MS",
+  "HERMES_LIVE_HOST",
+  "HERMES_LIVE_MAX_AUDIO_BYTES",
+  "HERMES_LIVE_MAX_CONCURRENT_TASKS",
+  "HERMES_LIVE_MAX_QUEUED_TASKS",
+  "HERMES_LIVE_MAX_SESSIONS",
+  "HERMES_LIVE_MAX_TEXT_CHARS",
+  "HERMES_LIVE_PORT",
+  "HERMES_LIVE_PROFILE_ID",
+  "HERMES_LIVE_PROVIDER",
+  "HERMES_LIVE_PROVIDER_READY_TIMEOUT_MS",
+  "HERMES_LIVE_RUN_INSTRUCTIONS",
+  "HERMES_LIVE_SESSION_PREFIX",
+  "HERMES_LIVE_TASK_HISTORY_LIMIT",
+  "HERMES_LIVE_TASK_POLL_INTERVAL_MS",
+  "HERMES_LIVE_TASK_RETENTION_HOURS",
+  "HERMES_LIVE_TASK_STATE_FILE",
+  "HERMES_LIVE_TRUST_CLIENT_IDENTITY",
+  "HERMES_LIVE_TRUST_DECLARED_READ_ONLY",
+  "HERMES_LIVE_USER_LABEL",
+  "HERMES_MODEL",
+  "OPENAI_API_KEY",
+  "OPENAI_REALTIME_BASE_URL",
+  "OPENAI_REALTIME_INPUT_AUDIO_FORMAT",
+  "OPENAI_REALTIME_MODEL",
+  "OPENAI_REALTIME_OUTPUT_AUDIO_FORMAT",
+  "OPENAI_REALTIME_REASONING_EFFORT",
+  "OPENAI_REALTIME_TURN_DETECTION",
+  "OPENAI_REALTIME_VOICE",
+] as const;
+
+export type ManagedConfigKey = (typeof MANAGED_CONFIG_KEYS)[number];
+export type ManagedConfigValues = Partial<Record<ManagedConfigKey, string>>;
+
+export interface ManagedConfigReadResult {
+  path: string;
+  exists: boolean;
+  values: ManagedConfigValues;
+}
+
+export interface ManagedConfigOptions {
+  path?: string;
+  home?: string;
+}
+
+const managedKeySet = new Set<string>(MANAGED_CONFIG_KEYS);
+
+export function managedConfigPath(options: ManagedConfigOptions = {}): string {
+  return resolve(
+    options.path
+      ?? process.env.HERMES_LIVE_CONFIG_FILE
+      ?? join(options.home ?? homedir(), ".hermes", "hermes-live", "config.env"),
+  );
+}
+
+export async function applyManagedConfigToProcess(options: ManagedConfigOptions = {}): Promise<ManagedConfigReadResult> {
+  const result = await readManagedConfig(options);
+  for (const [key, value] of Object.entries(result.values)) {
+    if (process.env[key] === undefined) {
+      process.env[key] = value;
+    }
+  }
+  return result;
+}
+
+export async function resolvedManagedEnvironment(
+  env: NodeJS.ProcessEnv = process.env,
+  options: ManagedConfigOptions = {},
+): Promise<NodeJS.ProcessEnv> {
+  const result = await readManagedConfig(options);
+  return { ...result.values, ...env };
+}
+
+export async function readManagedConfig(options: ManagedConfigOptions = {}): Promise<ManagedConfigReadResult> {
+  const path = managedConfigPath(options);
+  const stat = await lstat(path).catch((error: NodeJS.ErrnoException) => {
+    if (error.code === "ENOENT") return undefined;
+    throw error;
+  });
+  if (!stat) {
+    return { path, exists: false, values: {} };
+  }
+  assertSafeFileStat(path, stat);
+  await assertSafeConfigDirectory(dirname(path));
+
+  const noFollow = "O_NOFOLLOW" in fsConstants ? fsConstants.O_NOFOLLOW : 0;
+  const handle = await open(path, fsConstants.O_RDONLY | noFollow);
+  try {
+    const openedStat = await handle.stat();
+    assertSafeFileStat(path, openedStat);
+    if (openedStat.size > MAX_CONFIG_BYTES) {
+      throw new Error(`Managed config exceeds ${MAX_CONFIG_BYTES} bytes: ${path}`);
+    }
+    return {
+      path,
+      exists: true,
+      values: parseManagedConfig(await handle.readFile({ encoding: "utf8" }), path),
+    };
+  } finally {
+    await handle.close();
+  }
+}
+
+export async function writeManagedConfig(
+  values: ManagedConfigValues,
+  options: ManagedConfigOptions = {},
+): Promise<string> {
+  const path = managedConfigPath(options);
+  const directory = dirname(path);
+  await prepareConfigDirectory(directory);
+  const body = serializeManagedConfig(values);
+  if (Buffer.byteLength(body) > MAX_CONFIG_BYTES) {
+    throw new Error(`Managed config exceeds ${MAX_CONFIG_BYTES} bytes.`);
+  }
+
+  const temporaryPath = join(directory, `.config.env.${process.pid}.${randomUUID()}.tmp`);
+  const handle = await open(temporaryPath, fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_WRONLY, CONFIG_FILE_MODE);
+  try {
+    await handle.writeFile(body, { encoding: "utf8" });
+    await handle.sync();
+  } catch (error) {
+    await handle.close().catch(() => undefined);
+    await rm(temporaryPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
+  await handle.close();
+  try {
+    await rename(temporaryPath, path);
+    await chmod(path, CONFIG_FILE_MODE);
+  } catch (error) {
+    await rm(temporaryPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
+  return path;
+}
+
+export function parseManagedConfig(source: string, sourceLabel = "managed config"): ManagedConfigValues {
+  if (Buffer.byteLength(source) > MAX_CONFIG_BYTES) {
+    throw new Error(`${sourceLabel} exceeds ${MAX_CONFIG_BYTES} bytes.`);
+  }
+  const values: ManagedConfigValues = {};
+  const seen = new Set<string>();
+  for (const [index, rawLine] of source.split(/\r?\n/u).entries()) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const separator = line.indexOf("=");
+    if (separator <= 0) {
+      throw new Error(`${sourceLabel}:${index + 1}: expected KEY=\"value\".`);
+    }
+    const key = line.slice(0, separator).trim();
+    if (!managedKeySet.has(key)) {
+      throw new Error(`${sourceLabel}:${index + 1}: ${key || "empty key"} is not a supported Hermes Live setting.`);
+    }
+    if (seen.has(key)) {
+      throw new Error(`${sourceLabel}:${index + 1}: duplicate setting ${key}.`);
+    }
+    const encoded = line.slice(separator + 1).trim();
+    let value: unknown;
+    try {
+      value = JSON.parse(encoded);
+    } catch {
+      throw new Error(`${sourceLabel}:${index + 1}: values must be JSON strings.`);
+    }
+    if (typeof value !== "string") {
+      throw new Error(`${sourceLabel}:${index + 1}: ${key} must be a string.`);
+    }
+    assertSafeValue(key, value);
+    values[key as ManagedConfigKey] = value;
+    seen.add(key);
+  }
+  return values;
+}
+
+export function serializeManagedConfig(values: ManagedConfigValues): string {
+  const lines = [
+    "# Hermes Live Voice managed configuration.",
+    "# Edit with `hermes-live setup`; process environment variables take precedence.",
+  ];
+  for (const key of MANAGED_CONFIG_KEYS) {
+    const value = values[key];
+    if (value === undefined) continue;
+    assertSafeValue(key, value);
+    lines.push(`${key}=${JSON.stringify(value)}`);
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+async function prepareConfigDirectory(directory: string): Promise<void> {
+  await mkdir(directory, { recursive: true, mode: CONFIG_DIRECTORY_MODE });
+  const stat = await lstat(directory);
+  if (stat.isSymbolicLink() || !stat.isDirectory()) {
+    throw new Error(`Managed config directory must be a real directory, not a symlink: ${directory}`);
+  }
+  if (isPosix()) {
+    assertOwnedByCurrentUser(directory, stat.uid);
+    await chmod(directory, CONFIG_DIRECTORY_MODE);
+  }
+}
+
+async function assertSafeConfigDirectory(directory: string): Promise<void> {
+  const stat = await lstat(directory);
+  if (stat.isSymbolicLink() || !stat.isDirectory()) {
+    throw new Error(`Managed config directory must be a real directory, not a symlink: ${directory}`);
+  }
+  if (isPosix()) {
+    assertOwnedByCurrentUser(directory, stat.uid);
+    if ((stat.mode & 0o077) !== 0) {
+      throw new Error(`Managed config directory permissions must be 0700: ${directory}`);
+    }
+  }
+}
+
+function assertSafeFileStat(path: string, stat: Stats): void {
+  if (stat.isSymbolicLink() || !stat.isFile()) {
+    throw new Error(`Managed config must be a regular file, not a symlink: ${path}`);
+  }
+  if (isPosix()) {
+    assertOwnedByCurrentUser(path, stat.uid);
+    if ((stat.mode & 0o177) !== 0) {
+      throw new Error(`Managed config permissions must be 0600: ${path}`);
+    }
+  }
+}
+
+function assertOwnedByCurrentUser(path: string, uid: number): void {
+  const currentUid = process.getuid?.();
+  if (currentUid !== undefined && uid !== currentUid) {
+    throw new Error(`Managed config must be owned by the current user: ${path}`);
+  }
+}
+
+function assertSafeValue(key: string, value: string): void {
+  if (value.length > MAX_VALUE_CHARS) {
+    throw new Error(`${key} exceeds ${MAX_VALUE_CHARS} characters.`);
+  }
+  if (value.includes("\u0000")) {
+    throw new Error(`${key} contains a NUL character.`);
+  }
+}
+
+function isPosix(): boolean {
+  return process.platform !== "win32";
+}

--- a/src/cli/plugin-installer.ts
+++ b/src/cli/plugin-installer.ts
@@ -1,0 +1,103 @@
+import { constants as fsConstants } from "node:fs";
+import { access, cp, lstat, mkdir, readlink, rm, symlink } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export interface PluginInstallOptions {
+  dir?: string;
+  mode?: "copy" | "symlink";
+  force?: boolean;
+}
+
+export interface PluginInstallStatus {
+  source: string;
+  target: string;
+  installed: boolean;
+  manifestFound: boolean;
+  symlink: boolean;
+  symlinkTarget?: string;
+  mode?: "copy" | "symlink";
+  enabledHint: string;
+}
+
+export async function installHermesPlugin(options: PluginInstallOptions = {}): Promise<PluginInstallStatus> {
+  const normalized = normalizePluginOptions(options);
+  const source = pluginSourceDir();
+  const target = pluginTargetDir(normalized);
+  await assertPluginSource(source);
+  await mkdir(dirname(target), { recursive: true });
+  const existing = await pluginInstallStatus(normalized);
+  if (existing.installed) {
+    if (!normalized.force) {
+      return { ...existing, mode: existing.symlink ? "symlink" : "copy" };
+    }
+    await rm(target, { recursive: true, force: true });
+  }
+
+  if (normalized.mode === "symlink") {
+    await symlink(source, target, process.platform === "win32" ? "junction" : "dir");
+  } else {
+    await cp(source, target, {
+      recursive: true,
+      filter: (path) => !path.includes("__pycache__") && !path.endsWith(".pyc"),
+    });
+  }
+  return { ...(await pluginInstallStatus(normalized)), mode: normalized.mode };
+}
+
+export async function pluginInstallStatus(options: PluginInstallOptions = {}): Promise<PluginInstallStatus> {
+  const normalized = normalizePluginOptions(options);
+  const source = pluginSourceDir();
+  const target = pluginTargetDir(normalized);
+  const stat = await lstat(target).catch(() => undefined);
+  const symlinkTarget = stat?.isSymbolicLink() ? await readlink(target).catch(() => undefined) : undefined;
+  return {
+    source,
+    target,
+    installed: Boolean(stat),
+    manifestFound: await fileExists(join(target, "plugin.yaml")),
+    symlink: Boolean(stat?.isSymbolicLink()),
+    ...(symlinkTarget ? { symlinkTarget } : {}),
+    enabledHint: "Run `hermes plugins enable hermes-live` after installation.",
+  };
+}
+
+export function pluginSourceDir(): string {
+  return join(packageRoot(), "plugins", "hermes-live");
+}
+
+export function pluginTargetDir(options: PluginInstallOptions = {}): string {
+  return join(hermesPluginsDir(options), "hermes-live");
+}
+
+export function hermesPluginsDir(options: PluginInstallOptions = {}): string {
+  return resolve(options.dir ?? process.env.HERMES_LIVE_HERMES_PLUGINS_DIR ?? join(homedir(), ".hermes", "plugins"));
+}
+
+export function packageRoot(): string {
+  return dirname(dirname(dirname(fileURLToPath(import.meta.url))));
+}
+
+function normalizePluginOptions(options: PluginInstallOptions): Required<Pick<PluginInstallOptions, "mode" | "force">> & Pick<PluginInstallOptions, "dir"> {
+  return {
+    mode: options.mode ?? "copy",
+    force: options.force ?? false,
+    ...(options.dir ? { dir: options.dir } : {}),
+  };
+}
+
+async function assertPluginSource(source: string): Promise<void> {
+  if (!(await fileExists(join(source, "plugin.yaml"))) || !(await fileExists(join(source, "__init__.py")))) {
+    throw new Error(`Hermes plugin source is incomplete: ${source}`);
+  }
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await access(path, fsConstants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/cli/process.ts
+++ b/src/cli/process.ts
@@ -1,0 +1,115 @@
+import { spawn } from "node:child_process";
+import { constants as fsConstants } from "node:fs";
+import { access } from "node:fs/promises";
+import { delimiter, join } from "node:path";
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_OUTPUT_BYTES = 256 * 1024;
+
+export interface CommandResult {
+  command: string;
+  args: string[];
+  code: number;
+  signal?: NodeJS.Signals;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+}
+
+export interface RunCommandOptions {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  timeoutMs?: number;
+  maxOutputBytes?: number;
+}
+
+export type CommandRunner = (
+  command: string,
+  args: string[],
+  options?: RunCommandOptions,
+) => Promise<CommandResult>;
+
+export const runCommand: CommandRunner = async (command, args, options = {}) => {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const maxOutputBytes = options.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES;
+  return await new Promise<CommandResult>((resolve) => {
+    const child = spawn(command, args, {
+      shell: false,
+      stdio: ["ignore", "pipe", "pipe"],
+      ...(options.cwd ? { cwd: options.cwd } : {}),
+      ...(options.env ? { env: options.env } : {}),
+    });
+    let stdout: Buffer<ArrayBufferLike> = Buffer.alloc(0);
+    let stderr: Buffer<ArrayBufferLike> = Buffer.alloc(0);
+    let timedOut = false;
+    let settled = false;
+
+    const append = (current: Buffer<ArrayBufferLike>, chunk: Buffer | string): Buffer<ArrayBufferLike> => {
+      if (current.byteLength >= maxOutputBytes) return current;
+      const next = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      return Buffer.concat([current, next.subarray(0, maxOutputBytes - current.byteLength)]);
+    };
+    child.stdout?.on("data", (chunk: Buffer) => {
+      stdout = append(stdout, chunk);
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr = append(stderr, chunk);
+    });
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGTERM");
+      setTimeout(() => child.kill("SIGKILL"), 1_000).unref();
+    }, timeoutMs);
+    timer.unref?.();
+
+    const finish = (code: number, signal?: NodeJS.Signals): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({
+        command,
+        args: [...args],
+        code,
+        ...(signal ? { signal } : {}),
+        stdout: stdout.toString("utf8"),
+        stderr: stderr.toString("utf8"),
+        timedOut,
+      });
+    };
+    child.on("error", (error: NodeJS.ErrnoException) => {
+      stderr = append(stderr, error.message);
+      finish(error.code === "ENOENT" ? 127 : 1);
+    });
+    child.on("close", (code, signal) => finish(code ?? (signal ? 1 : 0), signal ?? undefined));
+  });
+};
+
+export async function findExecutable(
+  name: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<string | undefined> {
+  if (name.includes("/") || (process.platform === "win32" && name.includes("\\"))) {
+    return await isExecutable(name) ? name : undefined;
+  }
+  const pathEntries = (env.PATH ?? "").split(delimiter).filter(Boolean);
+  const suffixes = process.platform === "win32"
+    ? (env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM").split(";")
+    : [""];
+  for (const directory of pathEntries) {
+    for (const suffix of suffixes) {
+      const candidate = join(directory, `${name}${suffix}`);
+      if (await isExecutable(candidate)) return candidate;
+    }
+  }
+  return undefined;
+}
+
+async function isExecutable(path: string): Promise<boolean> {
+  try {
+    await access(path, process.platform === "win32" ? fsConstants.F_OK : fsConstants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/cli/service-manager.ts
+++ b/src/cli/service-manager.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { access, chmod, lstat, mkdir, open, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { managedConfigPath } from "./managed-config.js";
@@ -6,6 +6,7 @@ import { packageRoot } from "./plugin-installer.js";
 import { runCommand, type CommandResult, type CommandRunner } from "./process.js";
 
 export const SERVICE_LABEL = "dev.hermes-live-voice.gateway";
+const MAX_SERVICE_LOG_BYTES = 256 * 1024;
 
 export type ServicePlatform = "launchd" | "systemd" | "unsupported";
 export type ServiceAction = "install" | "uninstall" | "start" | "stop" | "restart" | "status" | "logs";
@@ -92,7 +93,9 @@ export async function serviceStatus(options: ServiceManagerOptions = {}): Promis
   const result = resolved.platform === "launchd"
     ? await resolved.runner("launchctl", ["print", launchdDomain(resolved)])
     : await resolved.runner("systemctl", ["--user", "is-active", SERVICE_LABEL]);
-  const running = result.code === 0 && (resolved.platform === "launchd" || result.stdout.trim() === "active");
+  const running = result.code === 0 && (resolved.platform === "launchd"
+    ? /(?:^|\n)\s*state = running\s*(?:\n|$)/u.test(result.stdout)
+    : result.stdout.trim() === "active");
   return {
     platform: resolved.platform,
     definitionPath,
@@ -184,6 +187,7 @@ function resolveServiceOptions(options: ServiceManagerOptions = {}): ResolvedSer
     : platform === "systemd"
       ? join(home, ".config", "systemd", "user", `${SERVICE_LABEL}.service`)
       : undefined;
+  const uid = options.uid ?? process.getuid?.();
   const resolvedOptions: ResolvedServiceOptions = {
     home,
     platform,
@@ -191,7 +195,7 @@ function resolveServiceOptions(options: ServiceManagerOptions = {}): ResolvedSer
     cliPath: resolve(options.cliPath ?? join(packageRoot(), "dist", "cli.js")),
     configPath: managedConfigPath({ path: options.configPath, home }),
     ...(definitionPath ? { definitionPath } : {}),
-    ...(options.uid ?? process.getuid?.()) !== undefined ? { uid: options.uid ?? process.getuid?.() } : {},
+    ...(uid !== undefined ? { uid } : {}),
     runner: options.runner ?? runCommand,
   };
   assertSafeServicePath("home", resolvedOptions.home);
@@ -214,8 +218,8 @@ async function installService(options: ResolvedServiceOptions): Promise<void> {
   await chmod(definitionPath, 0o600);
 
   if (options.platform === "launchd") {
-    await options.runner("launchctl", ["bootout", `gui/${options.uid}`, definitionPath]).catch(() => undefined);
-    await expectSuccess(await options.runner("launchctl", ["bootstrap", `gui/${options.uid}`, definitionPath]));
+    await options.runner("launchctl", ["bootout", launchdUserDomain(options), definitionPath]).catch(() => undefined);
+    await expectSuccess(await options.runner("launchctl", ["bootstrap", launchdUserDomain(options), definitionPath]));
   } else {
     await expectSuccess(await options.runner("systemctl", ["--user", "daemon-reload"]));
     await expectSuccess(await options.runner("systemctl", ["--user", "enable", SERVICE_LABEL]));
@@ -225,7 +229,7 @@ async function installService(options: ResolvedServiceOptions): Promise<void> {
 async function uninstallService(options: ResolvedServiceOptions): Promise<void> {
   const definitionPath = options.definitionPath!;
   if (options.platform === "launchd") {
-    await options.runner("launchctl", ["bootout", `gui/${options.uid}`, definitionPath]);
+    await options.runner("launchctl", ["bootout", launchdUserDomain(options), definitionPath]);
   } else {
     await options.runner("systemctl", ["--user", "disable", "--now", SERVICE_LABEL]);
   }
@@ -236,7 +240,7 @@ async function uninstallService(options: ResolvedServiceOptions): Promise<void> 
 }
 
 async function startService(options: ResolvedServiceOptions): Promise<void> {
-  assertDefinitionInstalled(options);
+  await assertDefinitionInstalled(options);
   const result = options.platform === "launchd"
     ? await options.runner("launchctl", ["kickstart", "-k", launchdDomain(options)])
     : await options.runner("systemctl", ["--user", "start", SERVICE_LABEL]);
@@ -244,7 +248,7 @@ async function startService(options: ResolvedServiceOptions): Promise<void> {
 }
 
 async function stopService(options: ResolvedServiceOptions): Promise<void> {
-  assertDefinitionInstalled(options);
+  await assertDefinitionInstalled(options);
   const result = options.platform === "launchd"
     ? await options.runner("launchctl", ["kill", "SIGTERM", launchdDomain(options)])
     : await options.runner("systemctl", ["--user", "stop", SERVICE_LABEL]);
@@ -252,7 +256,7 @@ async function stopService(options: ResolvedServiceOptions): Promise<void> {
 }
 
 async function restartService(options: ResolvedServiceOptions): Promise<void> {
-  assertDefinitionInstalled(options);
+  await assertDefinitionInstalled(options);
   const result = options.platform === "launchd"
     ? await options.runner("launchctl", ["kickstart", "-k", launchdDomain(options)])
     : await options.runner("systemctl", ["--user", "restart", SERVICE_LABEL]);
@@ -263,10 +267,8 @@ async function serviceLogs(options: ServiceManagerOptions): Promise<CommandResul
   const resolved = resolveServiceOptions(options);
   assertSupported(resolved);
   if (resolved.platform === "launchd") {
-    const stdout = await readFile(join(resolved.home, ".hermes", "hermes-live", "logs", "gateway.log"), "utf8")
-      .catch(() => "");
-    const stderr = await readFile(join(resolved.home, ".hermes", "hermes-live", "logs", "gateway.error.log"), "utf8")
-      .catch(() => "");
+    const stdout = await readBoundedLogTail(join(resolved.home, ".hermes", "hermes-live", "logs", "gateway.log"));
+    const stderr = await readBoundedLogTail(join(resolved.home, ".hermes", "hermes-live", "logs", "gateway.error.log"));
     return {
       command: "launchd log files",
       args: [],
@@ -285,9 +287,9 @@ function assertSupported(options: ResolvedServiceOptions): void {
   }
 }
 
-function assertDefinitionInstalled(options: ResolvedServiceOptions): void {
-  if (!options.definitionPath) {
-    throw new Error("Service definition path is unavailable.");
+async function assertDefinitionInstalled(options: ResolvedServiceOptions): Promise<void> {
+  if (!options.definitionPath || !(await fileExists(options.definitionPath))) {
+    throw new Error("Gateway service is not installed. Run `hermes-live service install` or `hermes-live setup`.");
   }
 }
 
@@ -298,7 +300,12 @@ async function expectSuccess(result: CommandResult): Promise<void> {
 }
 
 function launchdDomain(options: ResolvedServiceOptions): string {
-  return `gui/${options.uid}/${SERVICE_LABEL}`;
+  return `${launchdUserDomain(options)}/${SERVICE_LABEL}`;
+}
+
+function launchdUserDomain(options: ResolvedServiceOptions): string {
+  if (options.uid === undefined) throw new Error("Could not determine the current user id for launchd.");
+  return `gui/${options.uid}`;
 }
 
 function commandDetail(result: CommandResult, fallback: string): string {
@@ -320,7 +327,7 @@ function xmlEscape(value: string): string {
 }
 
 function assertSafeServicePath(label: string, value: string): void {
-  if (/[ -]/u.test(value)) {
+  if (/[\u0000-\u001f\u007f]/u.test(value)) {
     throw new Error(`${label} path contains a control character.`);
   }
 }
@@ -331,9 +338,29 @@ function tailLines(value: string, count: number): string {
 
 async function fileExists(path: string): Promise<boolean> {
   try {
-    await readFile(path);
+    await access(path);
     return true;
   } catch {
     return false;
+  }
+}
+
+async function readBoundedLogTail(path: string): Promise<string> {
+  const fileStat = await lstat(path).catch((error: NodeJS.ErrnoException) => {
+    if (error.code === "ENOENT") return undefined;
+    throw error;
+  });
+  if (!fileStat) return "";
+  if (fileStat.isSymbolicLink() || !fileStat.isFile()) {
+    throw new Error(`Gateway log must be a regular file, not a symlink: ${path}`);
+  }
+  const length = Math.min(fileStat.size, MAX_SERVICE_LOG_BYTES);
+  const buffer = Buffer.alloc(length);
+  const handle = await open(path, "r");
+  try {
+    const { bytesRead } = await handle.read(buffer, 0, length, Math.max(0, fileStat.size - length));
+    return buffer.subarray(0, bytesRead).toString("utf8");
+  } finally {
+    await handle.close();
   }
 }

--- a/src/cli/service-manager.ts
+++ b/src/cli/service-manager.ts
@@ -95,6 +95,7 @@ export async function serviceStatus(options: ServiceManagerOptions = {}): Promis
     : await resolved.runner("systemctl", ["--user", "is-active", SERVICE_LABEL]);
   const running = result.code === 0 && (resolved.platform === "launchd"
     ? /(?:^|\n)\s*state = running\s*(?:\n|$)/u.test(result.stdout)
+      || /(?:^|\n)\s*pid = [1-9][0-9]*\s*(?:\n|$)/u.test(result.stdout)
     : result.stdout.trim() === "active");
   return {
     platform: resolved.platform,

--- a/src/cli/service-manager.ts
+++ b/src/cli/service-manager.ts
@@ -1,0 +1,339 @@
+import { chmod, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { managedConfigPath } from "./managed-config.js";
+import { packageRoot } from "./plugin-installer.js";
+import { runCommand, type CommandResult, type CommandRunner } from "./process.js";
+
+export const SERVICE_LABEL = "dev.hermes-live-voice.gateway";
+
+export type ServicePlatform = "launchd" | "systemd" | "unsupported";
+export type ServiceAction = "install" | "uninstall" | "start" | "stop" | "restart" | "status" | "logs";
+
+export interface ServiceManagerOptions {
+  home?: string;
+  platform?: NodeJS.Platform;
+  nodePath?: string;
+  cliPath?: string;
+  configPath?: string;
+  uid?: number;
+  runner?: CommandRunner;
+}
+
+export interface ServiceStatus {
+  platform: ServicePlatform;
+  definitionPath?: string;
+  installed: boolean;
+  running: boolean;
+  detail: string;
+}
+
+interface ResolvedServiceOptions {
+  home: string;
+  platform: ServicePlatform;
+  nodePath: string;
+  cliPath: string;
+  configPath: string;
+  definitionPath?: string;
+  uid?: number;
+  runner: CommandRunner;
+}
+
+export async function runServiceAction(
+  action: ServiceAction,
+  options: ServiceManagerOptions = {},
+): Promise<ServiceStatus | CommandResult> {
+  const resolved = resolveServiceOptions(options);
+  assertSupported(resolved);
+  switch (action) {
+    case "install":
+      await installService(resolved);
+      return await serviceStatus(options);
+    case "uninstall":
+      await uninstallService(resolved);
+      return await serviceStatus(options);
+    case "start":
+      await startService(resolved);
+      return await serviceStatus(options);
+    case "stop":
+      await stopService(resolved);
+      return await serviceStatus(options);
+    case "restart":
+      await restartService(resolved);
+      return await serviceStatus(options);
+    case "status":
+      return await serviceStatus(options);
+    case "logs":
+      return await serviceLogs(options);
+  }
+}
+
+export async function serviceStatus(options: ServiceManagerOptions = {}): Promise<ServiceStatus> {
+  const resolved = resolveServiceOptions(options);
+  if (resolved.platform === "unsupported") {
+    return {
+      platform: "unsupported",
+      installed: false,
+      running: false,
+      detail: "Managed services are available on macOS (launchd) and Linux (systemd user services).",
+    };
+  }
+  const definitionPath = resolved.definitionPath!;
+  const installed = await fileExists(definitionPath);
+  if (!installed) {
+    return {
+      platform: resolved.platform,
+      definitionPath,
+      installed: false,
+      running: false,
+      detail: "Service definition is not installed.",
+    };
+  }
+  const result = resolved.platform === "launchd"
+    ? await resolved.runner("launchctl", ["print", launchdDomain(resolved)])
+    : await resolved.runner("systemctl", ["--user", "is-active", SERVICE_LABEL]);
+  const running = result.code === 0 && (resolved.platform === "launchd" || result.stdout.trim() === "active");
+  return {
+    platform: resolved.platform,
+    definitionPath,
+    installed,
+    running,
+    detail: running ? "Gateway service is running." : commandDetail(result, "Gateway service is installed but not running."),
+  };
+}
+
+export function resolveServicePlatform(platform: NodeJS.Platform = process.platform): ServicePlatform {
+  if (platform === "darwin") return "launchd";
+  if (platform === "linux") return "systemd";
+  return "unsupported";
+}
+
+export function launchdServiceDefinition(options: ServiceManagerOptions = {}): string {
+  const resolved = resolveServiceOptions({ ...options, platform: "darwin" });
+  return renderLaunchdServiceDefinition(resolved);
+}
+
+function renderLaunchdServiceDefinition(resolved: ResolvedServiceOptions): string {
+  const logsDirectory = join(resolved.home, ".hermes", "hermes-live", "logs");
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${xmlEscape(SERVICE_LABEL)}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${xmlEscape(resolved.nodePath)}</string>
+    <string>${xmlEscape(resolved.cliPath)}</string>
+    <string>serve</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>HERMES_LIVE_CONFIG_FILE</key>
+    <string>${xmlEscape(resolved.configPath)}</string>
+  </dict>
+  <key>WorkingDirectory</key>
+  <string>${xmlEscape(resolved.home)}</string>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+  </dict>
+  <key>ThrottleInterval</key>
+  <integer>5</integer>
+  <key>StandardOutPath</key>
+  <string>${xmlEscape(join(logsDirectory, "gateway.log"))}</string>
+  <key>StandardErrorPath</key>
+  <string>${xmlEscape(join(logsDirectory, "gateway.error.log"))}</string>
+</dict>
+</plist>
+`;
+}
+
+export function systemdServiceDefinition(options: ServiceManagerOptions = {}): string {
+  const resolved = resolveServiceOptions({ ...options, platform: "linux" });
+  return renderSystemdServiceDefinition(resolved);
+}
+
+function renderSystemdServiceDefinition(resolved: ResolvedServiceOptions): string {
+  return `[Unit]
+Description=Hermes Live Voice gateway
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=${systemdEscape(resolved.nodePath)} ${systemdEscape(resolved.cliPath)} serve
+Environment=${systemdEscape(`HERMES_LIVE_CONFIG_FILE=${resolved.configPath}`)}
+WorkingDirectory=${systemdEscape(resolved.home)}
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+`;
+}
+
+function resolveServiceOptions(options: ServiceManagerOptions = {}): ResolvedServiceOptions {
+  const home = resolve(options.home ?? homedir());
+  const platform = resolveServicePlatform(options.platform);
+  const definitionPath = platform === "launchd"
+    ? join(home, "Library", "LaunchAgents", `${SERVICE_LABEL}.plist`)
+    : platform === "systemd"
+      ? join(home, ".config", "systemd", "user", `${SERVICE_LABEL}.service`)
+      : undefined;
+  const resolvedOptions: ResolvedServiceOptions = {
+    home,
+    platform,
+    nodePath: resolve(options.nodePath ?? process.execPath),
+    cliPath: resolve(options.cliPath ?? join(packageRoot(), "dist", "cli.js")),
+    configPath: managedConfigPath({ path: options.configPath, home }),
+    ...(definitionPath ? { definitionPath } : {}),
+    ...(options.uid ?? process.getuid?.()) !== undefined ? { uid: options.uid ?? process.getuid?.() } : {},
+    runner: options.runner ?? runCommand,
+  };
+  assertSafeServicePath("home", resolvedOptions.home);
+  assertSafeServicePath("Node executable", resolvedOptions.nodePath);
+  assertSafeServicePath("CLI", resolvedOptions.cliPath);
+  assertSafeServicePath("managed config", resolvedOptions.configPath);
+  return resolvedOptions;
+}
+
+async function installService(options: ResolvedServiceOptions): Promise<void> {
+  const definitionPath = options.definitionPath!;
+  await mkdir(dirname(definitionPath), { recursive: true, mode: 0o700 });
+  if (options.platform === "launchd") {
+    await mkdir(join(options.home, ".hermes", "hermes-live", "logs"), { recursive: true, mode: 0o700 });
+  }
+  const definition = options.platform === "launchd"
+    ? renderLaunchdServiceDefinition(options)
+    : renderSystemdServiceDefinition(options);
+  await writeFile(definitionPath, definition, { encoding: "utf8", mode: 0o600 });
+  await chmod(definitionPath, 0o600);
+
+  if (options.platform === "launchd") {
+    await options.runner("launchctl", ["bootout", `gui/${options.uid}`, definitionPath]).catch(() => undefined);
+    await expectSuccess(await options.runner("launchctl", ["bootstrap", `gui/${options.uid}`, definitionPath]));
+  } else {
+    await expectSuccess(await options.runner("systemctl", ["--user", "daemon-reload"]));
+    await expectSuccess(await options.runner("systemctl", ["--user", "enable", SERVICE_LABEL]));
+  }
+}
+
+async function uninstallService(options: ResolvedServiceOptions): Promise<void> {
+  const definitionPath = options.definitionPath!;
+  if (options.platform === "launchd") {
+    await options.runner("launchctl", ["bootout", `gui/${options.uid}`, definitionPath]);
+  } else {
+    await options.runner("systemctl", ["--user", "disable", "--now", SERVICE_LABEL]);
+  }
+  await rm(definitionPath, { force: true });
+  if (options.platform === "systemd") {
+    await options.runner("systemctl", ["--user", "daemon-reload"]);
+  }
+}
+
+async function startService(options: ResolvedServiceOptions): Promise<void> {
+  assertDefinitionInstalled(options);
+  const result = options.platform === "launchd"
+    ? await options.runner("launchctl", ["kickstart", "-k", launchdDomain(options)])
+    : await options.runner("systemctl", ["--user", "start", SERVICE_LABEL]);
+  await expectSuccess(result);
+}
+
+async function stopService(options: ResolvedServiceOptions): Promise<void> {
+  assertDefinitionInstalled(options);
+  const result = options.platform === "launchd"
+    ? await options.runner("launchctl", ["kill", "SIGTERM", launchdDomain(options)])
+    : await options.runner("systemctl", ["--user", "stop", SERVICE_LABEL]);
+  await expectSuccess(result);
+}
+
+async function restartService(options: ResolvedServiceOptions): Promise<void> {
+  assertDefinitionInstalled(options);
+  const result = options.platform === "launchd"
+    ? await options.runner("launchctl", ["kickstart", "-k", launchdDomain(options)])
+    : await options.runner("systemctl", ["--user", "restart", SERVICE_LABEL]);
+  await expectSuccess(result);
+}
+
+async function serviceLogs(options: ServiceManagerOptions): Promise<CommandResult> {
+  const resolved = resolveServiceOptions(options);
+  assertSupported(resolved);
+  if (resolved.platform === "launchd") {
+    const stdout = await readFile(join(resolved.home, ".hermes", "hermes-live", "logs", "gateway.log"), "utf8")
+      .catch(() => "");
+    const stderr = await readFile(join(resolved.home, ".hermes", "hermes-live", "logs", "gateway.error.log"), "utf8")
+      .catch(() => "");
+    return {
+      command: "launchd log files",
+      args: [],
+      code: 0,
+      stdout: tailLines(stdout, 200),
+      stderr: tailLines(stderr, 200),
+      timedOut: false,
+    };
+  }
+  return await resolved.runner("journalctl", ["--user-unit", SERVICE_LABEL, "--no-pager", "-n", "200"]);
+}
+
+function assertSupported(options: ResolvedServiceOptions): void {
+  if (options.platform === "unsupported") {
+    throw new Error("Managed services require macOS launchd or a Linux systemd user session. Run `hermes-live serve` manually on this platform.");
+  }
+}
+
+function assertDefinitionInstalled(options: ResolvedServiceOptions): void {
+  if (!options.definitionPath) {
+    throw new Error("Service definition path is unavailable.");
+  }
+}
+
+async function expectSuccess(result: CommandResult): Promise<void> {
+  if (result.code !== 0) {
+    throw new Error(commandDetail(result, `Command failed with exit code ${result.code}.`));
+  }
+}
+
+function launchdDomain(options: ResolvedServiceOptions): string {
+  return `gui/${options.uid}/${SERVICE_LABEL}`;
+}
+
+function commandDetail(result: CommandResult, fallback: string): string {
+  const detail = result.stderr.trim() || result.stdout.trim();
+  return detail ? `${fallback} ${detail}` : fallback;
+}
+
+function systemdEscape(value: string): string {
+  return `"${value.replaceAll("\\", "\\\\").replaceAll('"', '\\"').replaceAll("%", "%%")}"`;
+}
+
+function xmlEscape(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
+function assertSafeServicePath(label: string, value: string): void {
+  if (/[ -]/u.test(value)) {
+    throw new Error(`${label} path contains a control character.`);
+  }
+}
+
+function tailLines(value: string, count: number): string {
+  return value.split(/\r?\n/u).slice(-count).join("\n");
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await readFile(path);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -183,8 +183,10 @@ export async function runSetup(
       configPath,
       runner,
     };
-    await runServiceAction("install", serviceOptions);
-    service = await runServiceAction("start", serviceOptions) as ServiceStatus;
+    const installedService = await runServiceAction("install", serviceOptions) as ServiceStatus;
+    service = installedService.running
+      ? installedService
+      : await runServiceAction("start", serviceOptions) as ServiceStatus;
     gateway = await waitForGateway(config, dependencies);
   } else if (options.service) {
     service = { skipped: true, reason: "Service was not installed because the readiness preflight failed." };

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -359,8 +359,8 @@ async function waitForGateway(
         signal: AbortSignal.timeout(Math.min(2_000, Math.max(1, deadline - Date.now()))),
       });
       if (response.ok) {
-        const body = await response.json() as { ok?: boolean };
-        if (body.ok === true) return { checked: true, ready: true, url };
+        const body = await response.json() as { ok?: boolean; status?: string };
+        if (body.ok === true || body.status === "ready") return { checked: true, ready: true, url };
         lastError = "Gateway responded but its dependencies were not ready.";
       } else {
         lastError = `Gateway readiness returned HTTP ${response.status}.`;

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -171,7 +171,10 @@ export async function runSetup(
     url: `http://${config.server.host}:${config.server.port}/ready`,
   };
 
-  if (options.service && readiness.ok && providerSession.ok) {
+  const activationPreflightOk = readiness.ok
+    && providerSession.ok
+    && (hermesCli.enabled || hermesCli.skipped);
+  if (options.service && activationPreflightOk) {
     const serviceOptions = {
       home,
       platform: dependencies.platform,
@@ -387,11 +390,22 @@ async function readLegacyHermesEnvironment(home: string): Promise<Record<string,
   if (currentUid !== undefined && stat.uid !== currentUid) {
     throw new Error(`Hermes environment must be owned by the current user: ${path}`);
   }
+  if (process.platform !== "win32" && (stat.mode & 0o077) !== 0) {
+    throw new Error(`Hermes environment must not be readable or writable by other users: ${path}`);
+  }
   if (stat.size > MAX_LEGACY_ENV_BYTES) throw new Error(`Hermes environment exceeds ${MAX_LEGACY_ENV_BYTES} bytes.`);
   const noFollow = "O_NOFOLLOW" in fsConstants ? fsConstants.O_NOFOLLOW : 0;
   const handle = await open(path, fsConstants.O_RDONLY | noFollow);
   try {
-    const source = await handle.readFile("utf8");
+    const openedStat = await handle.stat();
+    if (!openedStat.isFile()) throw new Error(`Hermes environment must be a regular file: ${path}`);
+    if (currentUid !== undefined && openedStat.uid !== currentUid) {
+      throw new Error(`Hermes environment must be owned by the current user: ${path}`);
+    }
+    if (process.platform !== "win32" && (openedStat.mode & 0o077) !== 0) {
+      throw new Error(`Hermes environment must not be readable or writable by other users: ${path}`);
+    }
+    const source = await readBoundedFile(handle, MAX_LEGACY_ENV_BYTES, path);
     return parseLegacyEnvironment(source);
   } finally {
     await handle.close();
@@ -413,6 +427,7 @@ function parseLegacyEnvironment(source: string): Record<string, string | undefin
     "OPENAI_API_KEY",
   ]);
   const result: Record<string, string | undefined> = {};
+  const seen = new Set<string>();
   for (const raw of source.split(/\r?\n/u)) {
     const line = raw.trim();
     if (!line || line.startsWith("#")) continue;
@@ -421,9 +436,23 @@ function parseLegacyEnvironment(source: string): Record<string, string | undefin
     if (separator < 1) continue;
     const key = normalized.slice(0, separator).trim();
     if (!accepted.has(key)) continue;
+    if (seen.has(key)) throw new Error(`Hermes environment contains duplicate ${key}.`);
     result[key] = unquoteLegacyValue(normalized.slice(separator + 1).trim());
+    seen.add(key);
   }
   return result;
+}
+
+async function readBoundedFile(handle: Awaited<ReturnType<typeof open>>, maximumBytes: number, path: string): Promise<string> {
+  const buffer = Buffer.alloc(maximumBytes + 1);
+  let offset = 0;
+  while (offset < buffer.length) {
+    const { bytesRead } = await handle.read(buffer, offset, buffer.length - offset, offset);
+    if (bytesRead === 0) break;
+    offset += bytesRead;
+  }
+  if (offset > maximumBytes) throw new Error(`Hermes environment exceeds ${maximumBytes} bytes: ${path}`);
+  return buffer.subarray(0, offset).toString("utf8");
 }
 
 function unquoteLegacyValue(value: string): string {

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -1,0 +1,561 @@
+import { constants as fsConstants } from "node:fs";
+import { lstat, open } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { createInterface } from "node:readline/promises";
+import { stdin, stdout } from "node:process";
+import { loadConfig, type RealtimeProvider } from "../config.js";
+import { runLiveProviderSmoke } from "../live-provider-smoke.js";
+import { buildReadinessReport, type ReadinessReport } from "../readiness.js";
+import {
+  readManagedConfig,
+  MANAGED_CONFIG_KEYS,
+  writeManagedConfig,
+  type ManagedConfigValues,
+} from "./managed-config.js";
+import { installHermesPlugin, type PluginInstallStatus } from "./plugin-installer.js";
+import { findExecutable, runCommand, type CommandRunner } from "./process.js";
+import { runServiceAction, type ServiceStatus } from "./service-manager.js";
+
+const MAX_LEGACY_ENV_BYTES = 64 * 1024;
+const DEFAULT_GATEWAY_READY_TIMEOUT_MS = 15_000;
+
+export interface SetupOptions {
+  provider?: RealtimeProvider;
+  hermesUrl?: string;
+  configPath?: string;
+  pluginsDir?: string;
+  hermesCommand?: string;
+  enablePlugin: boolean;
+  service: boolean;
+  nonInteractive: boolean;
+  json: boolean;
+}
+
+export interface SetupReport {
+  ok: boolean;
+  config: { path: string; written: boolean };
+  provider: RealtimeProvider;
+  plugin: PluginInstallStatus;
+  hermesCli: {
+    command?: string;
+    enabled: boolean;
+    skipped: boolean;
+    error?: string;
+  };
+  readiness: ReadinessReport;
+  providerSession: { checked: boolean; ok: boolean; error?: string };
+  service: ServiceStatus | { skipped: true; reason: string };
+  gateway: { checked: boolean; ready: boolean; url: string; error?: string };
+  nextSteps: string[];
+}
+
+export interface SetupDependencies {
+  env?: NodeJS.ProcessEnv;
+  home?: string;
+  platform?: NodeJS.Platform;
+  nodePath?: string;
+  cliPath?: string;
+  runner?: CommandRunner;
+  findCommand?: (name: string, env: NodeJS.ProcessEnv) => Promise<string | undefined>;
+  prompt?: (message: string) => Promise<string>;
+  promptSecret?: (message: string) => Promise<string>;
+  fetch?: typeof globalThis.fetch;
+  gatewayReadyTimeoutMs?: number;
+}
+
+export function parseSetupOptions(args: string[]): SetupOptions {
+  const options: SetupOptions = {
+    enablePlugin: true,
+    service: true,
+    nonInteractive: false,
+    json: false,
+  };
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    const nextValue = (): string => {
+      const value = args[index + 1];
+      if (!value) throw new Error(`${argument} requires a value.`);
+      index += 1;
+      return value;
+    };
+    if (argument === "--provider") options.provider = parseProvider(nextValue());
+    else if (argument?.startsWith("--provider=")) options.provider = parseProvider(argument.slice(11));
+    else if (argument === "--hermes-url") options.hermesUrl = nextValue();
+    else if (argument?.startsWith("--hermes-url=")) options.hermesUrl = argument.slice(13);
+    else if (argument === "--config") options.configPath = nextValue();
+    else if (argument?.startsWith("--config=")) options.configPath = argument.slice(9);
+    else if (argument === "--plugins-dir") options.pluginsDir = nextValue();
+    else if (argument?.startsWith("--plugins-dir=")) options.pluginsDir = argument.slice(14);
+    else if (argument === "--hermes-command") options.hermesCommand = nextValue();
+    else if (argument?.startsWith("--hermes-command=")) options.hermesCommand = argument.slice(17);
+    else if (argument === "--no-enable") options.enablePlugin = false;
+    else if (argument === "--no-service") options.service = false;
+    else if (argument === "--non-interactive") options.nonInteractive = true;
+    else if (argument === "--json") options.json = true;
+    else if (argument === "--help" || argument === "-h") throw new SetupHelpRequested();
+    else if (argument) throw new Error(`Unknown setup option: ${argument}`);
+  }
+  return options;
+}
+
+export async function runSetup(
+  options: SetupOptions,
+  dependencies: SetupDependencies = {},
+): Promise<SetupReport> {
+  const env = dependencies.env ?? process.env;
+  const home = resolve(dependencies.home ?? homedir());
+  const runner = dependencies.runner ?? runCommand;
+  const findCommand = dependencies.findCommand ?? findExecutable;
+  const existing = await readManagedConfig({ path: options.configPath, home });
+  const legacy = await readLegacyHermesEnvironment(home);
+  const inherited = firstDefinedEnvironment(env, existing.values, legacy);
+  const provider = await selectProvider(options, inherited, dependencies);
+  const hermesApiKey = await requireSecret(
+    "Hermes API_SERVER_KEY: ",
+    inherited.HERMES_AGENT_API_SERVER_KEY ?? inherited.HERMES_API_KEY ?? legacy.API_SERVER_KEY,
+    options,
+    dependencies,
+  );
+  const values: ManagedConfigValues = {
+    ...managedValuesFromEnvironment(inherited),
+    HERMES_BASE_URL: options.hermesUrl ?? inherited.HERMES_BASE_URL ?? "http://127.0.0.1:8642",
+    HERMES_AGENT_API_SERVER_KEY: hermesApiKey,
+    HERMES_LIVE_PROVIDER: provider,
+    HERMES_LIVE_HOST: inherited.HERMES_LIVE_HOST ?? "127.0.0.1",
+    HERMES_LIVE_PORT: inherited.HERMES_LIVE_PORT ?? "8788",
+    HERMES_LIVE_DEMO_ENABLED: inherited.HERMES_LIVE_DEMO_ENABLED ?? "true",
+  };
+  delete values.HERMES_API_KEY;
+
+  if (provider === "gemini") {
+    if (isEnabled(inherited.GOOGLE_GENAI_USE_ENTERPRISE)) {
+      values.GOOGLE_GENAI_USE_ENTERPRISE = "true";
+      values.GOOGLE_CLOUD_PROJECT = await requireTextValue(
+        "Google Cloud project ID: ",
+        inherited.GOOGLE_CLOUD_PROJECT,
+        options,
+        dependencies,
+      );
+    } else {
+      values.GEMINI_API_KEY = await requireSecret(
+        "Gemini API key: ",
+        inherited.GEMINI_API_KEY ?? inherited.GOOGLE_API_KEY,
+        options,
+        dependencies,
+      );
+    }
+  } else if (provider === "openai") {
+    values.OPENAI_API_KEY = await requireSecret(
+      "OpenAI API key: ",
+      inherited.OPENAI_API_KEY,
+      options,
+      dependencies,
+    );
+  }
+
+  const configPath = await writeManagedConfig(values, { path: options.configPath, home });
+  const plugin = await installHermesPlugin({
+    ...(options.pluginsDir ? { dir: options.pluginsDir } : {}),
+    mode: "copy",
+    force: true,
+  });
+  const hermesCli = await enableHermesPlugin(options, env, runner, findCommand);
+  const config = loadConfig({ ...values, ...env });
+  const readiness = await buildReadinessReport(config);
+  const providerSession = await checkProviderSession(config);
+  let service: SetupReport["service"] = { skipped: true, reason: "Service installation was disabled." };
+  let gateway: SetupReport["gateway"] = {
+    checked: false,
+    ready: false,
+    url: `http://${config.server.host}:${config.server.port}/ready`,
+  };
+
+  if (options.service && readiness.ok && providerSession.ok) {
+    const serviceOptions = {
+      home,
+      platform: dependencies.platform,
+      nodePath: dependencies.nodePath,
+      cliPath: dependencies.cliPath,
+      configPath,
+      runner,
+    };
+    await runServiceAction("install", serviceOptions);
+    service = await runServiceAction("start", serviceOptions) as ServiceStatus;
+    gateway = await waitForGateway(config, dependencies);
+  } else if (options.service) {
+    service = { skipped: true, reason: "Service was not installed because the readiness preflight failed." };
+  }
+
+  const nextSteps = setupNextSteps({ options, readiness, providerSession, hermesCli, service, gateway });
+  const ok = readiness.ok
+    && providerSession.ok
+    && (hermesCli.enabled || hermesCli.skipped)
+    && (!options.service || (!("skipped" in service) && service.running && gateway.ready));
+  return {
+    ok,
+    config: { path: configPath, written: true },
+    provider,
+    plugin,
+    hermesCli,
+    readiness,
+    providerSession,
+    service,
+    gateway,
+    nextSteps,
+  };
+}
+
+export async function runSetupCommand(args: string[]): Promise<void> {
+  let options: SetupOptions;
+  try {
+    options = parseSetupOptions(args);
+  } catch (error) {
+    if (error instanceof SetupHelpRequested) {
+      printSetupHelp();
+      return;
+    }
+    throw error;
+  }
+  let report: SetupReport;
+  try {
+    report = await runSetup(options);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Setup failed.";
+    if (options.json) console.log(JSON.stringify({ ok: false, error: message }, null, 2));
+    else {
+      console.error(`Setup could not finish: ${message}`);
+      console.error("No API key was printed. Fix the issue and run `hermes-live setup` again.");
+    }
+    process.exitCode = 1;
+    return;
+  }
+  if (options.json) console.log(JSON.stringify(report, null, 2));
+  else printSetupReport(report);
+  if (!report.ok) process.exitCode = 1;
+}
+
+export function printSetupHelp(): void {
+  console.log(`hermes-live setup
+
+Configure voice, install the Hermes plugin, verify both runtimes, and start the gateway.
+
+Options:
+  --provider <gemini|openai|mock>  Realtime voice provider
+  --hermes-url <url>               Hermes API Server URL
+  --config <path>                  Managed config path
+  --plugins-dir <path>             Hermes plugins directory
+  --hermes-command <path>          Hermes executable to enable the plugin
+  --no-enable                      Install but do not enable the Hermes plugin
+  --no-service                     Configure only; run hermes-live serve manually
+  --non-interactive                Never prompt; fail when required values are missing
+  --json                           Print a machine-readable report
+
+API keys are read from the current environment, an existing managed config, or
+~/.hermes/.env. Setup prompts securely for missing keys; secret CLI flags are not accepted.
+`);
+}
+
+function printSetupReport(report: SetupReport): void {
+  console.log(report.ok ? "Hermes Live Voice is ready." : "Hermes Live Voice needs attention.");
+  console.log(`  Config: ${shortHome(report.config.path)}`);
+  console.log(`  Provider: ${report.provider}`);
+  console.log(`  Plugin: ${report.plugin.manifestFound ? "installed" : "missing"}`);
+  console.log(`  Hermes plugin: ${report.hermesCli.enabled ? "enabled" : report.hermesCli.skipped ? "skipped" : "not enabled"}`);
+  console.log(`  Hermes API: ${report.readiness.hermes.ok ? "ready" : "not ready"}`);
+  console.log(`  Voice provider: ${report.providerSession.ok ? report.providerSession.checked ? "verified" : "configured" : "not ready"}`);
+  console.log(`  Gateway: ${report.gateway.ready ? "ready" : report.gateway.checked ? "not ready" : "not started"}`);
+  if (report.nextSteps.length > 0) {
+    console.log("\nNext:");
+    for (const step of report.nextSteps) console.log(`  - ${step}`);
+  }
+}
+
+async function selectProvider(
+  options: SetupOptions,
+  inherited: Record<string, string | undefined>,
+  dependencies: SetupDependencies,
+): Promise<RealtimeProvider> {
+  if (options.provider) return options.provider;
+  const configured = inherited.HERMES_LIVE_PROVIDER;
+  if (configured === "gemini" || configured === "openai" || configured === "mock") return configured;
+  if (inherited.OPENAI_API_KEY && !inherited.GEMINI_API_KEY && !inherited.GOOGLE_API_KEY) return "openai";
+  if (options.nonInteractive) return "gemini";
+  const answer = (await (dependencies.prompt ?? promptText)("Voice provider [gemini/openai/mock] (gemini): ")).trim();
+  return answer ? parseProvider(answer) : "gemini";
+}
+
+async function requireSecret(
+  prompt: string,
+  existing: string | undefined,
+  options: SetupOptions,
+  dependencies: SetupDependencies,
+): Promise<string> {
+  if (existing) return existing;
+  if (options.nonInteractive) {
+    throw new Error(`${prompt.replace(/:\s*$/u, "")} is required in non-interactive mode.`);
+  }
+  const value = (await (dependencies.promptSecret ?? promptHidden)(prompt)).trim();
+  if (!value) throw new Error(`${prompt.replace(/:\s*$/u, "")} is required.`);
+  return value;
+}
+
+async function requireTextValue(
+  prompt: string,
+  existing: string | undefined,
+  options: SetupOptions,
+  dependencies: SetupDependencies,
+): Promise<string> {
+  if (existing) return existing;
+  if (options.nonInteractive) {
+    throw new Error(`${prompt.replace(/:\s*$/u, "")} is required in non-interactive mode.`);
+  }
+  const value = (await (dependencies.prompt ?? promptText)(prompt)).trim();
+  if (!value) throw new Error(`${prompt.replace(/:\s*$/u, "")} is required.`);
+  return value;
+}
+
+async function enableHermesPlugin(
+  options: SetupOptions,
+  env: NodeJS.ProcessEnv,
+  runner: CommandRunner,
+  findCommand: (name: string, env: NodeJS.ProcessEnv) => Promise<string | undefined>,
+): Promise<SetupReport["hermesCli"]> {
+  if (!options.enablePlugin) return { enabled: false, skipped: true };
+  const command = options.hermesCommand
+    ? await findCommand(options.hermesCommand, env)
+    : await findCommand("hermes", env);
+  if (!command) {
+    return {
+      enabled: false,
+      skipped: false,
+      error: "Hermes CLI was not found. Install Hermes or pass --hermes-command, then run `hermes plugins enable hermes-live`.",
+    };
+  }
+  const result = await runner(command, ["plugins", "enable", "hermes-live"], { env });
+  if (result.code !== 0) {
+    return {
+      command,
+      enabled: false,
+      skipped: false,
+      error: result.stderr.trim() || result.stdout.trim() || `Hermes exited with code ${result.code}.`,
+    };
+  }
+  return { command, enabled: true, skipped: false };
+}
+
+async function waitForGateway(
+  config: ReturnType<typeof loadConfig>,
+  dependencies: SetupDependencies,
+): Promise<SetupReport["gateway"]> {
+  const url = `http://${config.server.host}:${config.server.port}/ready`;
+  const timeoutMs = dependencies.gatewayReadyTimeoutMs ?? DEFAULT_GATEWAY_READY_TIMEOUT_MS;
+  const deadline = Date.now() + timeoutMs;
+  let lastError = "Gateway did not become ready.";
+  while (Date.now() < deadline) {
+    try {
+      const response = await (dependencies.fetch ?? globalThis.fetch)(url, {
+        headers: config.server.authToken ? { authorization: `Bearer ${config.server.authToken}` } : {},
+        signal: AbortSignal.timeout(Math.min(2_000, Math.max(1, deadline - Date.now()))),
+      });
+      if (response.ok) {
+        const body = await response.json() as { ok?: boolean };
+        if (body.ok === true) return { checked: true, ready: true, url };
+        lastError = "Gateway responded but its dependencies were not ready.";
+      } else {
+        lastError = `Gateway readiness returned HTTP ${response.status}.`;
+      }
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error);
+    }
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 250));
+  }
+  return { checked: true, ready: false, url, error: lastError };
+}
+
+async function readLegacyHermesEnvironment(home: string): Promise<Record<string, string | undefined>> {
+  const path = join(home, ".hermes", ".env");
+  const stat = await lstat(path).catch((error: NodeJS.ErrnoException) => {
+    if (error.code === "ENOENT") return undefined;
+    throw error;
+  });
+  if (!stat) return {};
+  if (stat.isSymbolicLink() || !stat.isFile()) {
+    throw new Error(`Hermes environment must be a regular file, not a symlink: ${path}`);
+  }
+  const currentUid = process.getuid?.();
+  if (currentUid !== undefined && stat.uid !== currentUid) {
+    throw new Error(`Hermes environment must be owned by the current user: ${path}`);
+  }
+  if (stat.size > MAX_LEGACY_ENV_BYTES) throw new Error(`Hermes environment exceeds ${MAX_LEGACY_ENV_BYTES} bytes.`);
+  const noFollow = "O_NOFOLLOW" in fsConstants ? fsConstants.O_NOFOLLOW : 0;
+  const handle = await open(path, fsConstants.O_RDONLY | noFollow);
+  try {
+    const source = await handle.readFile("utf8");
+    return parseLegacyEnvironment(source);
+  } finally {
+    await handle.close();
+  }
+}
+
+function parseLegacyEnvironment(source: string): Record<string, string | undefined> {
+  const accepted = new Set([
+    "API_SERVER_KEY",
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "HERMES_AGENT_API_SERVER_KEY",
+    "HERMES_API_KEY",
+    "HERMES_BASE_URL",
+    "HERMES_LIVE_DEMO_ENABLED",
+    "HERMES_LIVE_HOST",
+    "HERMES_LIVE_PORT",
+    "HERMES_LIVE_PROVIDER",
+    "OPENAI_API_KEY",
+  ]);
+  const result: Record<string, string | undefined> = {};
+  for (const raw of source.split(/\r?\n/u)) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const normalized = line.startsWith("export ") ? line.slice(7).trim() : line;
+    const separator = normalized.indexOf("=");
+    if (separator < 1) continue;
+    const key = normalized.slice(0, separator).trim();
+    if (!accepted.has(key)) continue;
+    result[key] = unquoteLegacyValue(normalized.slice(separator + 1).trim());
+  }
+  return result;
+}
+
+function unquoteLegacyValue(value: string): string {
+  if (value.length >= 2 && ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'")))) {
+    const inner = value.slice(1, -1);
+    return value.startsWith('"') ? inner.replaceAll("\\\"", '"').replaceAll("\\\\", "\\") : inner;
+  }
+  return value;
+}
+
+function firstDefinedEnvironment(
+  env: NodeJS.ProcessEnv,
+  managed: ManagedConfigValues,
+  legacy: Record<string, string | undefined>,
+): Record<string, string | undefined> {
+  const keys = new Set([...Object.keys(legacy), ...Object.keys(managed), ...Object.keys(env)]);
+  return Object.fromEntries([...keys].map((key) => [key, env[key] || managed[key as keyof ManagedConfigValues] || legacy[key]]));
+}
+
+function setupNextSteps(input: {
+  options: SetupOptions;
+  readiness: ReadinessReport;
+  providerSession: SetupReport["providerSession"];
+  hermesCli: SetupReport["hermesCli"];
+  service: SetupReport["service"];
+  gateway: SetupReport["gateway"];
+}): string[] {
+  const steps: string[] = [];
+  if (!input.hermesCli.enabled && !input.hermesCli.skipped) {
+    steps.push(input.hermesCli.error ?? "Run `hermes plugins enable hermes-live`.");
+  }
+  if (!input.readiness.hermes.ok) {
+    steps.push(`Start the Hermes API Server and fix its readiness error: ${String(input.readiness.hermes.error ?? "unavailable")}`);
+  }
+  if (!input.readiness.realtime.ok) {
+    steps.push(`Run \`hermes-live setup\` again with a working provider key: ${String(input.readiness.realtime.error ?? "provider unavailable")}`);
+  }
+  if (!input.providerSession.ok) {
+    steps.push(`Fix the realtime provider connection, then rerun \`hermes-live setup\`: ${input.providerSession.error ?? "connection failed"}`);
+  }
+  if (!input.options.service) {
+    steps.push("Start the gateway with `hermes-live serve`.");
+  } else if (!("skipped" in input.service) && !input.gateway.ready) {
+    steps.push("Run `hermes-live service logs`, then `hermes-live doctor`.");
+  }
+  if (input.readiness.ok && (input.hermesCli.enabled || input.hermesCli.skipped) && (input.gateway.ready || !input.options.service)) {
+    steps.push("Open `hermes dashboard` and choose Live Voice.");
+  }
+  return steps;
+}
+
+function parseProvider(value: string): RealtimeProvider {
+  if (value === "gemini" || value === "openai" || value === "mock") return value;
+  throw new Error(`Unsupported provider: ${value}. Choose gemini, openai, or mock.`);
+}
+
+async function checkProviderSession(config: ReturnType<typeof loadConfig>): Promise<SetupReport["providerSession"]> {
+  if (config.realtime.provider === "mock") return { checked: false, ok: true };
+  try {
+    await runLiveProviderSmoke(config, { timeoutMs: config.server.providerReadyTimeoutMs });
+    return { checked: true, ok: true };
+  } catch (error) {
+    return {
+      checked: true,
+      ok: false,
+      error: error instanceof Error ? error.message : "Realtime provider connection failed.",
+    };
+  }
+}
+
+function managedValuesFromEnvironment(values: Record<string, string | undefined>): ManagedConfigValues {
+  const managed: ManagedConfigValues = {};
+  for (const key of MANAGED_CONFIG_KEYS) {
+    if (values[key]) managed[key] = values[key];
+  }
+  return managed;
+}
+
+function isEnabled(value: string | undefined): boolean {
+  return value === "1" || value?.toLowerCase() === "true" || value?.toLowerCase() === "yes";
+}
+
+async function promptText(message: string): Promise<string> {
+  const readline = createInterface({ input: stdin, output: stdout });
+  try {
+    return await readline.question(message);
+  } finally {
+    readline.close();
+  }
+}
+
+async function promptHidden(message: string): Promise<string> {
+  if (!stdin.isTTY || !stdout.isTTY || typeof stdin.setRawMode !== "function") {
+    throw new Error("A required API key is missing and cannot be prompted without a TTY. Set it in the environment and rerun setup.");
+  }
+  stdout.write(message);
+  stdin.setRawMode(true);
+  stdin.resume();
+  return await new Promise<string>((resolveValue, reject) => {
+    let value = "";
+    const restore = (): void => {
+      stdin.off("data", onData);
+      stdin.setRawMode(false);
+      stdin.pause();
+      stdout.write("\n");
+    };
+    const onData = (chunk: Buffer): void => {
+      for (const byte of chunk) {
+        if (byte === 3) {
+          restore();
+          reject(new Error("Setup cancelled."));
+          return;
+        }
+        if (byte === 13 || byte === 10) {
+          restore();
+          resolveValue(value);
+          return;
+        }
+        if (byte === 127 || byte === 8) {
+          value = value.slice(0, -1);
+          continue;
+        }
+        if (byte >= 32 && byte <= 126) value += String.fromCharCode(byte);
+      }
+    };
+    stdin.on("data", onData);
+  });
+}
+
+function shortHome(path: string): string {
+  const home = homedir();
+  return path === home ? "~" : path.startsWith(`${home}/`) ? `~/${path.slice(home.length + 1)}` : path;
+}
+
+class SetupHelpRequested extends Error {}

--- a/test/dashboard-plugin.test.ts
+++ b/test/dashboard-plugin.test.ts
@@ -238,6 +238,15 @@ describe("Hermes Dashboard plugin", () => {
     expect(utilities.negotiatedInputAudio({}, staleStatusInput)).toMatchObject(staleStatusInput);
     expect(source).toContain("if (!supportsBrowserPlayback(outputAudio)) return audio;");
   });
+
+  it("turns gateway failures into exact setup and repair commands", () => {
+    const utilities = loadDashboardUtilities();
+
+    expect(utilities.gatewayPresentation({ configured: false }).detail).toContain("hermes-live setup");
+    expect(utilities.gatewayPresentation({ reachable: false }).detail).toContain("hermes-live service status");
+    expect(utilities.gatewayPresentation({ ready: false, error: "Hermes is offline." }).detail)
+      .toBe("Hermes is offline. Run hermes-live doctor for the exact fix.");
+  });
 });
 
 function dashboardSource(): string {
@@ -272,6 +281,7 @@ function loadDashboardUtilities(): Record<string, (...args: any[]) => any> {
       connectedSessionNotice,
       connectionClosedNotice,
       disconnectSession,
+      gatewayPresentation,
       isTaskActive,
       microphoneActiveGuidance,
       negotiatedInputAudio,

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -1,0 +1,106 @@
+import { createServer } from "node:http";
+import { rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { mkdtemp } from "node:fs/promises";
+import { afterEach, describe, expect, it } from "vitest";
+import { runDoctor } from "../src/cli/doctor.js";
+import { writeManagedConfig } from "../src/cli/managed-config.js";
+import { installHermesPlugin } from "../src/cli/plugin-installer.js";
+import type { CommandRunner } from "../src/cli/process.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+});
+
+describe("doctor", () => {
+  it("reports a healthy managed installation without leaking credentials", async () => {
+    const home = await temporaryHome();
+    const pluginsDir = join(home, ".hermes", "plugins");
+    const server = createServer((request, response) => {
+      response.setHeader("content-type", "application/json");
+      if (request.url === "/v1/capabilities") {
+        response.end(JSON.stringify({
+          features: {
+            run_submission: true,
+            run_status: true,
+            run_events_sse: true,
+            run_stop: true,
+            run_approval_response: true,
+          },
+        }));
+      } else {
+        response.statusCode = 404;
+        response.end("{}");
+      }
+    });
+    await new Promise<void>((resolveListen) => server.listen(0, "127.0.0.1", resolveListen));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("Expected TCP server.");
+    await writeManagedConfig({
+      HERMES_BASE_URL: `http://127.0.0.1:${address.port}`,
+      HERMES_AGENT_API_SERVER_KEY: "doctor-hermes-secret",
+      HERMES_LIVE_PROVIDER: "mock",
+    }, { home });
+    await installHermesPlugin({ dir: pluginsDir, force: true });
+    const runner: CommandRunner = async (command, args) => ({
+      command,
+      args,
+      code: 0,
+      stdout: args.includes("is-active") ? "active\n" : "",
+      stderr: "",
+      timedOut: false,
+    });
+    try {
+      const report = await runDoctor({
+        json: true,
+        providerSmoke: false,
+        pluginsDir,
+      }, {
+        home,
+        platform: "linux",
+        env: {},
+        runner,
+        findCommand: async () => "/usr/local/bin/hermes",
+        fetch: async () => new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      });
+
+      expect(report.ok).toBe(true);
+      expect(report.checks.map((check) => check.id)).toEqual(expect.arrayContaining([
+        "node", "config", "plugin", "hermes-cli", "hermes-api", "provider-config", "service", "gateway",
+      ]));
+      expect(JSON.stringify(report)).not.toContain("doctor-hermes-secret");
+    } finally {
+      await new Promise<void>((resolveClose, reject) => server.close((error) => error ? reject(error) : resolveClose()));
+    }
+  });
+
+  it("turns missing activation pieces into exact remediation", async () => {
+    const home = await temporaryHome();
+    const report = await runDoctor({ json: true, providerSmoke: false }, {
+      home,
+      platform: "win32",
+      env: { HERMES_LIVE_PROVIDER: "mock" },
+      nodeVersion: "18.20.0",
+      findCommand: async () => undefined,
+      fetch: async () => { throw new Error("offline"); },
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.checks.find((check) => check.id === "node")).toMatchObject({ status: "fail" });
+    expect(report.checks.find((check) => check.id === "config")).toMatchObject({ status: "warn", fix: "Run `hermes-live setup`." });
+    expect(report.checks.find((check) => check.id === "plugin")).toMatchObject({ status: "fail" });
+    expect(report.checks.find((check) => check.id === "service")).toMatchObject({ status: "warn" });
+  });
+});
+
+async function temporaryHome(): Promise<string> {
+  const path = await mkdtemp(join(tmpdir(), "hermes-live-doctor-"));
+  temporaryDirectories.push(path);
+  return path;
+}

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -64,7 +64,7 @@ describe("doctor", () => {
         env: {},
         runner,
         findCommand: async () => "/usr/local/bin/hermes",
-        fetch: async () => new Response(JSON.stringify({ ok: true }), {
+        fetch: async () => new Response(JSON.stringify({ status: "ready", checks: {} }), {
           status: 200,
           headers: { "content-type": "application/json" },
         }),

--- a/test/managed-config.test.ts
+++ b/test/managed-config.test.ts
@@ -42,6 +42,19 @@ describe("managed config", () => {
     expect(resolved.HERMES_LIVE_PROVIDER).toBe("gemini");
   });
 
+  it("treats an empty config-path environment override as unset", async () => {
+    const home = await temporaryHome();
+    const previous = process.env.HERMES_LIVE_CONFIG_FILE;
+    process.env.HERMES_LIVE_CONFIG_FILE = "";
+    try {
+      const path = await writeManagedConfig({ HERMES_LIVE_PROVIDER: "mock" }, { home });
+      expect(path).toBe(join(home, ".hermes", "hermes-live", "config.env"));
+    } finally {
+      if (previous === undefined) delete process.env.HERMES_LIVE_CONFIG_FILE;
+      else process.env.HERMES_LIVE_CONFIG_FILE = previous;
+    }
+  });
+
   it("rejects unapproved keys, duplicates, and non-string values", () => {
     expect(() => parseManagedConfig('NODE_OPTIONS="--import=evil"')).toThrow(/not a supported/u);
     expect(() => parseManagedConfig('HERMES_LIVE_PORT="8788"\nHERMES_LIVE_PORT="9999"')).toThrow(/duplicate/u);

--- a/test/managed-config.test.ts
+++ b/test/managed-config.test.ts
@@ -94,6 +94,13 @@ describe("managed config", () => {
     await expect(readManagedConfig({ home })).rejects.toThrow(/0700/u);
   });
 
+  it.runIf(process.platform !== "win32")("refuses incomplete owner permissions", async () => {
+    const home = await temporaryHome();
+    const path = await writeManagedConfig({ HERMES_LIVE_PROVIDER: "mock" }, { home });
+    await chmod(path, 0o400);
+    await expect(readManagedConfig({ home })).rejects.toThrow(/0600/u);
+  });
+
   it("refuses a symlinked config file", async () => {
     const home = await temporaryHome();
     const directory = join(home, ".hermes", "hermes-live");

--- a/test/managed-config.test.ts
+++ b/test/managed-config.test.ts
@@ -1,0 +1,100 @@
+import { chmod, mkdir, readFile, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { mkdtemp } from "node:fs/promises";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  parseManagedConfig,
+  readManagedConfig,
+  resolvedManagedEnvironment,
+  serializeManagedConfig,
+  writeManagedConfig,
+} from "../src/cli/managed-config.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  const { rm } = await import("node:fs/promises");
+  await Promise.all(temporaryDirectories.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+});
+
+describe("managed config", () => {
+  it("round-trips supported values without shell evaluation", async () => {
+    const home = await temporaryHome();
+    const values = {
+      HERMES_BASE_URL: "http://127.0.0.1:8642",
+      HERMES_AGENT_API_SERVER_KEY: "secret with spaces; $(touch /tmp/nope)",
+      HERMES_LIVE_PROVIDER: "mock",
+    } as const;
+
+    const path = await writeManagedConfig(values, { home });
+    expect(await readManagedConfig({ home })).toMatchObject({ exists: true, path, values });
+    expect(await readFile(path, "utf8")).toContain(JSON.stringify(values.HERMES_AGENT_API_SERVER_KEY));
+  });
+
+  it("lets the process environment override managed values", async () => {
+    const home = await temporaryHome();
+    await writeManagedConfig({ HERMES_LIVE_PORT: "8788", HERMES_LIVE_PROVIDER: "gemini" }, { home });
+
+    const resolved = await resolvedManagedEnvironment({ HERMES_LIVE_PORT: "9999" }, { home });
+
+    expect(resolved.HERMES_LIVE_PORT).toBe("9999");
+    expect(resolved.HERMES_LIVE_PROVIDER).toBe("gemini");
+  });
+
+  it("rejects unapproved keys, duplicates, and non-string values", () => {
+    expect(() => parseManagedConfig('NODE_OPTIONS="--import=evil"')).toThrow(/not a supported/u);
+    expect(() => parseManagedConfig('HERMES_LIVE_PORT="8788"\nHERMES_LIVE_PORT="9999"')).toThrow(/duplicate/u);
+    expect(() => parseManagedConfig("HERMES_LIVE_PORT=8788")).toThrow(/must be a string/u);
+  });
+
+  it("serializes keys in a stable allowlist order", () => {
+    const serialized = serializeManagedConfig({
+      OPENAI_API_KEY: "openai-secret",
+      HERMES_BASE_URL: "http://127.0.0.1:8642",
+    });
+
+    expect(serialized.indexOf("HERMES_BASE_URL")).toBeLessThan(serialized.indexOf("OPENAI_API_KEY"));
+    expect(parseManagedConfig(serialized)).toEqual({
+      HERMES_BASE_URL: "http://127.0.0.1:8642",
+      OPENAI_API_KEY: "openai-secret",
+    });
+  });
+
+  it.runIf(process.platform !== "win32")("creates private directories and files", async () => {
+    const home = await temporaryHome();
+    const path = await writeManagedConfig({ HERMES_LIVE_PROVIDER: "mock" }, { home });
+    const { stat } = await import("node:fs/promises");
+
+    expect((await stat(join(home, ".hermes", "hermes-live"))).mode & 0o777).toBe(0o700);
+    expect((await stat(path)).mode & 0o777).toBe(0o600);
+  });
+
+  it.runIf(process.platform !== "win32")("refuses permissive files and directories", async () => {
+    const home = await temporaryHome();
+    const path = await writeManagedConfig({ HERMES_LIVE_PROVIDER: "mock" }, { home });
+    await chmod(path, 0o644);
+    await expect(readManagedConfig({ home })).rejects.toThrow(/0600/u);
+
+    await chmod(path, 0o600);
+    await chmod(join(home, ".hermes", "hermes-live"), 0o755);
+    await expect(readManagedConfig({ home })).rejects.toThrow(/0700/u);
+  });
+
+  it("refuses a symlinked config file", async () => {
+    const home = await temporaryHome();
+    const directory = join(home, ".hermes", "hermes-live");
+    await mkdir(directory, { recursive: true, mode: 0o700 });
+    const target = join(home, "target.env");
+    await writeFile(target, 'HERMES_LIVE_PROVIDER="mock"\n', { mode: 0o600 });
+    await symlink(target, join(directory, "config.env"));
+
+    await expect(readManagedConfig({ home })).rejects.toThrow(/not a symlink/u);
+  });
+});
+
+async function temporaryHome(): Promise<string> {
+  const path = await mkdtemp(join(tmpdir(), "hermes-live-managed-config-"));
+  temporaryDirectories.push(path);
+  return path;
+}

--- a/test/process.test.ts
+++ b/test/process.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { findExecutable, runCommand } from "../src/cli/process.js";
+
+describe("CLI process runner", () => {
+  it("runs commands without a shell and captures bounded output", async () => {
+    const marker = "literal;$(not-a-command)";
+    const result = await runCommand(process.execPath, ["-e", "process.stdout.write(process.argv[1])", marker], {
+      maxOutputBytes: 8,
+    });
+
+    expect(result).toMatchObject({ code: 0, timedOut: false, stdout: marker.slice(0, 8) });
+  });
+
+  it("terminates commands that exceed their deadline", async () => {
+    const result = await runCommand(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { timeoutMs: 20 });
+
+    expect(result.timedOut).toBe(true);
+    expect(result.code).not.toBe(0);
+  });
+
+  it("finds executables from PATH and rejects missing commands", async () => {
+    const executable = await findExecutable(process.platform === "win32" ? "node.exe" : "node");
+
+    expect(executable).toBeTruthy();
+    await expect(findExecutable("definitely-not-a-real-hermes-live-command")).resolves.toBeUndefined();
+  });
+});

--- a/test/service-manager.test.ts
+++ b/test/service-manager.test.ts
@@ -110,6 +110,38 @@ describe("service manager", () => {
       running: false,
     });
   });
+
+  it("distinguishes a loaded launch agent from a running process", async () => {
+    const home = await temporaryHome();
+    const definition = join(home, "Library", "LaunchAgents", `${SERVICE_LABEL}.plist`);
+    await mkdir(join(home, "Library", "LaunchAgents"), { recursive: true });
+    const { writeFile } = await import("node:fs/promises");
+    await writeFile(definition, "definition");
+    const waiting = await serviceStatus({
+      home,
+      platform: "darwin",
+      uid: 501,
+      runner: async (command, args) => result(command, args, 0, "state = waiting\n"),
+    });
+    const running = await serviceStatus({
+      home,
+      platform: "darwin",
+      uid: 501,
+      runner: async (command, args) => result(command, args, 0, "state = running\n"),
+    });
+
+    expect(waiting.running).toBe(false);
+    expect(running.running).toBe(true);
+  });
+
+  it("refuses to start before the service is installed", async () => {
+    const home = await temporaryHome();
+    await expect(runServiceAction("start", {
+      home,
+      platform: "linux",
+      runner: async (command, args) => result(command, args, 0),
+    })).rejects.toThrow(/service is not installed/u);
+  });
 });
 
 function fakeRunner(

--- a/test/service-manager.test.ts
+++ b/test/service-manager.test.ts
@@ -129,9 +129,16 @@ describe("service manager", () => {
       uid: 501,
       runner: async (command, args) => result(command, args, 0, "state = running\n"),
     });
+    const starting = await serviceStatus({
+      home,
+      platform: "darwin",
+      uid: 501,
+      runner: async (command, args) => result(command, args, 0, "state = xpcproxy\npid = 4321\n"),
+    });
 
     expect(waiting.running).toBe(false);
     expect(running.running).toBe(true);
+    expect(starting.running).toBe(true);
   });
 
   it("refuses to start before the service is installed", async () => {

--- a/test/service-manager.test.ts
+++ b/test/service-manager.test.ts
@@ -1,0 +1,134 @@
+import { mkdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { mkdtemp } from "node:fs/promises";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  SERVICE_LABEL,
+  launchdServiceDefinition,
+  resolveServicePlatform,
+  runServiceAction,
+  serviceStatus,
+  systemdServiceDefinition,
+} from "../src/cli/service-manager.js";
+import type { CommandResult, CommandRunner } from "../src/cli/process.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+});
+
+describe("service manager", () => {
+  it("generates a secret-free launchd definition with absolute paths", () => {
+    const definition = launchdServiceDefinition({
+      home: "/Users/alice",
+      nodePath: "/usr/local/bin/node",
+      cliPath: "/usr/local/lib/hermes-live/dist/cli.js",
+      configPath: "/Users/alice/.hermes/hermes-live/config.env",
+    });
+
+    expect(definition).toContain(`<string>${SERVICE_LABEL}</string>`);
+    expect(definition).toContain("/usr/local/bin/node");
+    expect(definition).toContain("HERMES_LIVE_CONFIG_FILE");
+    expect(definition).toContain("<key>RunAtLoad</key>");
+    expect(definition).not.toContain("API_KEY=");
+  });
+
+  it("escapes systemd paths and restarts only on failure", () => {
+    const definition = systemdServiceDefinition({
+      home: "/home/a user",
+      nodePath: "/opt/node/bin/node",
+      cliPath: "/home/a user/hermes-live/dist/cli.js",
+      configPath: "/home/a user/.hermes/hermes-live/config.env",
+    });
+
+    expect(definition).toContain('ExecStart="/opt/node/bin/node" "/home/a user/hermes-live/dist/cli.js" serve');
+    expect(definition).toContain('Environment="HERMES_LIVE_CONFIG_FILE=/home/a user/.hermes/hermes-live/config.env"');
+    expect(definition).toContain("Restart=on-failure");
+    expect(definition).not.toContain("API_KEY=");
+  });
+
+  it("maps native platforms and rejects unsupported service actions", async () => {
+    expect(resolveServicePlatform("darwin")).toBe("launchd");
+    expect(resolveServicePlatform("linux")).toBe("systemd");
+    expect(resolveServicePlatform("win32")).toBe("unsupported");
+    await expect(runServiceAction("install", { platform: "win32" })).rejects.toThrow(/macOS launchd/u);
+  });
+
+  it("rejects service paths that could inject definition lines", () => {
+    expect(() => systemdServiceDefinition({ home: "/home/alice\nEnvironment=EVIL=1" })).toThrow(/control character/u);
+  });
+
+  it("installs, enables, and reports a systemd user service", async () => {
+    const home = await temporaryHome();
+    const calls: Array<[string, string[]]> = [];
+    const runner = fakeRunner(calls, (command, args) => {
+      if (command === "systemctl" && args.includes("is-active")) return result(command, args, 0, "active\n");
+      return result(command, args, 0);
+    });
+
+    const status = await runServiceAction("install", {
+      home,
+      platform: "linux",
+      nodePath: "/usr/bin/node",
+      cliPath: "/opt/hermes-live/dist/cli.js",
+      runner,
+    });
+
+    expect(status).toMatchObject({ platform: "systemd", installed: true, running: true });
+    expect(calls).toContainEqual(["systemctl", ["--user", "daemon-reload"]]);
+    expect(calls).toContainEqual(["systemctl", ["--user", "enable", SERVICE_LABEL]]);
+  });
+
+  it("bootstraps a launch agent in the current GUI domain", async () => {
+    const home = await temporaryHome();
+    const calls: Array<[string, string[]]> = [];
+    const runner = fakeRunner(calls, (command, args) => result(command, args, 0));
+
+    await runServiceAction("install", {
+      home,
+      platform: "darwin",
+      nodePath: "/usr/bin/node",
+      cliPath: "/opt/hermes-live/dist/cli.js",
+      uid: 501,
+      runner,
+    });
+
+    expect(calls.some(([command, args]) => command === "launchctl" && args[0] === "bootstrap" && args[1] === "gui/501"))
+      .toBe(true);
+  });
+
+  it("reports an absent service without invoking its manager", async () => {
+    const home = await temporaryHome();
+    const runner: CommandRunner = async () => {
+      throw new Error("runner should not be called");
+    };
+
+    await expect(serviceStatus({ home, platform: "linux", runner })).resolves.toMatchObject({
+      installed: false,
+      running: false,
+    });
+  });
+});
+
+function fakeRunner(
+  calls: Array<[string, string[]]>,
+  implementation: (command: string, args: string[]) => CommandResult,
+): CommandRunner {
+  return async (command, args) => {
+    calls.push([command, [...args]]);
+    return implementation(command, args);
+  };
+}
+
+function result(command: string, args: string[], code: number, stdout = "", stderr = ""): CommandResult {
+  return { command, args, code, stdout, stderr, timedOut: false };
+}
+
+async function temporaryHome(): Promise<string> {
+  const path = await mkdtemp(join(tmpdir(), "hermes-live-service-"));
+  temporaryDirectories.push(path);
+  await mkdir(path, { recursive: true });
+  return path;
+}

--- a/test/setup.test.ts
+++ b/test/setup.test.ts
@@ -113,6 +113,22 @@ describe("setup", () => {
     await expect(readManagedConfig({ home })).resolves.toMatchObject({ exists: false });
   });
 
+  it.runIf(process.platform !== "win32")("refuses a shared Hermes environment file", async () => {
+    const home = await temporaryHome();
+    await mkdir(join(home, ".hermes"), { recursive: true });
+    const path = join(home, ".hermes", ".env");
+    await writeFile(path, "API_SERVER_KEY=private\n", { mode: 0o644 });
+    await chmod(path, 0o644);
+
+    await expect(runSetup({
+      provider: "mock",
+      enablePlugin: false,
+      service: false,
+      nonInteractive: true,
+      json: true,
+    }, { home, env: {} })).rejects.toThrow(/must not be readable or writable by other users/u);
+  });
+
   it("installs a user service and waits for the gateway after preflight", async () => {
     const home = await temporaryHome();
     const server = createServer((request, response) => {
@@ -163,6 +179,52 @@ describe("setup", () => {
       expect(report.service).toMatchObject({ platform: "systemd", installed: true, running: true });
       expect(report.gateway).toMatchObject({ checked: true, ready: true });
       expect(calls).toContainEqual(["systemctl", ["--user", "start", "dev.hermes-live-voice.gateway"]]);
+    } finally {
+      await new Promise<void>((resolveClose, reject) => server.close((error) => error ? reject(error) : resolveClose()));
+    }
+  });
+
+  it("does not install a service when plugin enablement fails", async () => {
+    const home = await temporaryHome();
+    const server = createServer((request, response) => {
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({
+        features: {
+          run_submission: true,
+          run_status: true,
+          run_events_sse: true,
+          run_stop: true,
+          run_approval_response: true,
+        },
+      }));
+    });
+    await new Promise<void>((resolveListen) => server.listen(0, "127.0.0.1", resolveListen));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("Expected a TCP test server.");
+    const calls: Array<[string, string[]]> = [];
+    const runner: CommandRunner = async (command, args) => {
+      calls.push([command, [...args]]);
+      return { command, args, code: 1, stdout: "", stderr: "enable failed", timedOut: false };
+    };
+    try {
+      const report = await runSetup({
+        provider: "mock",
+        hermesUrl: `http://127.0.0.1:${address.port}`,
+        hermesCommand: process.execPath,
+        enablePlugin: true,
+        service: true,
+        nonInteractive: true,
+        json: true,
+      }, {
+        home,
+        platform: "linux",
+        env: { HERMES_AGENT_API_SERVER_KEY: "private" },
+        runner,
+      });
+
+      expect(report.ok).toBe(false);
+      expect(report.service).toMatchObject({ skipped: true });
+      expect(calls.some(([command]) => command === "systemctl")).toBe(false);
     } finally {
       await new Promise<void>((resolveClose, reject) => server.close((error) => error ? reject(error) : resolveClose()));
     }

--- a/test/setup.test.ts
+++ b/test/setup.test.ts
@@ -1,0 +1,180 @@
+import { createServer } from "node:http";
+import { chmod, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { mkdtemp } from "node:fs/promises";
+import { afterEach, describe, expect, it } from "vitest";
+import { readManagedConfig } from "../src/cli/managed-config.js";
+import { parseSetupOptions, runSetup } from "../src/cli/setup.js";
+import type { CommandResult, CommandRunner } from "../src/cli/process.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+});
+
+describe("setup", () => {
+  it("parses non-secret activation options and rejects key flags", () => {
+    expect(parseSetupOptions([
+      "--provider", "mock",
+      "--hermes-url=http://127.0.0.1:9999",
+      "--no-service",
+      "--non-interactive",
+      "--json",
+    ])).toMatchObject({
+      provider: "mock",
+      hermesUrl: "http://127.0.0.1:9999",
+      service: false,
+      nonInteractive: true,
+      json: true,
+    });
+    expect(() => parseSetupOptions(["--openai-api-key", "secret"])).toThrow(/Unknown setup option/u);
+  });
+
+  it("activates a clean home using Hermes .env without exposing secrets", async () => {
+    const home = await temporaryHome();
+    const pluginsDir = join(home, ".hermes", "plugins");
+    await mkdir(join(home, ".hermes"), { recursive: true, mode: 0o700 });
+    await writeFile(join(home, ".hermes", ".env"), "API_SERVER_KEY=hermes-private\n", { mode: 0o600 });
+    await chmod(join(home, ".hermes", ".env"), 0o600);
+    const server = createServer((request, response) => {
+      if (request.url === "/v1/capabilities") {
+        response.setHeader("content-type", "application/json");
+        response.end(JSON.stringify({
+          model: "hermes-agent",
+          features: {
+            run_submission: true,
+            run_status: true,
+            run_events_sse: true,
+            run_stop: true,
+            run_approval_response: true,
+          },
+        }));
+        return;
+      }
+      response.statusCode = 404;
+      response.end("not found");
+    });
+    await new Promise<void>((resolveListen) => server.listen(0, "127.0.0.1", resolveListen));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("Expected a TCP test server.");
+    const hermesCommand = join(home, "bin", "hermes");
+    await mkdir(join(home, "bin"), { recursive: true });
+    await writeFile(hermesCommand, "#!/bin/sh\nexit 0\n", { mode: 0o700 });
+    const calls: Array<[string, string[]]> = [];
+    const runner: CommandRunner = async (command, args) => {
+      calls.push([command, [...args]]);
+      return commandResult(command, args);
+    };
+
+    try {
+      const report = await runSetup({
+        provider: "mock",
+        hermesUrl: `http://127.0.0.1:${address.port}`,
+        pluginsDir,
+        hermesCommand,
+        enablePlugin: true,
+        service: false,
+        nonInteractive: true,
+        json: true,
+      }, {
+        home,
+        env: { PATH: join(home, "bin") },
+        runner,
+      });
+
+      expect(report.ok).toBe(true);
+      expect(report.hermesCli).toMatchObject({ enabled: true, command: hermesCommand });
+      expect(report.readiness.ok).toBe(true);
+      expect(report.providerSession).toEqual({ checked: false, ok: true });
+      expect(report.nextSteps).toContain("Start the gateway with `hermes-live serve`.");
+      expect(calls).toContainEqual([hermesCommand, ["plugins", "enable", "hermes-live"]]);
+      const managed = await readManagedConfig({ home });
+      expect(managed.values).toMatchObject({
+        HERMES_AGENT_API_SERVER_KEY: "hermes-private",
+        HERMES_LIVE_PROVIDER: "mock",
+      });
+      expect(JSON.stringify(report)).not.toContain("hermes-private");
+    } finally {
+      await new Promise<void>((resolveClose, reject) => server.close((error) => error ? reject(error) : resolveClose()));
+    }
+  });
+
+  it("fails non-interactively before writing when required secrets are absent", async () => {
+    const home = await temporaryHome();
+    await expect(runSetup({
+      provider: "openai",
+      enablePlugin: false,
+      service: false,
+      nonInteractive: true,
+      json: true,
+    }, { home, env: {} })).rejects.toThrow(/Hermes API_SERVER_KEY is required/u);
+    await expect(readManagedConfig({ home })).resolves.toMatchObject({ exists: false });
+  });
+
+  it("installs a user service and waits for the gateway after preflight", async () => {
+    const home = await temporaryHome();
+    const server = createServer((request, response) => {
+      response.setHeader("content-type", "application/json");
+      if (request.url === "/v1/capabilities") {
+        response.end(JSON.stringify({
+          features: {
+            run_submission: true,
+            run_status: true,
+            run_events_sse: true,
+            run_stop: true,
+            run_approval_response: true,
+          },
+        }));
+      } else {
+        response.statusCode = 404;
+        response.end("{}");
+      }
+    });
+    await new Promise<void>((resolveListen) => server.listen(0, "127.0.0.1", resolveListen));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("Expected a TCP test server.");
+    const calls: Array<[string, string[]]> = [];
+    const runner: CommandRunner = async (command, args) => {
+      calls.push([command, [...args]]);
+      return commandResult(command, args, command === "systemctl" && args.includes("is-active") ? "active\n" : "");
+    };
+    try {
+      const report = await runSetup({
+        provider: "mock",
+        hermesUrl: `http://127.0.0.1:${address.port}`,
+        enablePlugin: false,
+        service: true,
+        nonInteractive: true,
+        json: true,
+      }, {
+        home,
+        platform: "linux",
+        env: { HERMES_AGENT_API_SERVER_KEY: "private" },
+        runner,
+        fetch: async () => new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      });
+
+      expect(report.ok).toBe(true);
+      expect(report.service).toMatchObject({ platform: "systemd", installed: true, running: true });
+      expect(report.gateway).toMatchObject({ checked: true, ready: true });
+      expect(calls).toContainEqual(["systemctl", ["--user", "start", "dev.hermes-live-voice.gateway"]]);
+    } finally {
+      await new Promise<void>((resolveClose, reject) => server.close((error) => error ? reject(error) : resolveClose()));
+    }
+  });
+});
+
+function commandResult(command: string, args: string[], stdout = ""): CommandResult {
+  return { command, args, code: 0, stdout, stderr: "", timedOut: false };
+}
+
+async function temporaryHome(): Promise<string> {
+  const path = await mkdtemp(join(tmpdir(), "hermes-live-setup-"));
+  temporaryDirectories.push(path);
+  return path;
+}

--- a/test/setup.test.ts
+++ b/test/setup.test.ts
@@ -152,9 +152,17 @@ describe("setup", () => {
     const address = server.address();
     if (!address || typeof address === "string") throw new Error("Expected a TCP test server.");
     const calls: Array<[string, string[]]> = [];
+    let serviceStarted = false;
     const runner: CommandRunner = async (command, args) => {
       calls.push([command, [...args]]);
-      return commandResult(command, args, command === "systemctl" && args.includes("is-active") ? "active\n" : "");
+      if (command === "systemctl" && args.includes("start")) serviceStarted = true;
+      if (command === "systemctl" && args.includes("is-active")) {
+        return {
+          ...commandResult(command, args, serviceStarted ? "active\n" : "inactive\n"),
+          code: serviceStarted ? 0 : 3,
+        };
+      }
+      return commandResult(command, args);
     };
     try {
       const report = await runSetup({

--- a/test/setup.test.ts
+++ b/test/setup.test.ts
@@ -153,7 +153,7 @@ describe("setup", () => {
         platform: "linux",
         env: { HERMES_AGENT_API_SERVER_KEY: "private" },
         runner,
-        fetch: async () => new Response(JSON.stringify({ ok: true }), {
+        fetch: async () => new Response(JSON.stringify({ status: "ready", checks: {} }), {
           status: 200,
           headers: { "content-type": "application/json" },
         }),


### PR DESCRIPTION
## Why

Hermes Live Voice already keeps conversation responsive while Hermes runs durable background work, but v0.5 still required users to install a plugin, assemble environment variables, and supervise a second process manually. v0.6 makes the project usable as a normal local product.

## What changed

- add `hermes-live setup` with private managed configuration, secure credential reuse/prompting, matching plugin install/enablement, Hermes/provider preflight, and gateway readiness
- add native launchd and systemd user-service lifecycle commands
- add `hermes-live doctor` with exact remediation and optional live-provider verification
- make setup the primary README/plugin/Dashboard/support path
- add a clean packed-package activation smoke covering setup, permissions, plugin parity, gateway startup, and doctor
- prepare package, plugin, Dashboard, and changelog metadata for v0.6.0

Protocol v3 and the durable task contract are unchanged.

## Verification

- `npm run verify` — 32 files / 579 tests plus docs, plugin, Dashboard, browser, CLI, gateway, and packed-package smokes
- `npm audit --audit-level=moderate` — 0 vulnerabilities
- final Docker image build and built-image gateway smoke
- clean packed npm install: setup, private config, exact v0.6 plugin, gateway, and doctor
- official Hermes Agent v0.18.2 pinned image: capabilities, real run submission/start/completion, retained exact output
- OpenAI Realtime `gpt-realtime-2.1`: real connect/open/clean close
- real macOS launchd: install/bootstrap, readiness, status, restart, bounded logs, and uninstall

## Security and compatibility

Managed configuration is allowlisted, atomically written, private on POSIX, never sourced as shell, and refuses symlinks, unsafe ownership/modes, duplicate or unexpected keys, oversized input, and non-string values. Process environment still has precedence. Service definitions contain only absolute runtime paths and the managed-config path, never API keys. Existing environment-only and manual/Docker operation remains supported.