### PR TITLE
fix(gemini): prevent duplicate audio chunks caused by overlapping parts aliases

### DIFF
--- a/src/adapters/outbound/realtime/gemini-live.adapter.ts
+++ b/src/adapters/outbound/realtime/gemini-live.adapter.ts
@@ -421,15 +421,16 @@ function extractToolCallCancellationIds(root: any): string[] | undefined {
 }
 
 function extractParts(root: any): any[] {
-  return [
-    root?.serverContent?.modelTurn?.parts,
-    root?.server_content?.model_turn?.parts,
-    root?.modelTurn?.parts,
-    root?.content?.parts,
-    root?.parts,
-  ]
-    .flat()
-    .filter(Boolean);
+  const parts = root?.serverContent?.modelTurn?.parts ??
+    root?.server_content?.model_turn?.parts ??
+    root?.modelTurn?.parts ??
+    root?.content?.parts ??
+    root?.parts;
+    
+  if (Array.isArray(parts)) {
+    return parts.filter(Boolean);
+  }
+  return [];
 }
 
 function normalizeArgs(value: unknown): Record<string, unknown> {

--- a/src/adapters/outbound/realtime/gemini-live.adapter.ts
+++ b/src/adapters/outbound/realtime/gemini-live.adapter.ts
@@ -421,15 +421,22 @@ function extractToolCallCancellationIds(root: any): string[] | undefined {
 }
 
 function extractParts(root: any): any[] {
-  const parts = root?.serverContent?.modelTurn?.parts ??
-    root?.server_content?.model_turn?.parts ??
-    root?.modelTurn?.parts ??
-    root?.content?.parts ??
-    root?.parts;
-    
-  if (Array.isArray(parts)) {
-    return parts.filter(Boolean);
+  const candidates = [
+    root?.serverContent?.modelTurn?.parts,
+    root?.server_content?.model_turn?.parts,
+    root?.modelTurn?.parts,
+    root?.content?.parts,
+    root?.parts,
+  ];
+
+  for (const candidate of candidates) {
+    const parts = Array.isArray(candidate) ? candidate : candidate ? [candidate] : [];
+    const filteredParts = parts.filter(Boolean);
+    if (filteredParts.length > 0) {
+      return filteredParts;
+    }
   }
+
   return [];
 }
 

--- a/test/gemini-live.test.ts
+++ b/test/gemini-live.test.ts
@@ -181,6 +181,19 @@ describe("Gemini Live adapter helpers", () => {
     ]);
   });
 
+  it("does not duplicate parts when Gemini exposes camelCase and snake_case aliases", () => {
+    const parts = [{ inlineData: { data: "YQ==", mimeType: "audio/pcm;rate=24000" } }];
+
+    const events = normalizeGeminiLiveMessage({
+      serverContent: { modelTurn: { parts } },
+      server_content: { model_turn: { parts } },
+    });
+
+    expect(events.filter((event) => event.type === "audio")).toEqual([
+      { type: "audio", audio: { data: "YQ==", mimeType: "audio/pcm;rate=24000" } },
+    ]);
+  });
+
   it("normalizes input and output transcriptions with speaker and final metadata", () => {
     const events = normalizeGeminiLiveMessage({
       serverContent: {


### PR DESCRIPTION
## Why
When using the Gemini Live provider, audio broadcasted to WebSocket clients (including the official Hermes Dashboard) stutters heavily, sounding like a "broken vinyl record" (repeating sliding-window overlap). This occurs because the Gemini SDK often aliases the identical underlying audio payload onto multiple property paths (e.g., `serverContent.modelTurn.parts` and `content.parts`), causing `extractParts` to accidentally duplicate the exact same PCM audio chunks into the broadcast array.

## What changed
Updated `extractParts` in the Gemini Live adapter (`gemini-live.adapter.ts`) to use the nullish coalescing operator (`??`) rather than a `.flat()` array concatenation. It now evaluates the paths sequentially and returns the first valid `parts` array it finds, preventing the duplication of aliased chunks.

## Verification

- [x] `npm run verify`
- [x] `npm audit --audit-level=moderate`
- [x] Tests added or updated *(None needed, fixes existing broken behavior)*
- [x] Docs and changelog updated when user-visible *(Not user-visible, backend patch)*
- [x] No secrets, private audio, prompts, or sensitive Hermes output included
- [x] No unrelated generated or vendored code

## Live provider evidence
- **Provider:** Gemini
- **Model:** `gemini-3.1-flash-live-preview` (also affects other Gemini 1.5/2.0/3.0 Live models depending on SDK object layout)
- **Command:** Connected via `hermes-live` dashboard or `ws://127.0.0.1:8788/v1/live` protocol v6.
- **Result:** Audio plays smoothly without overlapping chunks or stuttering playback.

## Security and compatibility
No effect on credentials, client identity, memory scope, session limits, or the public protocol. This solely fixes a bug in how incoming Gemini audio is buffered prior to protocol broadcasting.
