### PR TITLE
chore: release v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-## 0.9.0 - 2026-08-05
+## 0.9.1 - 2026-08-05
 
 - Make `hermes-live setup` the complete install path. It now configures Hermes' private API bridge, installs the Dashboard plugin, starts both services, waits for them to become ready, and warms a real task call. Custom and remote Hermes deployments remain operator-managed.
 - Run the tested Hugging Face speech-to-speech stack as a private Apple Silicon service. Setup owns its install, startup, endpoint selection, health checks, log limits, retries, and removal when switching providers; a second terminal is no longer part of the normal workflow.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hermes-live-voice",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes-live-voice",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "@google/genai": "2.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-live-voice",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Real-time voice for Hermes Agent—continue any chat while durable tasks work in the background.",
   "type": "module",
   "main": "./dist/index.js",

--- a/plugins/hermes-live/dashboard/manifest.json
+++ b/plugins/hermes-live/dashboard/manifest.json
@@ -3,7 +3,7 @@
   "label": "Live Voice",
   "description": "Continue any Hermes chat by voice while durable background tasks keep working and report back.",
   "icon": "Zap",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "tab": {
     "path": "/live-voice",
     "position": "after:chat"

--- a/plugins/hermes-live/plugin.yaml
+++ b/plugins/hermes-live/plugin.yaml
@@ -1,5 +1,5 @@
 name: hermes-live
-version: 0.9.0
+version: 0.9.1
 description: "Continue any Hermes chat by voice while durable background tasks keep working and report back."
 author: Biel Carpi and Hermes Live contributors
 kind: standalone


### PR DESCRIPTION
Publishes the corrected release candidate as v0.9.1 because repository rules preserve the earlier failed v0.9.0 tag.

No v0.9.0 GitHub release or npm package was created. v0.9.1 contains the full continuous/self-managing voice release plus the deterministic hydration fixture.

Validation:
- npm run verify: 37 files, 733 tests
- npm audit --audit-level=moderate: 0 vulnerabilities
- package activation and CLI smoke: hermes-live-voice-0.9.1.tgz, 248 files