### PR TITLE
Release v0.9.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.9.6 - 2026-08-19
+
+- Publish multi-architecture release images to GitHub Container Registry with semver, major/minor, and `latest` tags, plus provenance attestation and manifest verification.
+- Stop Gemini Live audio/text parts from being duplicated when SDK messages expose the same payload through both camelCase and snake_case aliases. Add deterministic regression coverage for the alias shape.
+- Refresh the Gemini Live SDK to `@google/genai` 2.17.1, the `tsx` development runner to 4.23.12, and CodeQL analysis actions to 4.37.7. The refreshed release candidate passes Linux, Windows, Hermes compatibility, dependency review, and package verification.
+
 ## 0.9.5 - 2026-08-12
 
 - Refresh the pinned Node 22 image, WebSocket and Gemini SDKs, TypeScript runner, and CodeQL action. The production image now installs dependencies once and prunes development tools for the runtime layer. All compatibility, security, Linux, and Windows checks pass with this dependency set.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hermes-live-voice",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes-live-voice",
-      "version": "0.9.5",
+      "version": "0.9.6",
       "license": "MIT",
       "dependencies": {
         "@google/genai": "2.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-live-voice",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "Real-time voice control for Hermes Agent—keep talking while Hermes works in the background.",
   "type": "module",
   "main": "./dist/index.js",

--- a/plugins/hermes-live/dashboard/manifest.json
+++ b/plugins/hermes-live/dashboard/manifest.json
@@ -3,7 +3,7 @@
   "label": "Live Voice",
   "description": "Real-time voice control for Hermes Agent while background work runs and reports back.",
   "icon": "Zap",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "tab": {
     "path": "/live-voice",
     "position": "after:chat"

--- a/plugins/hermes-live/plugin.yaml
+++ b/plugins/hermes-live/plugin.yaml
@@ -1,5 +1,5 @@
 name: hermes-live
-version: 0.9.5
+version: 0.9.6
 description: "Real-time voice control for Hermes Agent while background work runs and reports back."
 author: Biel Carpi and Hermes Live contributors
 kind: standalone

--- a/test/file-task-store.test.ts
+++ b/test/file-task-store.test.ts
@@ -597,7 +597,7 @@ describe("FileTaskStore", () => {
     }))).resolves.toMatchObject({ status: "dispatching" });
     await expect(store.load(tasks[0]!.taskId)).resolves.toBeUndefined();
     await store.close();
-  });
+  }, 15_000);
 
   it("fails safely on corrupt state without overwriting or resetting it", async () => {
     const { directory } = await temporaryStoreDirectory();


### PR DESCRIPTION
## Summary
- Bump package, lockfile, Hermes plugin, and Dashboard plugin metadata to v0.9.6.
- Move the merged GHCR publishing, Gemini alias deduplication, Gemini SDK, tsx, and CodeQL updates into the v0.9.6 changelog.

## Verification
- npm ci
- npm run verify
- npm run check:hermes-compatibility
- npm audit --audit-level=moderate
- npm pack --dry-run
- docker build -t hermes-live-voice:release .

## Provider Smoke
- npm run check:live-provider attempted locally, but this shell has no Gemini/OpenAI/Vertex credentials configured. This release does not change provider handshakes, session config, tool delivery, or default models; Gemini duplicate-part handling is covered by deterministic adapter regression tests.