### PR TITLE
Release v1.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -553,5 +553,6 @@ jobs:
           trap 'rm -rf "$install_dir"' EXIT
           npm install --prefix "$install_dir" --ignore-scripts --omit=dev --no-audit --no-fund "$package_spec"
           test "$("$install_dir/node_modules/.bin/hermes-live" --version)" = "$PACKAGE_VERSION"
+          "$install_dir/node_modules/.bin/hermes-live" --help | grep -q 'launch-check'
           "$install_dir/node_modules/.bin/hermes-live" --help | grep -q 'provider-smoke'
           npm audit signatures --prefix "$install_dir"

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ tasks-v1.json.lock/
 .tasks-v1.json.*.tmp
 **/.tasks-v1.json.*.tmp
 coverage/
+.codegraph/
 release/
 .npm/
 .pnpm-store/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## 1.0.0 - 2026-08-25
+
+- Add `hermes-live launch-check` as the stable v1 launch proof. It rejects mock mode and proves the real voice provider, Dashboard plugin version, gateway readiness, and one bounded Hermes worker with an exact output token.
+- Refresh managed local voice to Hugging Face `speech-to-speech` 0.2.12. Keep the compatibility guard and the Hermes task-tool patch for the tested realtime path.
+- Refresh `@google/genai` to 2.18.0 and Vitest to 4.1.11. Package, CLI, and release smokes now require the shipped CLI to expose `launch-check`.
+- Keep setup and release docs focused on one user path: install, run setup, run launch-check, open Hermes Dashboard, and talk to Hermes in Live Voice.
+
 ## 0.9.6 - 2026-08-19
 
 - Publish multi-architecture release images to GitHub Container Registry with semver, major/minor, and `latest` tags, plus provenance attestation and manifest verification.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,15 @@ hermes-live setup
 hermes dashboard
 ```
 
-Open **Live Voice**, choose a new or saved chat, and click **Connect**. The microphone starts automatically. Say “pause listening” or use the same screen to pause; resume from the microphone button.
+Open **Live Voice**, choose a new or saved chat, and click **Connect**. The microphone starts automatically. Say “pause listening” to pause. Use the microphone button to resume.
+
+Before a demo or production use, run:
+
+```sh
+hermes-live launch-check
+```
+
+This command rejects mock mode. It proves the voice provider, Dashboard plugin, gateway, and one bounded Hermes worker.
 
 On Apple Silicon, setup can install the tested [Hugging Face speech-to-speech](https://github.com/huggingface/speech-to-speech) stack. It runs local voice and the gateway as private user services. Gemini Live and OpenAI Realtime are also available.
 
@@ -101,6 +109,7 @@ See [UI integration](docs/ui-integration.md) for authentication and the full cli
 ## Operations
 
 ```sh
+hermes-live launch-check
 hermes-live doctor --provider-smoke
 hermes-live diagnostics
 hermes-live service status
@@ -110,7 +119,7 @@ hermes-live local logs
 hermes-live print-config
 ```
 
-After updating the npm package, run `hermes-live upgrade`. It reinstalls the matching plugin and service definitions without replacing your provider settings. `hermes-live diagnostics` writes a private support bundle without logs, prompts, task results, audio, or secret values.
+After updating the npm package, run `hermes-live upgrade`. It reinstalls the matching plugin and service definitions without replacing your provider settings. Run `hermes-live launch-check` after the upgrade. `hermes-live diagnostics` writes a private support bundle without logs, prompts, task results, audio, or secret values.
 
 `hermes-live setup` writes an allow-listed config to `$HERMES_HOME/hermes-live/config.env` (normally `~/.hermes/hermes-live/config.env`) with private permissions. The gateway and Dashboard plugin read the same file. If the default port belongs to another app, setup picks a free local port automatically. Environment variables override the managed config; project `.env` files are never loaded or executed.
 

--- a/assets/huggingface-realtime-entry.py
+++ b/assets/huggingface-realtime-entry.py
@@ -1,6 +1,6 @@
 """Hermes Live entrypoint for the pinned Hugging Face realtime server.
 
-speech-to-speech 0.2.11 publishes the OpenAI Realtime ``create_response``
+speech-to-speech 0.2.12 publishes the OpenAI Realtime ``create_response``
 turn-detection field but always starts an LLM response after final STT. Hermes
 Live needs the documented false setting so it can route explicit background
 commands without a second, conflicting model decision.
@@ -14,7 +14,7 @@ from importlib.metadata import version
 from typing import Any
 
 
-EXPECTED_VERSION = "0.2.11"
+EXPECTED_VERSION = "0.2.12"
 
 
 class _SilentContentConsole:
@@ -185,7 +185,7 @@ def _install_empty_response_tools_patch() -> None:
 def _install_transformers_tool_content_patch() -> None:
     """Keep MLX/Hugging Face chat templates compatible after tool calls.
 
-    speech-to-speech 0.2.11 serializes assistant function-call history without
+    speech-to-speech 0.2.12 serializes assistant function-call history without
     a ``content`` key. Qwen templates read that key even when ``tool_calls`` is
     present, so the follow-up response fails before generation. Normalize only
     that assistant history shape and leave every other message unchanged.

--- a/docs/live-provider-testing.md
+++ b/docs/live-provider-testing.md
@@ -7,9 +7,12 @@ CI proves the protocol, gateway, task store, plugin, package, and Docker image a
 ```sh
 hermes-live doctor
 hermes-live doctor --provider-smoke
+hermes-live launch-check
 ```
 
 The manual smoke opens the same adapter used by the gateway, waits for provider readiness, and closes it cleanly. It does not send audio or start a Hermes task. Managed Apple Silicon setup additionally runs an isolated task-tool and spoken-receipt check before declaring local voice ready.
+
+`hermes-live launch-check` is the v1 go/no-go check. It rejects mock mode and starts one bounded Hermes worker.
 
 For a source checkout:
 
@@ -46,7 +49,7 @@ Confirm:
 - one task tool call returns a receipt and the conversation continues;
 - a completion notice waits until the current turn is idle.
 
-`hermes-live local run` pins the upstream Python package version tested by the release. Normal installs use the managed service created by `hermes-live setup`. Other platforms should run the upstream `realtime` mode separately and point `HERMES_LIVE_LOCAL_URL` at it.
+`hermes-live local run` pins the upstream Python package version tested by the release. Normal installs use the managed service created by `hermes-live setup`. Other platforms can run the upstream `realtime` mode separately and point `HERMES_LIVE_LOCAL_URL` at it.
 
 ## Gemini
 
@@ -75,12 +78,12 @@ The default uses `gpt-realtime-2.1`, `marin`, PCM16, and push-to-talk semantics.
 3. Ask for a short direct answer and verify it remains in the selected Hermes chat.
 4. Delegate two read-only tasks and verify both receipts, progress, `/status`, and results.
 5. Disconnect voice while they run, reconnect, and verify the snapshot restores them.
-6. Let one finish while talking. Its notice should wait until the voice is idle and remain unread until acknowledged.
+6. Let one finish while talking. Its notice waits until the voice is idle and remains unread until acknowledged.
 7. Start a follow-up from the finished task and verify its parent/root lineage.
 8. Stop one exact task and verify the other continues.
 9. Restart only the gateway with the task volume preserved and verify reconciliation.
 
-Do not call a provider or model supported from a successful connection alone. Release evidence should include actual input, audio playback, interruption, task delegation, completion notification, and reconnect behavior.
+Do not call a provider or model supported from a successful connection alone. Release evidence must include actual input, audio playback, interruption, task delegation, completion notification, and reconnect behavior.
 
 ## References
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -30,6 +30,7 @@ Release notes must distinguish:
    npm ci
    npm run verify
    npm run check:hermes-compatibility
+   node dist/cli.js launch-check
    npm audit --audit-level=moderate
    npm pack --dry-run
    docker build -t hermes-live-voice:release .
@@ -43,6 +44,7 @@ Release notes must distinguish:
 
 Before tagging a stable release, record evidence for:
 
+- `hermes-live launch-check` with a real provider and exact Hermes worker output.
 - real Hermes submission, SSE completion, retained result, and exact stop.
 - the pinned official Hermes v0.20.0 image, required capabilities, and plugin discovery.
 - immediate receipt and a second conversation turn while a task remains active.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -7,6 +7,7 @@ Run:
 ```sh
 npm install --global hermes-live-voice
 hermes-live setup
+hermes-live launch-check
 hermes dashboard
 ```
 
@@ -21,11 +22,18 @@ hermes-live doctor --provider-smoke
 
 Both commands suppress credentials and print the next concrete fix.
 
+Use `hermes-live launch-check` before a demo or production use. It rejects mock mode and starts one bounded Hermes worker.
+
 To create a support bundle, run `hermes-live diagnostics`. The private JSON file excludes logs, prompts, task results, audio, and secret values.
 
 ## Local voice
 
-On Apple Silicon, `hermes-live setup` uses `uv` to install and run `speech-to-speech==0.2.11` with local Parakeet STT, a 4-bit MLX language model, Qwen3-TTS, VAD, and the realtime WebSocket transport. It installs a private launchd service, waits for the models, proves a structured task tool call and spoken receipt, then starts the gateway. This also warms the first real inference path. No second terminal is needed.
+On Apple Silicon, `hermes-live setup` uses `uv` to install and run `speech-to-speech==0.2.12`.
+The managed voice stack uses Parakeet STT, a 4-bit MLX language model, Qwen3-TTS, VAD, and realtime WebSocket transport.
+It installs a private launchd service and waits for the models.
+Then it proves a structured task tool call and spoken receipt before it starts the gateway.
+This warms the first real inference path.
+No second terminal is needed.
 
 The managed profile requires at least 12 GB of physical memory; a 16 GB Apple Silicon Mac is recommended (7.6 GB observed warm, 9.0 GB peak on the tested 16 GB M1 Pro). Setup checks this before downloading models. It moves an implicit local endpoint to a nearby free port when needed; an explicit `HERMES_LIVE_LOCAL_URL` is never changed.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "hermes-live-voice",
-  "version": "0.9.6",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes-live-voice",
-      "version": "0.9.6",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@google/genai": "2.17.1",
+        "@google/genai": "2.18.0",
         "ws": "8.21.3",
         "zod": "^3.25.76"
       },
@@ -21,44 +21,10 @@
         "@types/ws": "^8.18.1",
         "tsx": "^4.23.11",
         "typescript": "^7.0.2",
-        "vitest": "^4.1.10"
+        "vitest": "^4.1.11"
       },
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -504,9 +470,9 @@
       }
     },
     "node_modules/@google/genai": {
-      "version": "2.17.1",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.17.1.tgz",
-      "integrity": "sha512-CdZ3M/titoH81hXXkvOikrOW26bC9IXh9iYT7u+r+5p7wi1LnMEnB0AbJfDeWAkjuneP4oJ299BtCt6twmORWg==",
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.18.0.tgz",
+      "integrity": "sha512-uy9gWVTAZXuA/2tld0QJl/QNiGEn4QOmfX4PiRgZQmeFQRQhojpD/Gf41SPnBJmjEnT83a+h4AdU1HHYaYvVDw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -534,29 +500,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
-      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.3"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
-      }
-    },
     "node_modules/@oxc-project/types": {
-      "version": "0.139.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
-      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "version": "0.146.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.146.0.tgz",
+      "integrity": "sha512-XC0QsnnhVe7sLIWmYmdPw7x5P0h4W8vUU3Nv1ySgWXtvCz8NizoAEpGXA0sOYoJQV2Rl13LgURAHQ5cI5ILCSA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -620,10 +567,27 @@
       "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@rolldown/binding-android-arm-eabi": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.5.tgz",
+      "integrity": "sha512-DLe/i+l8ynIBY7XEQ191TeZvCoowIGa18R+dIV30GW7DiOtp74i/xX8hs8GUjW5ARV7VZuie3d6AumSmCwbeRA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
-      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.5.tgz",
+      "integrity": "sha512-zXcwKlQApYAOELHd8PwKDFkagYF9Wy4e0RJ+0qnzl9Pjnpj75TEG8ufv40p2J7kCEfwZAsNiuzRIyNNMWT38ig==",
       "cpu": [
         "arm64"
       ],
@@ -638,9 +602,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
-      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.5.tgz",
+      "integrity": "sha512-dK4QakI42nzWgJT5sm4y4y/O//D4OxM75/cH28RLV+nzIN9AY+YsbuUVrUTjlLjXR6vpyxFbSsbmNuJ6BP9sww==",
       "cpu": [
         "arm64"
       ],
@@ -655,9 +619,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
-      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.5.tgz",
+      "integrity": "sha512-fqSALaUu1Wjd1nK2uW2kJDWdLCc8lx1IcY+MTY26Aurfdx19anlzhqXOgCFbBFQnlFDTn4TC1/7Nz4Bl2mLP3A==",
       "cpu": [
         "x64"
       ],
@@ -672,9 +636,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
-      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.5.tgz",
+      "integrity": "sha512-/vCnNxlkxs9tKxNDcyWUePpJ/PgTzxIaVhoM5SmG8UV+GR/IcPam4VYxi7GIMo7PSDuNqlJqvprqii9NqqVCMw==",
       "cpu": [
         "x64"
       ],
@@ -689,9 +653,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
-      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.5.tgz",
+      "integrity": "sha512-abk0NLA519LxRCszmbE0jYKuQ9YPocOXTiOXOo6Yr+YAT95VH+PtqYAjOJvGKt3viEd/x4qzabAlwd5bHOOARg==",
       "cpu": [
         "arm"
       ],
@@ -706,9 +670,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
-      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.5.tgz",
+      "integrity": "sha512-Y7eALiJ8lr0M2HH103Js+g7V34wf6snlpZLAsHI90uLhr3PVlNsbFVAXJC9d/V6BnPyKtpSwI+NcB/RLxsQxuA==",
       "cpu": [
         "arm64"
       ],
@@ -726,9 +690,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
-      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.5.tgz",
+      "integrity": "sha512-xMvZgnbZg4YVnR/AX2b3oOPDTFYJvUVaJg5FedA/LuvexAtXibZQej4cnTkw3rjsJ/ggUROB64TdtETiim+FYA==",
       "cpu": [
         "arm64"
       ],
@@ -746,9 +710,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
-      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.5.tgz",
+      "integrity": "sha512-GRjeqTUDHTo5GwntsLaAMcBahG3nlpjftXWZLN73HiYQlhwEowvarFgQnRnQZtIp4keXX7quXFbG38uPZBa2EA==",
       "cpu": [
         "ppc64"
       ],
@@ -766,9 +730,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
-      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.5.tgz",
+      "integrity": "sha512-vLNTR45F2Uwc8AufkNXPmB4VliaXs+FvcheEogIzOXzO4l+LzieXF5A/TWxLy5HtqpsRCHUfd0lPVrrdgXdLHQ==",
       "cpu": [
         "s390x"
       ],
@@ -786,9 +750,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
-      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.5.tgz",
+      "integrity": "sha512-Mgj59/HTuYeK9Gz2MA+mBWKnHsAgkBSec15ZMb1st3oIfFbX7gCjOae7GydHhzcyQi9Z/7M1QuN9bR3oFqF0jQ==",
       "cpu": [
         "x64"
       ],
@@ -806,9 +770,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
-      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.5.tgz",
+      "integrity": "sha512-mY8AP0/ichsbhAxGnLa3d3+MwV0EfgrPND2bplI3Ym8T6R2pJ0N87bvrKVwNXmdy3jnr6eQBecdqx/HMknBmpA==",
       "cpu": [
         "x64"
       ],
@@ -826,9 +790,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
-      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.5.tgz",
+      "integrity": "sha512-8SLssA2oweAxyRgDp789ACfRb/3P+zNRJpzZxSizxF9m8NUDQ4+3xjo8ttjhVGGw6Qxb70oZiEtIjaKikCO7Yw==",
       "cpu": [
         "arm64"
       ],
@@ -842,29 +806,10 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
-      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.11.1",
-        "@emnapi/runtime": "1.11.1",
-        "@napi-rs/wasm-runtime": "^1.1.6"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
-      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.5.tgz",
+      "integrity": "sha512-vGbruD5zquhoc8D9SViXgN2FBJtNdTyQ4DtG+SWiEGlJiAzoKcZ2xp+xuXCffhubVdt0NJlTZqkeRuERy7g8Cw==",
       "cpu": [
         "arm64"
       ],
@@ -879,9 +824,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
-      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.5.tgz",
+      "integrity": "sha512-e/SXpgISz+IoqVcSSI0rx/d/he8zqLex+/rCWpnHpmVfmPIUjag9H6P7zotf0gJHwPUhQxZ/mF8tr6acebT9yw==",
       "cpu": [
         "x64"
       ],
@@ -908,17 +853,6 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@tybys/wasm-util": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
-      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -1311,16 +1245,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
-      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.10",
-        "@vitest/utils": "4.1.10",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -1329,13 +1263,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
-      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.10",
+        "@vitest/spy": "4.1.11",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -1356,9 +1290,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
-      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1369,13 +1303,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
-      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.10",
+        "@vitest/utils": "4.1.11",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1383,14 +1317,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
-      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.10",
-        "@vitest/utils": "4.1.10",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -1399,9 +1333,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
-      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1409,13 +1343,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
-      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.10",
+        "@vitest/pretty-format": "4.1.11",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -1780,9 +1714,9 @@
       }
     },
     "node_modules/lightningcss": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -1796,23 +1730,23 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-android-arm64": "1.32.0",
-        "lightningcss-darwin-arm64": "1.32.0",
-        "lightningcss-darwin-x64": "1.32.0",
-        "lightningcss-freebsd-x64": "1.32.0",
-        "lightningcss-linux-arm-gnueabihf": "1.32.0",
-        "lightningcss-linux-arm64-gnu": "1.32.0",
-        "lightningcss-linux-arm64-musl": "1.32.0",
-        "lightningcss-linux-x64-gnu": "1.32.0",
-        "lightningcss-linux-x64-musl": "1.32.0",
-        "lightningcss-win32-arm64-msvc": "1.32.0",
-        "lightningcss-win32-x64-msvc": "1.32.0"
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
       }
     },
     "node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
       "cpu": [
         "arm64"
       ],
@@ -1831,9 +1765,9 @@
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
       "cpu": [
         "arm64"
       ],
@@ -1852,9 +1786,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
       "cpu": [
         "x64"
       ],
@@ -1873,9 +1807,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
       "cpu": [
         "x64"
       ],
@@ -1894,9 +1828,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
       "cpu": [
         "arm"
       ],
@@ -1915,9 +1849,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
       "cpu": [
         "arm64"
       ],
@@ -1939,9 +1873,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
       "cpu": [
         "arm64"
       ],
@@ -1963,9 +1897,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
       "cpu": [
         "x64"
       ],
@@ -1987,9 +1921,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
       "cpu": [
         "x64"
       ],
@@ -2011,9 +1945,9 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
       "cpu": [
         "arm64"
       ],
@@ -2032,9 +1966,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
       "cpu": [
         "x64"
       ],
@@ -2173,9 +2107,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2186,9 +2120,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.25",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
-      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -2206,7 +2140,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -2247,13 +2181,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
-      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.5.tgz",
+      "integrity": "sha512-VD2IE5PUG4Oj8zz2VGykiYd5wbnjdIiSsNQb8Qu5B+noEp+A78mu2iVvpp27g8es14Tk9rofNs5Tku9iQCS4fA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.139.0",
+        "@oxc-project/types": "=0.146.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -2263,21 +2197,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.1.5",
-        "@rolldown/binding-darwin-arm64": "1.1.5",
-        "@rolldown/binding-darwin-x64": "1.1.5",
-        "@rolldown/binding-freebsd-x64": "1.1.5",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
-        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
-        "@rolldown/binding-linux-arm64-musl": "1.1.5",
-        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
-        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
-        "@rolldown/binding-linux-x64-gnu": "1.1.5",
-        "@rolldown/binding-linux-x64-musl": "1.1.5",
-        "@rolldown/binding-openharmony-arm64": "1.1.5",
-        "@rolldown/binding-wasm32-wasi": "1.1.5",
-        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
-        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+        "@rolldown/binding-android-arm-eabi": "1.2.5",
+        "@rolldown/binding-android-arm64": "1.2.5",
+        "@rolldown/binding-darwin-arm64": "1.2.5",
+        "@rolldown/binding-darwin-x64": "1.2.5",
+        "@rolldown/binding-freebsd-x64": "1.2.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.5",
+        "@rolldown/binding-linux-arm64-musl": "1.2.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.5",
+        "@rolldown/binding-linux-x64-gnu": "1.2.5",
+        "@rolldown/binding-linux-x64-musl": "1.2.5",
+        "@rolldown/binding-openharmony-arm64": "1.2.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.5",
+        "@rolldown/binding-win32-x64-msvc": "1.2.5"
       }
     },
     "node_modules/safe-buffer": {
@@ -2366,22 +2300,14 @@
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
-      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
-    },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
     },
     "node_modules/tsx": {
       "version": "4.23.12",
@@ -2444,16 +2370,16 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
-      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
+      "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "lightningcss": "^1.32.0",
+        "lightningcss": "^1.33.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.16",
-        "rolldown": "~1.1.4",
+        "postcss": "^8.5.26",
+        "rolldown": "~1.2.4",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -2470,7 +2396,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.3.0",
+        "@vitejs/devtools": "^0.4.0 || ^0.5.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -2522,19 +2448,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
-      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.10",
-        "@vitest/mocker": "4.1.10",
-        "@vitest/pretty-format": "4.1.10",
-        "@vitest/runner": "4.1.10",
-        "@vitest/snapshot": "4.1.10",
-        "@vitest/spy": "4.1.10",
-        "@vitest/utils": "4.1.10",
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -2562,12 +2488,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.10",
-        "@vitest/browser-preview": "4.1.10",
-        "@vitest/browser-webdriverio": "4.1.10",
-        "@vitest/coverage-istanbul": "4.1.10",
-        "@vitest/coverage-v8": "4.1.10",
-        "@vitest/ui": "4.1.10",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-live-voice",
-  "version": "0.9.6",
+  "version": "1.0.0",
   "description": "Real-time voice control for Hermes Agent—keep talking while Hermes works in the background.",
   "type": "module",
   "main": "./dist/index.js",
@@ -116,7 +116,7 @@
     "prepack": "npm run check:dashboard-assets && npm run build"
   },
   "dependencies": {
-    "@google/genai": "2.17.1",
+    "@google/genai": "2.18.0",
     "ws": "8.21.3",
     "zod": "^3.25.76"
   },
@@ -125,7 +125,7 @@
     "@types/ws": "^8.18.1",
     "tsx": "^4.23.11",
     "typescript": "^7.0.2",
-    "vitest": "^4.1.10"
+    "vitest": "^4.1.11"
   },
   "overrides": {
     "esbuild": "^0.28.1"

--- a/plugins/hermes-live/dashboard/manifest.json
+++ b/plugins/hermes-live/dashboard/manifest.json
@@ -3,7 +3,7 @@
   "label": "Live Voice",
   "description": "Real-time voice control for Hermes Agent while background work runs and reports back.",
   "icon": "Zap",
-  "version": "0.9.6",
+  "version": "1.0.0",
   "tab": {
     "path": "/live-voice",
     "position": "after:chat"

--- a/plugins/hermes-live/plugin.yaml
+++ b/plugins/hermes-live/plugin.yaml
@@ -1,5 +1,5 @@
 name: hermes-live
-version: 0.9.6
+version: 1.0.0
 description: "Real-time voice control for Hermes Agent while background work runs and reports back."
 author: Biel Carpi and Hermes Live contributors
 kind: standalone

--- a/scripts/cli-check-smoke.mjs
+++ b/scripts/cli-check-smoke.mjs
@@ -141,6 +141,7 @@ for (const command of [
   "terminal",
   "client",
   "check",
+  "launch-check",
   "provider-smoke",
   "print-config",
   "serve",

--- a/scripts/local-runtime-contract-smoke.py
+++ b/scripts/local-runtime-contract-smoke.py
@@ -142,7 +142,7 @@ def main() -> None:
     try:
         entrypoint._install_create_response_patch()
     except RuntimeError as error:
-        assert "expected speech-to-speech 0.2.11" in str(error)
+        assert "expected speech-to-speech 0.2.12" in str(error)
     else:
         raise AssertionError("An unreviewed speech-to-speech version must fail closed")
 

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -54,6 +54,7 @@ try {
     "dist/cli/task-operator.js",
     "dist/cli/terminal-session.js",
     "dist/cli/doctor.js",
+    "dist/cli/launch-check.js",
     "dist/cli/diagnostics.js",
     "dist/cli/gateway-probe.js",
     "dist/cli/managed-config.js",
@@ -187,6 +188,7 @@ try {
     !help.stdout.includes("upgrade") ||
     !help.stdout.includes("service") ||
     !help.stdout.includes("provider-smoke") ||
+    !help.stdout.includes("launch-check") ||
     !help.stdout.includes("hermes dashboard") ||
     !help.stdout.includes("setup --help") ||
     help.stdout.includes("Required environment:") ||

--- a/src/adapters/outbound/realtime/huggingface-realtime.adapter.ts
+++ b/src/adapters/outbound/realtime/huggingface-realtime.adapter.ts
@@ -758,7 +758,7 @@ class HuggingFaceRealtimeSession implements LiveModelSession {
       return [{ ...completed[0], speaker: "assistant", final: true }];
     }
 
-    // speech-to-speech 0.2.11 publishes each generated text chunk as its own
+    // speech-to-speech 0.2.12 publishes each generated text chunk as its own
     // `response.output_audio_transcript.done` event. Coalesce those chunks at
     // the compatibility boundary so clients still receive one assistant turn.
     // If a provider only sends deltas, terminalize the accumulated text here.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,6 +22,7 @@ import { applyManagedConfigToProcess } from "./cli/managed-config.js";
 import { runServiceAction, type ServiceAction } from "./cli/service-manager.js";
 import { runSetupCommand } from "./cli/setup.js";
 import { runDoctorCommand } from "./cli/doctor.js";
+import { launchCheckHelp, runLaunchCheckCommand } from "./cli/launch-check.js";
 import { diagnosticsHelp, runDiagnosticsCommand } from "./cli/diagnostics.js";
 import { runUpgradeCommand, upgradeHelp } from "./cli/upgrade.js";
 import { printLocalVoiceHelp, runLocalVoiceCommand } from "./cli/local-voice.js";
@@ -61,6 +62,11 @@ async function main(): Promise<void> {
 
   if (command === "doctor") {
     await runDoctorCommand(process.argv.slice(3));
+    return;
+  }
+
+  if (command === "launch-check") {
+    await runLaunchCheckCommand(process.argv.slice(3));
     return;
   }
 
@@ -242,6 +248,7 @@ function usesManagedRuntimeConfig(command: string): boolean {
     "terminal",
     "chat",
     "check",
+    "launch-check",
     "provider-smoke",
     "check-live-provider",
     "tasks",
@@ -270,6 +277,7 @@ function printRequestedCommandHelp(command: string, args: readonly string[]): bo
 
 function commandHelp(command: string): string | undefined {
   if (command === "diagnostics") return diagnosticsHelp();
+  if (command === "launch-check") return launchCheckHelp();
   if (command === "upgrade") return upgradeHelp();
   if (command === "service") {
     return `hermes-live service <action>
@@ -350,6 +358,7 @@ Quick start:
 
 Everyday commands:
   hermes-live setup         Configure, verify, and start everything
+  hermes-live launch-check  Prove the real v1 voice, plugin, gateway, and worker path
   hermes-live upgrade       Reconcile an updated npm package
   hermes-live doctor        Diagnose the installation and print exact fixes
   hermes-live diagnostics   Write a private, redacted support bundle
@@ -360,6 +369,7 @@ Operations:
   hermes-live service <status|restart|logs|stop|start|uninstall>
   hermes-live local <status|restart|logs|stop|start|uninstall>
   hermes-live check         Check Hermes and provider readiness
+  hermes-live launch-check  Run the real v1 launch proof
   hermes-live provider-smoke  Open and close a real provider session
   hermes-live print-config  Show resolved settings with secrets redacted
 

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -11,6 +11,7 @@ import { pluginInstallStatus } from "./plugin-installer.js";
 import { findExecutable, runCommand, type CommandRunner } from "./process.js";
 import { serviceStatus, type ServiceStatus } from "./service-manager.js";
 import {
+  HUGGINGFACE_SPEECH_TO_SPEECH_VERSION,
   MIN_MANAGED_LOCAL_MEMORY_BYTES,
   probeLocalVoiceEndpoint,
 } from "./local-voice.js";
@@ -161,7 +162,11 @@ export async function runDoctor(
       const managedProfileSupported = (dependencies.platform ?? process.platform) === "darwin"
         && (dependencies.arch ?? process.arch) === "arm64";
       checks.push(uv
-        ? pass("local-launcher", "Local voice launcher", `${shortHome(uv, dependencies.home)} (speech-to-speech 0.2.11)`)
+        ? pass(
+          "local-launcher",
+          "Local voice launcher",
+          `${shortHome(uv, dependencies.home)} (speech-to-speech ${HUGGINGFACE_SPEECH_TO_SPEECH_VERSION})`,
+        )
         : managedProfileSupported
           ? fail("local-launcher", "Local voice launcher", "uv is not installed.", "Run `brew install uv`, then rerun `hermes-live setup`.")
           : pass("local-launcher", "Local voice launcher", "External speech-to-speech runtime expected on this platform."));

--- a/src/cli/launch-check.ts
+++ b/src/cli/launch-check.ts
@@ -1,0 +1,269 @@
+import { createRequire } from "node:module";
+import { randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { loadConfig, type AppConfig } from "../config.js";
+import { HermesClient } from "../adapters/outbound/hermes/hermes-runs.client.js";
+import type { HermesRunsPort } from "../application/live-gateway/ports/hermes-runs.port.js";
+import { runLiveProviderSmoke, type LiveProviderSmokeReport } from "../live-provider-smoke.js";
+import { buildReadinessReport, type ReadinessReport } from "../readiness.js";
+import { errorToMessage } from "../domain/error-message.js";
+import { gatewayOrigin, probeGatewayReadiness } from "./gateway-probe.js";
+import {
+  pluginInstallStatus,
+  type PluginInstallStatus,
+} from "./plugin-installer.js";
+import { serviceStatus, type ServiceStatus } from "./service-manager.js";
+
+const packageRequire = createRequire(import.meta.url);
+const PACKAGE_VERSION = (packageRequire("../../package.json") as { version: string }).version;
+const DEFAULT_LAUNCH_CHECK_TIMEOUT_MS = 120_000;
+const WORKER_TOKEN = "HERMES_LIVE_WORKER_OK";
+
+export interface LaunchCheckOptions {
+  json: boolean;
+  timeoutMs?: number;
+}
+
+export interface LaunchCheckReport {
+  ok: true;
+  version: string;
+  provider: Exclude<AppConfig["realtime"]["provider"], "mock">;
+  readiness: ReadinessReport;
+  plugin: {
+    installed: true;
+    version: string;
+    path: string;
+  };
+  service: ServiceStatus;
+  gateway: {
+    ok: true;
+    url: string;
+  };
+  providerSession: LiveProviderSmokeReport;
+  worker: {
+    runId: string;
+    status: "completed";
+    outputVerified: true;
+  };
+}
+
+export interface LaunchCheckDependencies {
+  config?: AppConfig;
+  readinessCheck?: (config: AppConfig) => Promise<ReadinessReport>;
+  pluginStatus?: () => Promise<PluginInstallStatus>;
+  pluginVersion?: (target: string) => Promise<string | undefined>;
+  serviceStatus?: () => Promise<ServiceStatus>;
+  gatewayReadiness?: (origin: string, config: AppConfig) => Promise<{ ok: true } | { ok: false; error: string }>;
+  providerSmoke?: (config: AppConfig, options: { timeoutMs: number; verifyToolCall?: boolean }) => Promise<LiveProviderSmokeReport>;
+  hermes?: HermesLaunchCheckPort;
+  now?: () => number;
+}
+
+type HermesLaunchCheckPort = Pick<
+  HermesRunsPort,
+  "assertRunsSupported" | "startRun" | "streamRunEvents" | "getRun"
+>;
+
+export function parseLaunchCheckOptions(args: readonly string[]): LaunchCheckOptions {
+  const options: LaunchCheckOptions = { json: false };
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    const nextValue = (): string => {
+      const value = args[index + 1];
+      if (!value) throw new Error(`${argument} requires a value.`);
+      index += 1;
+      return value;
+    };
+    if (argument === "--json") options.json = true;
+    else if (argument === "--timeout-ms") options.timeoutMs = positiveTimeout(nextValue(), argument);
+    else if (argument?.startsWith("--timeout-ms=")) {
+      options.timeoutMs = positiveTimeout(argument.slice("--timeout-ms=".length), "--timeout-ms");
+    } else if (argument === "--help" || argument === "-h") throw new LaunchCheckHelpRequested();
+    else if (argument) throw new Error(`Unknown launch-check option: ${argument}`);
+  }
+  return options;
+}
+
+export async function runLaunchCheck(
+  options: LaunchCheckOptions,
+  dependencies: LaunchCheckDependencies = {},
+): Promise<LaunchCheckReport> {
+  const config = dependencies.config ?? loadConfig();
+  if (config.realtime.provider === "mock") {
+    throw new Error("HERMES_LIVE_PROVIDER=mock is for development and cannot pass launch-check.");
+  }
+
+  const timeoutMs = options.timeoutMs ?? DEFAULT_LAUNCH_CHECK_TIMEOUT_MS;
+  const readiness = await (dependencies.readinessCheck ?? buildReadinessReport)(config);
+  if (!readiness.ok) {
+    throw new Error("Runtime readiness failed. Run `hermes-live doctor` for the exact fix.");
+  }
+
+  const plugin = await checkedPlugin(dependencies);
+  const service = await (dependencies.serviceStatus ?? serviceStatus)();
+  if (service.installed && !service.running) {
+    throw new Error("The Hermes Live gateway service is installed but stopped. Run `hermes-live service restart`.");
+  }
+
+  const gatewayUrl = gatewayOrigin(config.server.host, config.server.port);
+  const gateway = await (dependencies.gatewayReadiness ?? defaultGatewayReadiness)(gatewayUrl, config);
+  if (!gateway.ok) {
+    throw new Error(`The Live Voice gateway is not ready: ${gateway.error}`);
+  }
+
+  const providerSession = await (dependencies.providerSmoke ?? runLiveProviderSmoke)(config, {
+    timeoutMs,
+    ...(config.realtime.provider === "local" ? { verifyToolCall: true } : {}),
+  });
+  const worker = await checkHermesWorker(
+    dependencies.hermes ?? new HermesClient(config.hermes),
+    config,
+    timeoutMs,
+    dependencies.now ?? Date.now,
+  );
+
+  return {
+    ok: true,
+    version: PACKAGE_VERSION,
+    provider: config.realtime.provider,
+    readiness,
+    plugin,
+    service,
+    gateway: { ok: true, url: gatewayUrl },
+    providerSession,
+    worker,
+  };
+}
+
+export async function runLaunchCheckCommand(args: readonly string[]): Promise<void> {
+  let options: LaunchCheckOptions;
+  try {
+    options = parseLaunchCheckOptions(args);
+  } catch (error) {
+    if (error instanceof LaunchCheckHelpRequested) {
+      console.log(launchCheckHelp());
+      return;
+    }
+    throw error;
+  }
+
+  try {
+    const report = await runLaunchCheck(options);
+    if (options.json) console.log(JSON.stringify(report, null, 2));
+    else printLaunchCheckReport(report);
+  } catch (error) {
+    const message = errorToMessage(error);
+    if (options.json) console.log(JSON.stringify({ ok: false, error: message }, null, 2));
+    else {
+      console.error(`Hermes Live Voice launch-check failed: ${message}`);
+      console.error("Run `hermes-live doctor --provider-smoke` for detailed fixes.");
+    }
+    process.exitCode = 1;
+  }
+}
+
+export function launchCheckHelp(): string {
+  return `hermes-live launch-check [--json] [--timeout-ms <ms>]
+
+Run the v1 launch proof. This opens a real voice-provider session, checks the
+Dashboard plugin and gateway, then starts one bounded Hermes worker.
+
+Mock mode is rejected. Use this before a public release or user demo.`;
+}
+
+async function checkedPlugin(
+  dependencies: Pick<LaunchCheckDependencies, "pluginStatus" | "pluginVersion">,
+): Promise<LaunchCheckReport["plugin"]> {
+  const status = await (dependencies.pluginStatus ?? pluginInstallStatus)();
+  if (!status.installed || !status.manifestFound) {
+    throw new Error("The Hermes Dashboard Live Voice plugin is not installed. Run `hermes-live setup`.");
+  }
+  const version = await (dependencies.pluginVersion ?? readInstalledPluginVersion)(status.target);
+  if (version !== PACKAGE_VERSION) {
+    throw new Error(
+      `The installed Hermes plugin is ${version ? `v${version}` : "missing a version"}; package is v${PACKAGE_VERSION}. Run \`hermes-live upgrade\`.`,
+    );
+  }
+  return { installed: true, version, path: status.target };
+}
+
+async function checkHermesWorker(
+  hermes: HermesLaunchCheckPort,
+  config: AppConfig,
+  timeoutMs: number,
+  now: () => number,
+): Promise<LaunchCheckReport["worker"]> {
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(new Error("Hermes worker launch verification timed out.")),
+    timeoutMs,
+  );
+  timeout.unref?.();
+  const sessionKey = [
+    config.server.sessionPrefix,
+    `profile:${config.server.defaultProfileId}`,
+    `user:${config.server.defaultUserLabel}`,
+    "launch-check",
+  ].join(":");
+  const sessionId = `hermes_live_launch_check_${now()}_${randomUUID().replaceAll("-", "").slice(0, 8)}`;
+  try {
+    await hermes.assertRunsSupported(controller.signal);
+    const started = await hermes.startRun({
+      sessionId,
+      sessionKey,
+      input: `Launch verification only. Do not use tools or modify files. Reply with exactly ${WORKER_TOKEN}.`,
+    }, controller.signal);
+
+    for await (const event of hermes.streamRunEvents(started.runId, {
+      signal: controller.signal,
+      sessionKey,
+    })) {
+      if (["run.completed", "run.failed", "run.cancelled"].includes(event.event ?? "")) break;
+    }
+
+    const snapshot = await hermes.getRun(started.runId, {
+      signal: controller.signal,
+      sessionKey,
+    });
+    if (snapshot.status !== "completed") {
+      throw new Error(`Hermes worker ended in ${snapshot.status}.`);
+    }
+    if (snapshot.output.trim() !== WORKER_TOKEN) {
+      throw new Error("Hermes worker completed but did not return the exact launch-check token.");
+    }
+    return { runId: started.runId, status: "completed", outputVerified: true };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function defaultGatewayReadiness(
+  origin: string,
+  config: AppConfig,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  return await probeGatewayReadiness(origin, {
+    ...(config.server.authToken ? { authToken: config.server.authToken } : {}),
+    timeoutMs: 3_000,
+  });
+}
+
+async function readInstalledPluginVersion(target: string): Promise<string | undefined> {
+  const manifest = await readFile(`${target}/plugin.yaml`, "utf8").catch(() => "");
+  return /^version:\s*["']?([^\s"']+)["']?\s*$/mu.exec(manifest)?.[1];
+}
+
+function printLaunchCheckReport(report: LaunchCheckReport): void {
+  console.log("Hermes Live Voice passed v1 launch verification.");
+  console.log(`  Voice provider: ${report.provider} ${report.providerSession.model}`);
+  console.log(`  Hermes worker: completed ${report.worker.runId}`);
+  console.log(`  Gateway: ${report.gateway.url}`);
+  console.log(`  Dashboard plugin: v${report.plugin.version}`);
+}
+
+function positiveTimeout(value: string, argument: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) throw new Error(`${argument} requires a positive integer.`);
+  return parsed;
+}
+
+class LaunchCheckHelpRequested extends Error {}

--- a/src/cli/local-voice.ts
+++ b/src/cli/local-voice.ts
@@ -14,7 +14,7 @@ import {
   type ServiceStatus,
 } from "./service-manager.js";
 
-export const HUGGINGFACE_SPEECH_TO_SPEECH_VERSION = "0.2.11";
+export const HUGGINGFACE_SPEECH_TO_SPEECH_VERSION = "0.2.12";
 export const MIN_MANAGED_LOCAL_MEMORY_BYTES = 12 * 1024 * 1024 * 1024;
 export const MANAGED_LOCAL_MIN_SILENCE_MS = 700;
 export const MANAGED_LOCAL_MAX_NEW_TOKENS = 96;

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,8 @@ export { createLiveModelAdapter } from "./adapters/outbound/realtime/factory.js"
 export { buildSystemInstruction } from "./application/live-gateway/system-instruction.js";
 export { runLiveProviderSmoke } from "./live-provider-smoke.js";
 export type { LiveProviderSmokeOptions, LiveProviderSmokeReport } from "./live-provider-smoke.js";
+export { runLaunchCheck } from "./cli/launch-check.js";
+export type { LaunchCheckOptions, LaunchCheckReport } from "./cli/launch-check.js";
 export {
   classifyHermesVersion,
   HERMES_COMPATIBILITY,

--- a/test/huggingface-realtime.test.ts
+++ b/test/huggingface-realtime.test.ts
@@ -183,7 +183,7 @@ describe("Hugging Face speech-to-speech adapter", () => {
     await session.close();
   });
 
-  it("coalesces completed transcript chunks from speech-to-speech 0.2.11 into one turn", async () => {
+  it("coalesces completed transcript chunks from speech-to-speech 0.2.12 into one turn", async () => {
     const harness = await createHarness();
     const events: LiveModelEvent[] = [];
     const session = await new HuggingFaceRealtimeAdapter(

--- a/test/launch-check.test.ts
+++ b/test/launch-check.test.ts
@@ -1,0 +1,198 @@
+import { createRequire } from "node:module";
+import { describe, expect, it, vi } from "vitest";
+import { loadConfig } from "../src/config.js";
+import {
+  parseLaunchCheckOptions,
+  runLaunchCheck,
+} from "../src/cli/launch-check.js";
+
+const packageRequire = createRequire(import.meta.url);
+const PACKAGE_VERSION = (packageRequire("../package.json") as { version: string }).version;
+
+describe("launch-check", () => {
+  it("parses json and timeout options", () => {
+    expect(parseLaunchCheckOptions(["--json", "--timeout-ms", "12345"])).toEqual({
+      json: true,
+      timeoutMs: 12345,
+    });
+    expect(() => parseLaunchCheckOptions(["--timeout-ms", "0"])).toThrow(/positive integer/u);
+  });
+
+  it("rejects mock mode because it cannot prove real voice", async () => {
+    await expect(
+      runLaunchCheck({ json: true }, {
+        config: loadConfig({ HERMES_LIVE_PROVIDER: "mock" }),
+      }),
+    ).rejects.toThrow("HERMES_LIVE_PROVIDER=mock is for development");
+  });
+
+  it("proves provider, plugin, gateway, and exact Hermes worker output", async () => {
+    const config = loadConfig({
+      HERMES_LIVE_PROVIDER: "openai",
+      OPENAI_API_KEY: "openai-launch-secret",
+      HERMES_AGENT_API_SERVER_KEY: "hermes-launch-secret",
+    });
+    const providerSmoke = vi.fn(async (_config: unknown, _options: unknown) => ({
+      ok: true,
+      provider: "openai",
+      model: "gpt-realtime-2.1",
+      connected: true,
+      openCallback: true,
+      elapsedMs: 1,
+      eventCount: 0,
+      sampleEvents: [] as Array<Record<string, unknown>>,
+    } as const));
+    const hermes = {
+      assertRunsSupported: vi.fn(async () => ({ features: {} })),
+      startRun: vi.fn(async () => ({ runId: "run_launch", status: "queued" as const })),
+      streamRunEvents: vi.fn(async function* () {
+        yield { event: "run.completed" as const };
+      }),
+      getRun: vi.fn(async () => ({
+        object: "hermes.run" as const,
+        run_id: "run_launch",
+        status: "completed" as const,
+        output: "HERMES_LIVE_WORKER_OK",
+        usage: { input_tokens: 4, output_tokens: 1, total_tokens: 5 },
+      })),
+    };
+
+    const report = await runLaunchCheck({ json: true, timeoutMs: 123_000 }, {
+      config,
+      readinessCheck: async () => ({
+        ok: true,
+        gateway: { ok: true },
+        hermes: { ok: true },
+        realtime: { ok: true },
+        tasks: { ok: true },
+      }),
+      pluginStatus: async () => ({
+        source: "/pkg/plugins/hermes-live",
+        target: "/home/alice/.hermes/plugins/hermes-live",
+        installed: true,
+        manifestFound: true,
+        symlink: false,
+        enabledHint: "Run `hermes plugins enable hermes-live` after installation.",
+      }),
+      pluginVersion: async () => PACKAGE_VERSION,
+      serviceStatus: async () => ({
+        platform: "launchd",
+        installed: true,
+        running: true,
+        detail: "running",
+      }),
+      gatewayReadiness: async () => ({ ok: true }),
+      providerSmoke,
+      hermes,
+      now: () => 1_000,
+    });
+
+    expect(report.ok).toBe(true);
+    expect(report.plugin.version).toBe(PACKAGE_VERSION);
+    expect(report.worker).toEqual({
+      runId: "run_launch",
+      status: "completed",
+      outputVerified: true,
+    });
+    expect(providerSmoke).toHaveBeenCalledWith(config, { timeoutMs: 123_000 });
+    expect(hermes.startRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.stringContaining("HERMES_LIVE_WORKER_OK"),
+        sessionId: expect.stringMatching(/^hermes_live_launch_check_1000_[a-f0-9]{8}$/u),
+        sessionKey: expect.stringContaining(":launch-check"),
+      }),
+      expect.any(AbortSignal),
+    );
+    expect(hermes.getRun).toHaveBeenCalledWith("run_launch", expect.objectContaining({
+      sessionKey: expect.stringContaining(":launch-check"),
+    }));
+  });
+
+  it("rejects a stale installed plugin", async () => {
+    const config = loadConfig({
+      HERMES_LIVE_PROVIDER: "openai",
+      OPENAI_API_KEY: "openai-launch-secret",
+      HERMES_AGENT_API_SERVER_KEY: "hermes-launch-secret",
+    });
+
+    await expect(runLaunchCheck({ json: true }, {
+      config,
+      readinessCheck: async () => ({
+        ok: true,
+        gateway: { ok: true },
+        hermes: { ok: true },
+        realtime: { ok: true },
+        tasks: { ok: true },
+      }),
+      pluginStatus: async () => ({
+        source: "/pkg/plugins/hermes-live",
+        target: "/home/alice/.hermes/plugins/hermes-live",
+        installed: true,
+        manifestFound: true,
+        symlink: false,
+        enabledHint: "Run `hermes plugins enable hermes-live` after installation.",
+      }),
+      pluginVersion: async () => "0.0.0",
+    })).rejects.toThrow("Run `hermes-live upgrade`");
+  });
+
+  it("requires the exact Hermes launch token", async () => {
+    const config = loadConfig({
+      HERMES_LIVE_PROVIDER: "openai",
+      OPENAI_API_KEY: "openai-launch-secret",
+      HERMES_AGENT_API_SERVER_KEY: "hermes-launch-secret",
+    });
+    const hermes = {
+      assertRunsSupported: vi.fn(async () => ({ features: {} })),
+      startRun: vi.fn(async () => ({ runId: "run_launch", status: "queued" as const })),
+      streamRunEvents: vi.fn(async function* () {
+        yield { event: "run.completed" as const };
+      }),
+      getRun: vi.fn(async () => ({
+        object: "hermes.run" as const,
+        run_id: "run_launch",
+        status: "completed" as const,
+        output: "close enough",
+        usage: { input_tokens: 4, output_tokens: 2, total_tokens: 6 },
+      })),
+    };
+
+    await expect(runLaunchCheck({ json: true }, {
+      config,
+      readinessCheck: async () => ({
+        ok: true,
+        gateway: { ok: true },
+        hermes: { ok: true },
+        realtime: { ok: true },
+        tasks: { ok: true },
+      }),
+      pluginStatus: async () => ({
+        source: "/pkg/plugins/hermes-live",
+        target: "/home/alice/.hermes/plugins/hermes-live",
+        installed: true,
+        manifestFound: true,
+        symlink: false,
+        enabledHint: "Run `hermes plugins enable hermes-live` after installation.",
+      }),
+      pluginVersion: async () => PACKAGE_VERSION,
+      serviceStatus: async () => ({
+        platform: "launchd",
+        installed: false,
+        running: false,
+        detail: "not installed",
+      }),
+      gatewayReadiness: async () => ({ ok: true }),
+      providerSmoke: async () => ({
+        ok: true,
+        provider: "openai",
+        model: "gpt-realtime-2.1",
+        connected: true,
+        openCallback: true,
+        elapsedMs: 1,
+        eventCount: 0,
+        sampleEvents: [] as Array<Record<string, unknown>>,
+      } as const),
+      hermes,
+    })).rejects.toThrow("exact launch-check token");
+  });
+});

--- a/test/service-manager.test.ts
+++ b/test/service-manager.test.ts
@@ -56,7 +56,7 @@ describe("service manager", () => {
       kind: "local-voice",
       command: {
         command: "/opt/homebrew/bin/uv",
-        args: ["tool", "run", "--from", "speech-to-speech==0.2.11", "speech-to-speech", "--mode", "realtime"],
+        args: ["tool", "run", "--from", "speech-to-speech==0.2.12", "speech-to-speech", "--mode", "realtime"],
         environment: { SSL_CERT_FILE: "/etc/ssl/cert.pem" },
       },
       home: "/Users/alice",
@@ -64,7 +64,7 @@ describe("service manager", () => {
 
     expect(definition).toContain(`<string>${LOCAL_VOICE_SERVICE_LABEL}</string>`);
     expect(definition).toContain("/opt/homebrew/bin/uv");
-    expect(definition).toContain("speech-to-speech==0.2.11");
+    expect(definition).toContain("speech-to-speech==0.2.12");
     expect(definition).toContain("local-voice.log");
     expect(definition).toContain("SSL_CERT_FILE");
     expect(definition).toContain("<integer>30</integer>");


### PR DESCRIPTION
## Summary
- add hermes-live launch-check as the v1 release proof for provider, plugin, gateway, and bounded Hermes worker
- refresh managed local voice to Hugging Face speech-to-speech 0.2.12 and pin @google/genai 2.18.0
- bump package and Hermes plugin manifests to 1.0.0 and update release/package smokes

## Verification
- npm run verify
- npm run check:hermes-compatibility
- npm audit --audit-level=moderate
- npm pack --dry-run
- docker build -t hermes-live-voice:release .

## Live gate note
- node dist/cli.js launch-check correctly fails on this workstation because no managed config, real Hermes API key, or voice-provider key is installed; the released command now reports that state explicitly.