### PR TITLE
fix: allow repeated new voice chats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 0.7.1 - 2026-07-20
+
+- Stop Dashboard and terminal clients from reusing fixed titles for every new Hermes chat. Fresh voice sessions can now be created repeatedly without Hermes rejecting a duplicate title.
+
 ## 0.7.0 - 2026-07-19
 
 - Bind each protocol v4 voice session to a real persisted Hermes conversation. Dashboard and terminal users can start a new chat or resume an existing session, including its current writable compression tip, while protocol v3 remains available as an unbound compatibility mode.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hermes-live-voice",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes-live-voice",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
         "@google/genai": "2.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-live-voice",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Real-time voice for Hermes Agent—continue any chat while durable tasks work in the background.",
   "type": "module",
   "main": "./dist/index.js",

--- a/plugins/hermes-live/dashboard/dist/index.js
+++ b/plugins/hermes-live/dashboard/dist/index.js
@@ -587,7 +587,7 @@
       primePlaybackFromGesture();
       runAction("connect", function () {
         const conversation = conversationId === "new"
-          ? { mode: "new", title: "Live Voice" }
+          ? { mode: "new" }
           : { mode: "resume", sessionId: conversationId };
         return client.connect({ conversation: conversation }).then(function () {
           if (ensureAudioRef.current) ensureAudioRef.current();

--- a/plugins/hermes-live/dashboard/manifest.json
+++ b/plugins/hermes-live/dashboard/manifest.json
@@ -3,7 +3,7 @@
   "label": "Live Voice",
   "description": "Continue any Hermes chat by voice while durable background tasks keep working and report back.",
   "icon": "Zap",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "tab": {
     "path": "/live-voice",
     "position": "after:chat"

--- a/plugins/hermes-live/plugin.yaml
+++ b/plugins/hermes-live/plugin.yaml
@@ -1,5 +1,5 @@
 name: hermes-live
-version: 0.7.0
+version: 0.7.1
 description: "Continue any Hermes chat by voice while durable background tasks keep working and report back."
 author: Biel Carpi and Hermes Live contributors
 kind: standalone

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -305,7 +305,7 @@ Plugin options:
 
 function parseTerminalConversation(args: string[]): ConversationSelection {
   if (args.length === 0 || (args.length === 1 && args[0] === "--new")) {
-    return { mode: "new", title: "Terminal" };
+    return { mode: "new" };
   }
   if (args.length === 1 && args[0] === "--unbound") return { mode: "unbound" };
   if (args.length === 2 && args[0] === "--resume") {

--- a/src/cli/terminal-session.ts
+++ b/src/cli/terminal-session.ts
@@ -115,7 +115,7 @@ export class TerminalGatewaySession {
     this.userLabel = sanitizeMetadata(options.userLabel ?? process.env.USER ?? "terminal");
     this.connectTimeoutMs = positiveInteger(options.connectTimeoutMs, DEFAULT_CONNECT_TIMEOUT_MS);
     this.onLine = options.onLine ?? ((line) => process.stdout.write(`${line}\n`));
-    this.conversationSelection = options.conversation ?? { mode: "new", title: "Terminal" };
+    this.conversationSelection = options.conversation ?? { mode: "new" };
     this.closed = new Promise<void>((resolve) => {
       this.resolveClosed = resolve;
     });

--- a/test/dashboard-plugin.test.ts
+++ b/test/dashboard-plugin.test.ts
@@ -55,6 +55,8 @@ describe("Hermes Dashboard plugin", () => {
 
     expect(source).toContain("Start a new chat");
     expect(source).toContain("Continue a saved chat or start a fresh one.");
+    expect(source).toContain('? { mode: "new" }');
+    expect(source).not.toContain('{ mode: "new", title: "Live Voice" }');
     expect(source).toContain('{ mode: "resume", sessionId: conversationId }');
     expect(source).toContain("client.connect({ conversation: conversation })");
   });

--- a/test/terminal-client.test.ts
+++ b/test/terminal-client.test.ts
@@ -78,6 +78,7 @@ describe("TerminalGatewaySession protocol v4", () => {
       profileId: "terminal",
       userLabel: "test-user",
     });
+    expect(received[0]?.conversation).toEqual({ mode: "new" });
     expect(session.snapshot).toMatchObject({
       connected: true,
       sessionId: "live_terminal_test",


### PR DESCRIPTION
## What changed

- stop the Dashboard and terminal from assigning the same fixed title to every new Hermes chat
- add regression coverage for both clients
- prepare patch release 0.7.1

## Why

Hermes requires session titles to be unique. The first Dashboard connection created a chat titled Live Voice, then later attempts to start a new chat were rejected as duplicate titles and appeared as an immediate disconnect.

Fresh sessions now omit a fixed title. Hermes can create them repeatedly, and the saved-chat picker falls back to conversation preview or session ID.

## Verification

- npm run verify
- npm audit --audit-level=moderate
- npm pack --dry-run
- real OpenAI Realtime Dashboard connection through the authenticated Hermes proxy, repeated twice
- direct protocol v4 new-chat handshake, repeated twice