### PR TITLE
Release v0.9.5 dependency refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 0.9.5 - 2026-08-12
 
-- Refresh the pinned Node 22 image, WebSocket and Gemini SDKs, TypeScript runner, and CodeQL action. All compatibility, security, Linux, and Windows checks pass with the new dependency set.
+- Refresh the pinned Node 22 image, WebSocket and Gemini SDKs, TypeScript runner, and CodeQL action. The production image now installs dependencies once and prunes development tools for the runtime layer. All compatibility, security, Linux, and Windows checks pass with this dependency set.
 
 ## 0.9.4 - 2026-08-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 0.9.5 - 2026-08-12
+
+- Refresh the pinned Node 22 image, WebSocket and Gemini SDKs, TypeScript runner, and CodeQL action. All compatibility, security, Linux, and Windows checks pass with the new dependency set.
+
 ## 0.9.4 - 2026-08-11
 
 - Test the bundled plugin and required API capabilities against the official Hermes Agent v0.20.0 image. Add scheduled and release compatibility gates. The doctor now checks the installed Hermes version.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:22-slim@sha256:d649c27dae7ba0137b3cef5dd75baa422c08dc3d9e3fc0c23dfb172dc3cc6436 AS deps
 WORKDIR /app
 COPY package.json package-lock.json* ./
-RUN npm ci --ignore-scripts \
+RUN npm ci --ignore-scripts --no-audit --no-fund \
     && npm cache clean --force
 
 FROM node:22-slim@sha256:d649c27dae7ba0137b3cef5dd75baa422c08dc3d9e3fc0c23dfb172dc3cc6436 AS build
@@ -18,7 +18,8 @@ ENV NODE_ENV=production \
     NPM_CONFIG_FUND=false \
     NPM_CONFIG_UPDATE_NOTIFIER=false
 COPY package.json package-lock.json* ./
-RUN npm ci --omit=dev --ignore-scripts \
+COPY --from=deps /app/node_modules ./node_modules
+RUN npm prune --omit=dev --ignore-scripts --no-audit --no-fund \
     && npm cache clean --force
 COPY LICENSE ./LICENSE
 COPY --from=build /app/dist ./dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hermes-live-voice",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes-live-voice",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "license": "MIT",
       "dependencies": {
         "@google/genai": "2.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-live-voice",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Real-time voice control for Hermes Agent—keep talking while Hermes works in the background.",
   "type": "module",
   "main": "./dist/index.js",

--- a/plugins/hermes-live/dashboard/manifest.json
+++ b/plugins/hermes-live/dashboard/manifest.json
@@ -3,7 +3,7 @@
   "label": "Live Voice",
   "description": "Real-time voice control for Hermes Agent while background work runs and reports back.",
   "icon": "Zap",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "tab": {
     "path": "/live-voice",
     "position": "after:chat"

--- a/plugins/hermes-live/plugin.yaml
+++ b/plugins/hermes-live/plugin.yaml
@@ -1,5 +1,5 @@
 name: hermes-live
-version: 0.9.4
+version: 0.9.5
 description: "Real-time voice control for Hermes Agent while background work runs and reports back."
 author: Biel Carpi and Hermes Live contributors
 kind: standalone


### PR DESCRIPTION
## What changed

- Publish the dependency updates that passed protected checks after v0.9.4.
- Reuse one installed dependency tree in the production image and prune development tools from the runtime layer.
- Prepare v0.9.5 package and plugin metadata.

## Verified

- npm run verify
- npm run check:hermes-compatibility
- npm audit --audit-level=moderate
- no-cache production Docker build
- runtime dependency and dev-pruning probes
- Docker gateway smoke